### PR TITLE
Feature: ZeroTier Integration in ERC-8004 Registry/Indexer and IP Resolution for Agent Card URLs

### DIFF
--- a/agents/a2a-agent-trader/Makefile
+++ b/agents/a2a-agent-trader/Makefile
@@ -12,10 +12,10 @@ install:
 # ==============================================================================
 
 # Register agent on-chain (run this before starting the agent)
-# Usage: make register-onchain [ENV_FILE=.env]
+# Usage: make register [ENV_FILE=.env]
 # This registers to the on-chain Registry separately from agent startup.
 # The agent ID will be saved to .env as ONCHAIN_AGENT_ID
-register-onchain:
+register:
 	@echo "==============================================================================="
 	@echo "| 🔗 Registering agent on-chain...                                            |"
 	@echo "==============================================================================="

--- a/agents/a2a-agent-trader/app/utils/config.py
+++ b/agents/a2a-agent-trader/app/utils/config.py
@@ -1,6 +1,9 @@
+import logging
 import os
 from dataclasses import dataclass
 from pathlib import Path
+
+from app.utils.zerotier import BaseUrlResolutionError, resolve_base_url_best_effort
 
 # Load .env file if it exists (before loading any config values)
 try:
@@ -12,6 +15,9 @@ try:
 except ImportError:
     # python-dotenv not available, skip
     pass
+
+
+logger = logging.getLogger(__name__)
 
 
 def _get_bool_env(var_name: str, default: bool = False) -> bool:
@@ -100,6 +106,7 @@ class Config:
     agent_id: str  # Internal identifier (must be valid Python identifier)
     agent_name: str  # Display name (can be any string, used in agent card and on-chain metadata)
     mcp_server_url: str
+    base_url_override_raw: str
     base_url_override: str
     port: int
     remote_agent_port: int
@@ -152,12 +159,35 @@ def load_config() -> Config:
     
     # Get agent_name (display name) - can be any string, falls back to agent_id
     agent_name = get_agent_name()
-    
+
+    # BASE_URL_OVERRIDE handling with optional ZeroTier placeholder
+    base_url_override_raw = os.getenv("BASE_URL_OVERRIDE", "http://localhost:8000")
+    zerotier_network = os.getenv("ZEROTIER_NETWORK")
+
+    try:
+        base_url_override_resolved = resolve_base_url_best_effort(
+            base_url_override_raw,
+            zerotier_network,
+        )
+        if base_url_override_resolved != base_url_override_raw:
+            logger.info(
+                "[CONFIG] BASE_URL_OVERRIDE resolved to %s (network=%s)",
+                base_url_override_resolved,
+                zerotier_network,
+            )
+    except BaseUrlResolutionError as exc:
+        logger.warning(
+            "[CONFIG] BASE_URL_OVERRIDE is invalid (%s); using raw value from env",
+            exc,
+        )
+        base_url_override_resolved = base_url_override_raw
+
     return Config(
         agent_id=agent_id,
         agent_name=agent_name,
         mcp_server_url=os.getenv("MCP_SERVER_URL", "http://localhost:8080/mcp"),
-        base_url_override=os.getenv("BASE_URL_OVERRIDE", "http://localhost:8000"),
+        base_url_override_raw=base_url_override_raw,
+        base_url_override=base_url_override_resolved,
         port=_get_int_env("PORT", 8000),
         remote_agent_port=_get_int_env("REMOTE_AGENT_PORT", 8000),
         remote_agent_url_override=os.getenv(

--- a/agents/a2a-agent-trader/app/utils/zerotier.py
+++ b/agents/a2a-agent-trader/app/utils/zerotier.py
@@ -1,20 +1,48 @@
+import asyncio
 import json
 import logging
 import subprocess
-from typing import Optional
+import time
+from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse, urlunparse
 
 logger = logging.getLogger(__name__)
 
+NetworkInfo = Dict[str, Any]
 
-def get_zerotier_ip(network_id: str, *, timeout: float = 5.0) -> Optional[str]:
+ZEROTIER_IP_TOKEN = "{ZEROTIER_IP}"
+
+
+class BaseUrlResolutionError(Exception):
+    """Raised when BASE_URL_OVERRIDE cannot be resolved into a valid URL."""
+
+
+def _normalize_base_url(url: str) -> str:
     """
-    Return the first assigned IP for the given ZeroTier network, if any.
+    Validate and normalize a base URL.
 
-    Uses `sudo zerotier-cli listnetworks -j` (may prompt for privileges).
+    Ensures scheme, host, and port are present and strips any trailing slash from the path.
     """
-    if not network_id:
-        return None
+    parsed = urlparse(url)
+    if not parsed.scheme:
+        raise BaseUrlResolutionError("BASE_URL_OVERRIDE must include a scheme (e.g., http://).")
+    if not parsed.hostname:
+        raise BaseUrlResolutionError("BASE_URL_OVERRIDE must include a host.")
+    if parsed.port is None:
+        raise BaseUrlResolutionError("BASE_URL_OVERRIDE must include a port.")
 
+    path = parsed.path.rstrip("/")
+    normalized = parsed._replace(path=path)
+    return urlunparse(normalized)
+
+
+def _replace_zerotier_token(base_url: str, zerotier_ip: str) -> str:
+    """Replace the {ZEROTIER_IP} token with the provided ZeroTier IP."""
+    return base_url.replace(ZEROTIER_IP_TOKEN, zerotier_ip)
+
+
+def _list_zerotier_networks(timeout: float = 5.0) -> Optional[List[NetworkInfo]]:
+    """List all ZeroTier networks via zerotier-cli."""
     cmd = ["sudo", "zerotier-cli", "listnetworks", "-j"]
     try:
         proc = subprocess.run(
@@ -25,7 +53,7 @@ def get_zerotier_ip(network_id: str, *, timeout: float = 5.0) -> Optional[str]:
             timeout=timeout,
         )
     except FileNotFoundError:
-        logger.warning("ZeroTier CLI not found; skipping IP lookup.")
+        logger.warning("ZeroTier CLI not found.")
         return None
     except subprocess.TimeoutExpired:
         logger.warning("ZeroTier CLI timed out while listing networks.")
@@ -35,9 +63,21 @@ def get_zerotier_ip(network_id: str, *, timeout: float = 5.0) -> Optional[str]:
         return None
 
     try:
-        networks = json.loads(proc.stdout)
+        return json.loads(proc.stdout)
     except json.JSONDecodeError:
         logger.warning("ZeroTier CLI returned invalid JSON.")
+        return None
+
+
+def get_zerotier_ip(network_id: str, *, timeout: float = 5.0) -> Optional[str]:
+    """
+    Return the first assigned IP for the given ZeroTier network, if any.
+    """
+    if not network_id:
+        return None
+
+    networks = _list_zerotier_networks(timeout=timeout)
+    if not networks:
         return None
 
     for net in networks:
@@ -51,3 +91,163 @@ def get_zerotier_ip(network_id: str, *, timeout: float = 5.0) -> Optional[str]:
 
     logger.info("ZeroTier network %s not found in listnetworks output.", network_id)
     return None
+
+
+def is_network_joined(network_id: str) -> bool:
+    """Check if the given ZeroTier network is already joined."""
+    if not network_id:
+        return False
+
+    networks = _list_zerotier_networks()
+    if not networks:
+        return False
+
+    return any(net.get("id") == network_id for net in networks)
+
+
+def join_zerotier_network(network_id: str) -> bool:
+    """
+    Join the given ZeroTier network.
+
+    Returns True if the join command was issued successfully.
+    """
+    if not network_id:
+        logger.warning("No ZeroTier network ID provided; cannot join network.")
+        return False
+
+    if is_network_joined(network_id):
+        logger.info("ZeroTier network %s already joined.", network_id)
+        return True
+
+    if not _check_zerotier_cli():
+        return False
+
+    cmd = ["sudo", "zerotier-cli", "join", network_id]
+    try:
+        subprocess.run(cmd, check=True, capture_output=True, text=True)
+        logger.info("Joined ZeroTier network %s.", network_id)
+        return True
+    except subprocess.CalledProcessError as exc:
+        logger.error("Failed to join ZeroTier network %s: %s", network_id, exc.stderr or exc.stdout)
+        return False
+
+
+def _check_zerotier_cli() -> bool:
+    """Return True if zerotier-cli is installed, False otherwise."""
+    try:
+        subprocess.run(
+            ["zerotier-cli", "-v"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        return True
+    except FileNotFoundError:
+        logger.warning("ZeroTier CLI not found. Install with: cd infra && make install")
+        return False
+
+
+def get_zerotier_node_id() -> Optional[str]:
+    """Return the local ZeroTier node ID, if available."""
+    if not _check_zerotier_cli():
+        return None
+
+    try:
+        proc = subprocess.run(
+            ["sudo", "zerotier-cli", "info"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        logger.warning("ZeroTier CLI error when getting node ID: %s", exc.stderr or exc.stdout)
+        return None
+    except FileNotFoundError:
+        # Already logged by _check_zerotier_cli
+        return None
+
+    parts = proc.stdout.split()
+    if len(parts) >= 3:
+        return parts[2]
+    return None
+
+
+def resolve_base_url_best_effort(base_url_override: str, zerotier_network: Optional[str]) -> str:
+    """
+    Resolve BASE_URL_OVERRIDE once without waiting.
+
+    - If no token is present, validate and return the normalized URL.
+    - If token is present and IP is available, substitute and normalize.
+    - If token is present but IP is not yet available, return the raw base_url_override.
+    """
+    if not base_url_override:
+        raise BaseUrlResolutionError("BASE_URL_OVERRIDE is empty.")
+
+    has_token = ZEROTIER_IP_TOKEN in base_url_override
+    if not has_token:
+        return _normalize_base_url(base_url_override)
+
+    if not zerotier_network:
+        raise BaseUrlResolutionError(
+            "BASE_URL_OVERRIDE uses {ZEROTIER_IP} but ZEROTIER_NETWORK is not set."
+        )
+
+    zerotier_ip = get_zerotier_ip(zerotier_network)
+    if not zerotier_ip:
+        # IP not assigned yet; caller can decide to keep placeholder.
+        return base_url_override
+
+    substituted = _replace_zerotier_token(base_url_override, zerotier_ip)
+    return _normalize_base_url(substituted)
+
+
+async def await_base_url_resolution(
+    base_url_override: str,
+    zerotier_network: Optional[str],
+    *,
+    wait_timeout: float = 120.0,
+    initial_interval: float = 2.0,
+    max_interval: float = 15.0,
+) -> str:
+    """
+    Resolve BASE_URL_OVERRIDE, waiting for ZeroTier IP if a token is present.
+
+    Raises BaseUrlResolutionError if resolution fails or times out.
+    """
+    if not base_url_override:
+        raise BaseUrlResolutionError("BASE_URL_OVERRIDE is empty.")
+
+    has_token = ZEROTIER_IP_TOKEN in base_url_override
+    if not has_token:
+        return _normalize_base_url(base_url_override)
+
+    if not zerotier_network:
+        raise BaseUrlResolutionError(
+            "BASE_URL_OVERRIDE uses {ZEROTIER_IP} but ZEROTIER_NETWORK is not set."
+        )
+
+    deadline = time.monotonic() + wait_timeout
+    interval = initial_interval
+
+    while True:
+        zerotier_ip = get_zerotier_ip(zerotier_network)
+        if zerotier_ip:
+            substituted = _replace_zerotier_token(base_url_override, zerotier_ip)
+            return _normalize_base_url(substituted)
+
+        now = time.monotonic()
+        if now >= deadline:
+            raise BaseUrlResolutionError(
+                f"ZeroTier IP not available after waiting {wait_timeout:.0f}s for network {zerotier_network}."
+            )
+
+        remaining = deadline - now
+        logger.info(
+            "Waiting for ZeroTier IP for network %s (placeholder present in BASE_URL_OVERRIDE). "
+            "Retrying in %.1fs (%.0fs remaining).",
+            zerotier_network,
+            interval,
+            remaining,
+        )
+        await asyncio.sleep(interval)
+        interval = min(max_interval, interval * 1.5)

--- a/agents/a2a-agent-trader/scripts/register_onchain.py
+++ b/agents/a2a-agent-trader/scripts/register_onchain.py
@@ -17,12 +17,23 @@ import asyncio
 import os
 import sys
 from pathlib import Path
+from urllib.parse import urlparse
 
 # Add parent directory to path to import app modules
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from app.utils.registry.onchain_registration import register_onchain_from_env, build_agent_card_url, build_registration_file_url
+from app.utils.registry.onchain_registration import (
+    register_onchain_from_env,
+    build_agent_card_url,
+    build_registration_file_url,
+)
 from app.utils.registry.blockchain_utils import build_erc8004_canonical_id
+from app.utils.zerotier import (
+    await_base_url_resolution,
+    join_zerotier_network,
+    get_zerotier_node_id,
+    BaseUrlResolutionError,
+)
 
 
 def update_env_file(env_file: Path, agent_id: int) -> bool:
@@ -61,6 +72,81 @@ def update_env_file(env_file: Path, agent_id: int) -> bool:
     return updated
 
 
+def update_env_file_zerotier_ip(env_file: Path, zerotier_ip: str) -> bool:
+    """
+    Update .env file with ZEROTIER_IP.
+
+    Returns:
+        True if file was updated, False otherwise
+    """
+    if not zerotier_ip:
+        return False
+
+    if not env_file.exists():
+        # Create a new file with just ZEROTIER_IP
+        env_file.write_text(f"ZEROTIER_IP={zerotier_ip}\n")
+        return True
+
+    content = env_file.read_text()
+    lines = content.split("\n")
+
+    current_ip = None
+    updated = False
+    for i, line in enumerate(lines):
+        if line.startswith("ZEROTIER_IP="):
+            current_ip = line.split("=", 1)[1].strip()
+            if current_ip != zerotier_ip:
+                lines[i] = f"ZEROTIER_IP={zerotier_ip}"
+                updated = True
+            break
+
+    if current_ip is None:
+        lines.append(f"ZEROTIER_IP={zerotier_ip}")
+        updated = True
+
+    if updated:
+        env_file.write_text("\n".join(lines))
+
+    return updated
+
+
+def update_env_file_base_url_override(env_file: Path, base_url: str) -> bool:
+    """
+    Update .env file with BASE_URL_OVERRIDE.
+
+    Returns:
+        True if file was updated, False otherwise
+    """
+    if not base_url:
+        return False
+
+    if not env_file.exists():
+        env_file.write_text(f"BASE_URL_OVERRIDE={base_url}\n")
+        return True
+
+    content = env_file.read_text()
+    lines = content.split("\n")
+
+    current_value = None
+    updated = False
+    for i, line in enumerate(lines):
+        if line.startswith("BASE_URL_OVERRIDE="):
+            current_value = line.split("=", 1)[1].strip()
+            if current_value != base_url:
+                lines[i] = f"BASE_URL_OVERRIDE={base_url}"
+                updated = True
+            break
+
+    if current_value is None:
+        lines.append(f"BASE_URL_OVERRIDE={base_url}")
+        updated = True
+
+    if updated:
+        env_file.write_text("\n".join(lines))
+
+    return updated
+
+
 async def main():
     """Register agent on-chain and output the agent ID."""
     import argparse
@@ -76,18 +162,85 @@ async def main():
     except ImportError:
         # dotenv not available, rely on environment variables from Makefile or shell
         pass
-    
+
+    # Path to the env file we will read/update
+    env_file = Path(args.env_file)
+
     # Read config for display
-    base_url_override = os.getenv("BASE_URL_OVERRIDE", "http://localhost:8000")
+    base_url_override_env = os.getenv("BASE_URL_OVERRIDE")
+    zerotier_network = os.getenv("ZEROTIER_NETWORK")
     chain_id = int(os.getenv("CHAIN_ID", "1337"))
     identity_registry_address = os.getenv("IDENTITY_REGISTRY_ADDRESS")
     agent_wallet_address = os.getenv("AGENT_WALLET_ADDRESS")
     chain_rpc_url = os.getenv("CHAIN_RPC_URL")
     onchain_agent_id = os.getenv("ONCHAIN_AGENT_ID")
-    
-    # Build URLs for display
-    agent_card_url = build_agent_card_url(base_url_override)
-    registration_file_url = build_registration_file_url(base_url_override)
+
+    # Determine final base URL, possibly using ZeroTier
+    use_zerotier = bool(zerotier_network)
+    resolved_base_url: str
+
+    if use_zerotier:
+        # Choose a template that always includes {ZEROTIER_IP}
+        if base_url_override_env and "{ZEROTIER_IP}" in base_url_override_env:
+            base_url_template = base_url_override_env
+        else:
+            # Default template if none provided
+            base_url_template = "http://{ZEROTIER_IP}:8000/"
+
+        print("ZeroTier network detected. Ensuring network is joined before registration...")
+        joined = join_zerotier_network(zerotier_network)
+        if not joined:
+            print(f"❌ Failed to join ZeroTier network {zerotier_network}.")
+            return 1
+
+        node_id = get_zerotier_node_id()
+        if node_id:
+            print(f"ZeroTier node ID: {node_id}")
+            print("Share this node ID with the Market Controller for authorization.")
+        else:
+            print("⚠️  Unable to determine ZeroTier node ID (zerotier-cli info failed).")
+
+        print("Waiting for ZeroTier IP assignment...")
+        try:
+            resolved_base_url = await await_base_url_resolution(
+                base_url_template,
+                zerotier_network,
+                wait_timeout=120.0,
+            )
+        except BaseUrlResolutionError as exc:
+            print(f"❌ Failed to resolve BASE_URL_OVERRIDE with ZeroTier IP: {exc}")
+            return 1
+
+        # Extract IP from resolved URL and store as ZEROTIER_IP in .env
+        parsed = urlparse(resolved_base_url)
+        zerotier_ip = parsed.hostname
+        if zerotier_ip:
+            ip_updated = update_env_file_zerotier_ip(env_file, zerotier_ip)
+            if ip_updated:
+                print(f"✅ Saved ZeroTier IP to {env_file}: ZEROTIER_IP={zerotier_ip}")
+            else:
+                print(f"✓ .env already has ZEROTIER_IP={zerotier_ip}")
+        else:
+            print("⚠️  Could not extract ZeroTier IP from resolved URL; skipping ZEROTIER_IP env update.")
+
+        # Persist the resolved BASE_URL_OVERRIDE (no placeholder) back into .env
+        base_url_updated = update_env_file_base_url_override(env_file, resolved_base_url)
+        if base_url_updated:
+            print(f"✅ Saved BASE_URL_OVERRIDE to {env_file}: {resolved_base_url}")
+        else:
+            print(f"✓ .env already has BASE_URL_OVERRIDE={resolved_base_url}")
+    else:
+        # No ZeroTier configured; fall back to existing env or localhost default
+        resolved_base_url = base_url_override_env or "http://localhost:8000"
+        if base_url_override_env and "{ZEROTIER_IP}" in base_url_override_env:
+            print(
+                "⚠️  BASE_URL_OVERRIDE contains {ZEROTIER_IP} but ZEROTIER_NETWORK is not set. "
+                "Proceeding without ZeroTier resolution."
+            )
+
+    # Build URLs for display using resolved base URL
+    agent_card_url = build_agent_card_url(resolved_base_url)
+    registration_file_url = build_registration_file_url(resolved_base_url)
     
     # Display registration info
     print("=" * 70)
@@ -108,9 +261,9 @@ async def main():
     print("Registering agent on-chain...")
     try:
         result = await register_onchain_from_env(
-            base_url=base_url_override,
+            base_url=resolved_base_url,
             chain_id=chain_id,
-            explicit_agent_id=onchain_agent_id
+            explicit_agent_id=onchain_agent_id,
         )
         
         if result:
@@ -159,7 +312,6 @@ async def main():
             print()
             
             # Auto-update .env file (unless --no-update-env flag is set)
-            env_file = Path(args.env_file)
             if not args.no_update_env:
                 updated = update_env_file(env_file, numeric_agent_id)
                 if updated:

--- a/erc-8004-registry-py/src/config.py
+++ b/erc-8004-registry-py/src/config.py
@@ -43,6 +43,9 @@ class Settings(BaseSettings):
     # Server Configuration
     port: int = 8080
     host: str = "0.0.0.0"
+
+    # Optional ZeroTier configuration (used by deployment/Makefile, not by app logic)
+    zerotier_network: str | None = Field(default=None, env="ZEROTIER_NETWORK")
     
     # Health Check Configuration
     enable_health_checks: bool = False  # Opt-in: Registry-initiated health checks (disabled by default)


### PR DESCRIPTION
## Overview

Adds ZeroTier IP resolution for Agent Card URLs, enabling agents to use templated URLs with `{ZEROTIER_IP}` placeholders that resolve to ZeroTier-assigned IPs. A single `make register` command now:
- Ensures the node has joined the ZeroTier network
- Waits for IP assignment
- Writes `ZEROTIER_IP` (and, if desired, the resolved `BASE_URL_OVERRIDE`) into your `.env`
- Registers or updates the agent on-chain using the resolved URL

## Testing

### Setup

1. **ZeroTier Installation**
```
cd infra
make install
```
2. **Test Network**
```
cd infra
make create-network
# Note the NETWORK_ID from the output
```
3. **Test Node Setup**
```
# Get local ZeroTier node ID
NODE_ID=$(sudo zerotier-cli info | cut -d " " -f3)
# Ask the Market Controller to add/authorize this node:
cd infra
make add-node NODE_ID=$NODE_ID
```
### Agent Env Configuration

In the agent project directory (`agents/a2a-agent-trader`), create or update your `.env`:
```
ZEROTIER_NETWORK=<NETWORK_ID_FROM_ABOVE>
# Optional: templated base URL; if omitted, a default of http://{ZEROTIER_IP}:8000/ is used
BASE_URL_OVERRIDE=http://{ZEROTIER_IP}:8000/
```
You should also have the usual chain/registry variables set (examples):
```
CHAIN_ID=31337
IDENTITY_REGISTRY_ADDRESS=<identity_registry_address>
AGENT_WALLET_ADDRESS=<wallet_address>
CHAIN_RPC_URL=http://127.0.0.1:8545### Run Unified Registration
```

From `agents/a2a-agent-trader`:
```
make register           # or: make register ENV_FILE=.envWhat happens:
```
1. The script loads env vars from the chosen env file.
2. If `ZEROTIER_NETWORK` is set:
   - Ensures the node is joined to the ZeroTier network.
   - Prints the ZeroTier node ID (for controller authorization if needed).
   - Waits (up to ~120s) for IP assignment.
   - Resolves the `{ZEROTIER_IP}` placeholder to the assigned IP.
   - Writes/updates `ZEROTIER_IP=<assigned_ip>` in your env file.
   - Optionally writes/updates `BASE_URL_OVERRIDE` with the fully resolved URL.
3. Registers or updates the agent on-chain using the resolved base URL as the Agent Card/registration base.

### Verification

1. **Verify env file**

After `make register`, open your env file and confirm:

```  
   ZEROTIER_IP=10.10.10.11               # example
   BASE_URL_OVERRIDE=http://10.10.10.11:8000/
   ONCHAIN_AGENT_ID=<numeric_id>
``` 
2. **Verify ZeroTier IP**
```
   sudo zerotier-cli listnetworks -j | jq '.[] | {id, assignedAddresses}'
```
You should see the same IP as in `ZEROTIER_IP`.

3. **Verify on-chain registration / indexer**
- The ERC-8004 indexer logs should show an updated token URI pointing at your ZeroTier IP, for example:
```
Updated token URI for agent ... to http://10.10.10.11:8000/.well-known/erc-8004-registration.json
```
- Agent heartbeats should succeed and be logged against the canonical agent ID.

**Expected:**

- `{ZEROTIER_IP}` placeholder is resolved to the actual ZeroTier IP (e.g. `http://10.10.10.11:8000/`).
- `.env` contains `ZEROTIER_IP` (and resolved `BASE_URL_OVERRIDE` if enabled).
- On-chain registration succeeds (new or “no changes detected”).
- Indexer logs show the registration URL with the ZeroTier IP, and heartbeats succeed.