### PR TITLE
feature(token_registry): Add TokenRegistry

### DIFF
--- a/agents/a2a-agent-trader/.env.sample
+++ b/agents/a2a-agent-trader/.env.sample
@@ -6,3 +6,4 @@ POLICY_DB_PATH=./policies.db
 AGENT_ID=agent_xxx
 CHAIN_RPC_URL=http://127.0.0.1:8545
 AGENT_PRIV_KEY=0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356
+TOKEN_REGISTRY_PATH=./app/data/token_registry.json

--- a/agents/a2a-agent-trader/app/agent.py
+++ b/agents/a2a-agent-trader/app/agent.py
@@ -78,6 +78,7 @@ from .utils.event_ingestion import (
 from .utils.market_provider import create_market_provider, MarketProvider
 from .utils.action_executor import execute_action
 from .utils.serializer import json_serializer
+from .utils.token_registry import TOKEN_REGISTRY
 from pydantic import PrivateAttr
 
 
@@ -441,16 +442,18 @@ class TraderAgent(BaseAgent):
         return None
     
     async def _demo_alkahest(self) -> None:
-        # Token address of USDC
-        ADDRESS_USDC = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        token = TOKEN_REGISTRY.require("USDC")
+        logger.info(
+            "[ALKAHEST] Using %s (%s) with %s decimals",
+            token.symbol,
+            token.contract_address,
+            token.decimals,
+        )
 
-        # TODO: Take this out and put this in the acceptance logic
-        logger.info(f"[ALKAHEST]: Using USDC: {ADDRESS_USDC}")
-
-        # Approve a demo escrow transaction
+        approval_value = 100 * (10 ** token.decimals)
         hash = await self._alkahest_client.erc20.approve(
-            {"address": ADDRESS_USDC, "value": 100},
-            "escrow"
+            {"address": token.contract_address, "value": approval_value},
+            "escrow",
         )
 
         logger.info(f"[ALKAHEST]: Hash: {hash}")

--- a/agents/a2a-agent-trader/app/data/token_registry.json
+++ b/agents/a2a-agent-trader/app/data/token_registry.json
@@ -1,0 +1,12 @@
+[
+  {
+    "symbol": "USDC",
+    "contract_address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+    "decimals": 6
+  },
+  {
+    "symbol": "USDT",
+    "contract_address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+    "decimals": 6
+  }
+]

--- a/agents/a2a-agent-trader/app/schema/pydantic_models.py
+++ b/agents/a2a-agent-trader/app/schema/pydantic_models.py
@@ -5,6 +5,16 @@ from pydantic import BaseModel, Field, SerializeAsAny
 from pydantic import ConfigDict
 
 
+class ERC20TokenMetadata(BaseModel):
+    """Describes registry metadata for an ERC-20 token."""
+
+    symbol: str = Field(description="Ticker symbol, e.g. USDC")
+    contract_address: str = Field(description="Checksummed ERC-20 contract address")
+    decimals: int = Field(
+        description="Number of decimal places the token uses", ge=0, le=30
+    )
+
+
 class GPUModel(str, Enum):
     """GPU hardware models available in the marketplace"""
 
@@ -46,14 +56,11 @@ class Resource(BaseModel):
 
 
 class TokenResource(Resource):
-    """Describes a given value and amount of a token used for trade.
+    """Describes a given value and amount of a token used for trade."""
 
-    Note that while USDT and USDC are precise to 6 decimal places, ERC-20 uses 18 as standard.
-    Thus, we use 18 decimal places.
-    """
-    token: str = Field(description="Token or currency")
-    amount: int = Field(description=
-        "Integer amount for the token, up to 18 decimal places (e.g. 10 units = 10 * 10**18)"
+    token: ERC20TokenMetadata = Field(description="Token metadata resolved from registry")
+    amount: int = Field(
+        description="Integer amount in base units (token amount * 10**decimals)"
     )
 
 class ComputeResource(Resource):
@@ -384,5 +391,3 @@ class Decision(BaseModel):
     def record_outcome(self, outcome: dict[str, Any]) -> None:
         """Record the outcome of this decision."""
         self.outcome = outcome
-
-

--- a/agents/a2a-agent-trader/app/utils/action_executor.py
+++ b/agents/a2a-agent-trader/app/utils/action_executor.py
@@ -28,6 +28,7 @@ from app.schema.pydantic_models import (
 )
 
 from .config import CONFIG
+from .token_registry import TOKEN_REGISTRY
 
 BASE_URL_OVERRIDE = CONFIG.base_url_override
 REMOTE_AGENT_URL_OVERRIDE = CONFIG.remote_agent_url_override
@@ -228,6 +229,8 @@ def create_order(order_tag: Tag, gpu_model_str: str, sla: float, region_str: str
         This creates a UUID identifying the new order, and the details should match the provided arguments.
     """
     logger.info(f"[TOOL] Creating order of type {order_tag} for resource.")
+    settlement_token = TOKEN_REGISTRY.require("USDC")
+
     order = MarketOrder(
         order_id=str(uuid.uuid4()),
         tag=order_tag,
@@ -240,8 +243,8 @@ def create_order(order_tag: Tag, gpu_model_str: str, sla: float, region_str: str
             region=Region(region_str),
         ),
         demand_resource=TokenResource(
-            token="USDT",
-            amount=9 * 10**18
+            token=settlement_token,
+            amount=9 * 10**settlement_token.decimals
         ),
         duration=1,
         maker_attestation=None,

--- a/agents/a2a-agent-trader/app/utils/config.py
+++ b/agents/a2a-agent-trader/app/utils/config.py
@@ -1,5 +1,6 @@
 import os
 from dataclasses import dataclass
+from pathlib import Path
 
 
 def _get_bool_env(var_name: str, default: bool = False) -> bool:
@@ -37,6 +38,12 @@ class Config:
     redis_channels: str  # comma-separated
     enable_event_queue: bool
     market_provider: str  # "static" or "redis"
+    token_registry_path: str
+
+
+DEFAULT_TOKEN_REGISTRY_PATH = (
+    Path(__file__).resolve().parents[1] / "data" / "token_registry.json"
+)
 
 
 def load_config() -> Config:
@@ -59,6 +66,9 @@ def load_config() -> Config:
         redis_channels=os.getenv("REDIS_CHANNELS", "events:*"),
         enable_event_queue=_get_bool_env("ENABLE_EVENT_QUEUE", True),
         market_provider=os.getenv("MARKET_PROVIDER", "static"),
+        token_registry_path=os.getenv(
+            "TOKEN_REGISTRY_PATH", str(DEFAULT_TOKEN_REGISTRY_PATH)
+        ),
     )
 
 
@@ -82,5 +92,3 @@ def ensure_google_defaults_if_needed(cfg: Config) -> None:
 # Module-level singleton for convenience
 CONFIG = load_config()
 ensure_google_defaults_if_needed(CONFIG)
-
-

--- a/agents/a2a-agent-trader/app/utils/token_registry.py
+++ b/agents/a2a-agent-trader/app/utils/token_registry.py
@@ -1,0 +1,107 @@
+"""Simple ERC-20 token registry loader."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from threading import RLock
+
+from app.schema.pydantic_models import ERC20TokenMetadata
+from app.utils.config import CONFIG
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_REGISTRY_PATH = Path(__file__).resolve().parents[1] / "data" / "token_registry.json"
+
+
+class TokenRegistryError(RuntimeError):
+    """Raised when the registry encounters unrecoverable issues."""
+
+
+class TokenRegistry:
+    """Handles token metadata lookups backed by a JSON file."""
+
+    def __init__(self, source_path: str | Path | None = None):
+        self._path = Path(source_path) if source_path else DEFAULT_REGISTRY_PATH
+        self._lock = RLock()
+        self._tokens_by_symbol: dict[str, ERC20TokenMetadata] = {}
+        self._tokens_by_address: dict[str, ERC20TokenMetadata] = {}
+        self.reload()
+
+    def reload(self) -> None:
+        """Reload registry data from disk."""
+        with self._lock:
+            self._tokens_by_symbol.clear()
+            self._tokens_by_address.clear()
+            if not self._path.exists():
+                logger.warning("[TOKEN_REGISTRY] Path %s does not exist; registry empty", self._path)
+                return
+            try:
+                raw_tokens = json.loads(self._path.read_text())
+            except json.JSONDecodeError as exc:
+                raise TokenRegistryError(f"Invalid registry file: {exc}") from exc
+            if not isinstance(raw_tokens, list):
+                raise TokenRegistryError("Registry payload must be a list of token entries")
+            for entry in raw_tokens:
+                try:
+                    token = ERC20TokenMetadata(**entry)
+                except Exception as exc:
+                    raise TokenRegistryError(f"Invalid token entry: {entry}") from exc
+                self._store(token)
+
+    def _store(self, token: ERC20TokenMetadata) -> None:
+        symbol_key = token.symbol.upper()
+        address_key = token.contract_address.lower()
+        if symbol_key in self._tokens_by_symbol:
+            raise TokenRegistryError(f"Duplicate symbol detected: {token.symbol}")
+        if address_key in self._tokens_by_address:
+            raise TokenRegistryError(f"Duplicate contract address detected: {token.contract_address}")
+        self._tokens_by_symbol[symbol_key] = token
+        self._tokens_by_address[address_key] = token
+
+    def list_tokens(self) -> list[ERC20TokenMetadata]:
+        with self._lock:
+            return list(self._tokens_by_symbol.values())
+
+    def get_by_symbol(self, symbol: str) -> ERC20TokenMetadata | None:
+        with self._lock:
+            return self._tokens_by_symbol.get(symbol.upper())
+
+    def get_by_address(self, address: str) -> ERC20TokenMetadata | None:
+        with self._lock:
+            return self._tokens_by_address.get(address.lower())
+
+    def resolve(self, identifier: str) -> ERC20TokenMetadata | None:
+        """Resolve either a symbol (USDC) or contract address."""
+        if identifier.startswith("0x"):
+            return self.get_by_address(identifier)
+        return self.get_by_symbol(identifier)
+
+    def register_token(self, token: ERC20TokenMetadata, persist: bool = False) -> None:
+        with self._lock:
+            self._store(token)
+            if persist:
+                self._persist()
+
+    def require(self, identifier: str) -> ERC20TokenMetadata:
+        token = self.resolve(identifier)
+        if token is None:
+            raise TokenRegistryError(f"Unknown token: {identifier}")
+        return token
+
+    def _persist(self) -> None:
+        payload = [token.model_dump() for token in self._tokens_by_symbol.values()]
+        payload.sort(key=lambda entry: entry["symbol"].upper())
+        self._path.write_text(json.dumps(payload, indent=2))
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self._tokens_by_symbol)
+
+    def __contains__(self, symbol: str) -> bool:  # pragma: no cover - convenience
+        return self.get_by_symbol(symbol) is not None
+
+
+TOKEN_REGISTRY = TokenRegistry(CONFIG.token_registry_path)
+
+__all__ = ["TokenRegistry", "TokenRegistryError", "TOKEN_REGISTRY"]


### PR DESCRIPTION
# Overview
This adds a Token Registry singleton, which by default is populated from a JSON.

## Changes Made
- Added `ERC20TokenMetadata` (w/ decimals) and updated `TokenResource` schema to embed full token metadata.
- Seeded `app/data/token_registry.json` with USDC/USDT entries including contract addresses and precision.
- Introduced `app/utils/token_registry.py` plus `TOKEN_REGISTRY` singleton wired via config/env overrides.
- Switched `create_order()` to resolve USDC from the registry and scale amounts by the token’s decimals.
- Updated `_demo_alkahest()` to use the registry when approving escrow transactions.
