### PR TITLE
Feature: Provision VM via Ansible

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "erc-8004-contracts"]
 	path = erc-8004-contracts
 	url = https://github.com/ww-jermaine/erc-8004-contracts.git
+[submodule "compute-provisioning-iac"]
+	path = compute-provisioning-iac
+	url = git@github.com:arkhai-io/compute-provisioning-iac.git

--- a/agents/a2a-agent-trader/app/agent.py
+++ b/agents/a2a-agent-trader/app/agent.py
@@ -92,6 +92,7 @@ from .utils.action_executor import execute_action
 from .utils.serializer import json_serializer
 from .utils.token_registry import TOKEN_REGISTRY
 from .utils.zerotier import get_zerotier_ip
+from .utils.provisioning import run_vm_provisioning_playbook
 from pydantic import PrivateAttr
 
 # Limits to keep stored JSON blobs from exploding the SQLite size
@@ -359,7 +360,6 @@ def _serialize_outcome_for_storage(outcome: dict[str, Any]) -> str:
             }
         )
     return outcome_json
-
 class TraderAgent(BaseAgent):
     """
     Custom agent for trading computational resources.
@@ -862,6 +862,11 @@ async def handle_resource_alert(request: Request) -> JSONResponse:
             {"error": "Failed to validate alert", "detail": str(e)},
             status_code=400
         )
+
+    logger.info("Provisioning...")
+    run_vm_provisioning_playbook("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGhWsCyFhP7XsBcnjft0H9463ShWBuv6ck+bhIEfWVyJ albert@whitewidget.com")
+    logger.info("Provisioning complete.")
+    return JSONResponse({"message": "Provisioning successful."})
 
     try:
         response_text = await _run_alert_conversation(alert_request)

--- a/agents/a2a-agent-trader/app/agent.py
+++ b/agents/a2a-agent-trader/app/agent.py
@@ -92,7 +92,6 @@ from .utils.action_executor import execute_action
 from .utils.serializer import json_serializer
 from .utils.token_registry import TOKEN_REGISTRY
 from .utils.zerotier import get_zerotier_ip
-from .utils.provisioning import run_vm_provisioning_playbook
 from pydantic import PrivateAttr
 
 # Limits to keep stored JSON blobs from exploding the SQLite size
@@ -862,11 +861,6 @@ async def handle_resource_alert(request: Request) -> JSONResponse:
             {"error": "Failed to validate alert", "detail": str(e)},
             status_code=400
         )
-
-    logger.info("Provisioning...")
-    run_vm_provisioning_playbook("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGhWsCyFhP7XsBcnjft0H9463ShWBuv6ck+bhIEfWVyJ albert@whitewidget.com")
-    logger.info("Provisioning complete.")
-    return JSONResponse({"message": "Provisioning successful."})
 
     try:
         response_text = await _run_alert_conversation(alert_request)

--- a/agents/a2a-agent-trader/app/utils/action_executor.py
+++ b/agents/a2a-agent-trader/app/utils/action_executor.py
@@ -1,4 +1,4 @@
-"""Action execution simulation (logging only for now)."""
+"""Action execution."""
 
 from __future__ import annotations
 
@@ -38,6 +38,7 @@ from app.schema.pydantic_models import (
 from .config import CONFIG
 from .token_registry import TOKEN_REGISTRY
 from .registry_client import get_registry_client
+from .provisioning import run_vm_provisioning_playbook
 
 BASE_URL_OVERRIDE = CONFIG.base_url_override
 REMOTE_AGENT_URL_OVERRIDE = CONFIG.remote_agent_url_override
@@ -172,7 +173,7 @@ async def execute_action(
             outcome["message"] = "Resources rebalanced internally (simulated)"
 
         case ActionType.FULFILL_COMPUTE_OBLIGATION.value:
-            logger.info(f"[ACTION] [SIMULATED] Fulfilling compute obligation with params: {parameters}")
+            logger.info(f"[ACTION] Fulfilling compute obligation with params: {parameters}")
             escrow_uid = parameters.get("escrow_uid")
             ssh_public_key = parameters.get("ssh_public_key")
             order_id = parameters.get("order_id")
@@ -211,7 +212,7 @@ async def execute_action(
                 except Exception as send_err:
                     logger.warning("[ACTION] Failed to send fulfillment to remote agent: %s", send_err)
             outcome["result"] = result
-            outcome["message"] = result.get("message", "Compute obligation fulfilled (simulated)")
+            outcome["message"] = result.get("message", "Compute obligation fulfilled")
 
         case ActionType.TRUST_COMPUTE_OBLIGATION_FULFILLMENT.value:
             logger.info(f"[ACTION] Trusting compute fulfillment with params: {parameters}")
@@ -310,7 +311,7 @@ async def execute_action(
         case ActionType.NOOP.value:
             logger.info(f"[ACTION] [SIMULATED] No operation required")
             outcome["result"] = None
-            outcome["message"] = "No operation (simulated)"
+            outcome["message"] = "No operation"
             
         case _:
             logger.warning(f"[ACTION] [SIMULATED] Unknown action type: {action_type_str}")
@@ -432,6 +433,28 @@ async def mock_provision_machine(ssh_public_key: str) -> str:
     """
     logger.info(f"[TOOL] (Simulated) Machine provisioned with SSH key for pubkey: {ssh_public_key}.")
     return "demo-user@node-01.example.net"
+
+
+async def provision_machine(ssh_public_key: str) -> str:
+    """Provision a machine using the provided SSH public key.
+
+    Args:
+        ssh_public_key: SSH public key to install on the provisioned machine.
+
+    Returns:
+        String with connection details.
+    """
+    logger.info(f"[TOOL] Provisioning machine with provided SSH public key.")
+    try:
+        connection_info = run_vm_provisioning_playbook(ssh_public_key)
+        if connection_info:
+            logger.info(f"[TOOL] Machine provisioned: {connection_info}")
+            return connection_info
+        logger.warning("[TOOL] Provisioning completed but connection info was not available.")
+        return "Provisioning completed, but SSH connection info unavailable."
+    except Exception as exc:
+        logger.error("[TOOL] Provisioning failed: %s", exc)
+        return f"Provisioning failed: {exc}"
 
 
 async def accept_offer(
@@ -1130,7 +1153,7 @@ async def fulfill_compute_obligation(
     When the maker fulfills, this sets maker_attestation in the registry.
     """
     oracle_address = _resolve_oracle_address(oracle_address)
-    connection_details = await mock_provision_machine(ssh_public_key)
+    connection_details = await provision_machine(ssh_public_key)
     fulfillment_uid = None
     maker_attestation = None
     
@@ -1146,7 +1169,7 @@ async def fulfill_compute_obligation(
                 escrow_uid
             )
             maker_attestation = fulfillment_uid  # Use fulfillment_uid as maker_attestation
-            logger.info("[ALKAHEST] Fulfilled compute obligation with on-chain client; simulated machine provisioned.")
+            logger.info("[ALKAHEST] Fulfilled compute obligation with on-chain client; machine provisioned.")
             request_arbitration_result = await client.oracle.request_arbitration(fulfillment_uid, oracle_address)
             logger.info(f"[ALKAHEST] Arbitration requested: {request_arbitration_result}")
         except Exception as error:

--- a/agents/a2a-agent-trader/app/utils/provisioning.py
+++ b/agents/a2a-agent-trader/app/utils/provisioning.py
@@ -91,7 +91,7 @@ def run_vm_provisioning_playbook(ssh_pubkey: str, vm_host: str = "vm1") -> Optio
 
     vm_vars_payload = (
         f"vm_host: {vm_host}\n"
-        "vm_target: albert-vm\n"
+        "vm_target: tenant-vm\n"
         "vm_action: create\n"
         "vm_ram: 2048\n"
         "vm_vcpus: 2\n"

--- a/agents/a2a-agent-trader/app/utils/provisioning.py
+++ b/agents/a2a-agent-trader/app/utils/provisioning.py
@@ -1,0 +1,164 @@
+import logging
+import re
+import subprocess
+import uuid
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _find_project_root() -> Path:
+    """Walk up the tree to locate the repo root (uses compute-provisioning-iac or .git as sentinels)."""
+    current = Path(__file__).resolve()
+    for parent in [current] + list(current.parents):
+        if (parent / "compute-provisioning-iac").exists():
+            return parent
+        if (parent / ".git").exists():
+            return parent
+    # Fallback: go up four levels (expected repo layout)
+    return current.parents[3]
+
+
+def _extract_external_port(playbook_output: str, vm_host: str | None = None) -> Optional[str]:
+    """Extract the external SSH port from playbook stdout."""
+    patterns = [r'"external_ssh_port":\s*"(?P<port>\d+)"']
+    if vm_host:
+        patterns.extend(
+            [
+                rf"-p\s*(?P<port>\d{{2,5}})\s+root@{re.escape(vm_host)}",
+                rf"-p\s*(?P<port>\d{{2,5}})\s+\S+@{re.escape(vm_host)}",
+            ]
+        )
+    patterns.append(r"-p\s*(?P<port>\d{2,5})\s+\S+@[\w\.-]+")
+    for pattern in patterns:
+        match = re.search(pattern, playbook_output)
+        if match:
+            return match.group("port")
+    return None
+
+
+def _extract_tenant_user(playbook_output: str, vm_host: str | None = None) -> Optional[str]:
+    """Extract the tenant SSH username from playbook stdout."""
+    patterns = [r'"tenant_user":\s*"(?P<user>[^"]+)"']
+    if vm_host:
+        patterns.append(rf"-p\s*\d{{2,5}}\s+(?P<user>[A-Za-z0-9._-]+)@{re.escape(vm_host)}")
+    patterns.append(r"-p\s*\d{2,5}\s+(?P<user>[A-Za-z0-9._-]+)@\S+")
+    for pattern in patterns:
+        match = re.search(pattern, playbook_output)
+        if match:
+            return match.group("user")
+    return None
+
+
+def _lookup_vm_host_ip(vm_host: str) -> Optional[str]:
+    """Read the Ansible inventory to find the external IP for a given host."""
+    project_root = _find_project_root()
+    inventory_path = (project_root / "compute-provisioning-iac/ansible/inventory/hosts").resolve()
+
+    try:
+        for line in inventory_path.read_text(encoding="utf-8").splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#") or stripped.startswith("["):
+                continue
+            if not stripped.startswith(vm_host + " "):
+                continue
+
+            parts = stripped.split()
+            for part in parts:
+                if part.startswith("ansible_host="):
+                    return part.split("=", 1)[1]
+    except Exception as exc:
+        logger.warning("Failed to read inventory %s: %s", inventory_path, exc)
+
+    logger.warning("No ansible_host found for %s in inventory", vm_host)
+    return None
+
+
+def run_vm_provisioning_playbook(ssh_pubkey: str, vm_host: str = "vm1") -> str:
+    """
+    Run the Ansible playbook that provisions a VM using the shared inventory and vars file.
+
+    Returns:
+        Stdout from the playbook run.
+
+    Raises:
+        subprocess.CalledProcessError if the playbook exits with a non-zero status.
+    """
+    nonce = uuid.uuid4().hex
+    vm_vars_path = Path(f"/tmp/vm_vars_{nonce}.yml")
+    escaped_pubkey = ssh_pubkey.replace('"', '\\"')
+
+    vm_vars_payload = (
+        f"vm_host: {vm_host}\n"
+        "vm_target: albert-vm\n"
+        "vm_action: create\n"
+        "vm_ram: 2048\n"
+        "vm_vcpus: 2\n"
+        "vm_disk_size: 25G\n"
+        f'vm_tenant_pubkey: "{escaped_pubkey}"\n'
+    )
+
+    vm_vars_path.write_text(vm_vars_payload, encoding="utf-8")
+
+    project_root = _find_project_root()
+
+    cmd = [
+        "ansible-playbook",
+        "-i",
+        str(project_root / "compute-provisioning-iac/ansible/inventory/hosts"),
+        str(project_root / "compute-provisioning-iac/ansible/playbooks/single-tenant/vm-operations.yaml"),
+        "--extra-vars",
+        f"@{vm_vars_path}",
+        "--limit",
+        vm_host,
+    ]
+    cwd = project_root
+
+    try:
+        result = subprocess.run(
+            cmd,
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+        )
+    except subprocess.CalledProcessError as exc:
+        logger.error(
+            "VM provisioning playbook failed (code %s): %s",
+            exc.returncode,
+            exc.stderr,
+        )
+        raise
+
+    logger.info("VM provisioning playbook output:\n%s", result.stdout)
+    if result.stderr:
+        logger.warning("VM provisioning playbook stderr:\n%s", result.stderr)
+
+    external_port = _extract_external_port(result.stdout, vm_host)
+    if external_port:
+        logger.info("External SSH port for %s: %s", vm_host, external_port)
+    else:
+        logger.warning("External SSH port not found in playbook output.")
+
+    vm_host_ip = _lookup_vm_host_ip(vm_host)
+    if vm_host_ip:
+        logger.info("External IP for %s: %s", vm_host, vm_host_ip)
+    else:
+        logger.warning("Could not determine external IP for %s.", vm_host)
+
+    tenant_user = _extract_tenant_user(result.stdout, vm_host)
+    if tenant_user:
+        logger.info("Tenant SSH user: %s", tenant_user)
+    else:
+        logger.warning("Tenant SSH user not found in playbook output.")
+
+    if external_port and vm_host_ip and tenant_user:
+        logger.info(
+            "SSH command: ssh -i <your_private_key> -p %s %s@%s",
+            external_port,
+            tenant_user,
+            vm_host_ip,
+        )
+
+    return result.stdout

--- a/agents/a2a-agent-trader/app/utils/provisioning.py
+++ b/agents/a2a-agent-trader/app/utils/provisioning.py
@@ -75,12 +75,12 @@ def _lookup_vm_host_ip(vm_host: str) -> Optional[str]:
     return None
 
 
-def run_vm_provisioning_playbook(ssh_pubkey: str, vm_host: str = "vm1") -> str:
+def run_vm_provisioning_playbook(ssh_pubkey: str, vm_host: str = "vm1") -> Optional[str]:
     """
     Run the Ansible playbook that provisions a VM using the shared inventory and vars file.
 
     Returns:
-        Stdout from the playbook run.
+        SSH command string if all connection details were found, otherwise None.
 
     Raises:
         subprocess.CalledProcessError if the playbook exits with a non-zero status.
@@ -125,8 +125,9 @@ def run_vm_provisioning_playbook(ssh_pubkey: str, vm_host: str = "vm1") -> str:
         )
     except subprocess.CalledProcessError as exc:
         logger.error(
-            "VM provisioning playbook failed (code %s): %s",
+            "VM provisioning playbook failed (code %s). stdout:\n%s\nstderr:\n%s",
             exc.returncode,
+            exc.stdout,
             exc.stderr,
         )
         raise
@@ -153,12 +154,9 @@ def run_vm_provisioning_playbook(ssh_pubkey: str, vm_host: str = "vm1") -> str:
     else:
         logger.warning("Tenant SSH user not found in playbook output.")
 
+    ssh_command = None
     if external_port and vm_host_ip and tenant_user:
-        logger.info(
-            "SSH command: ssh -i <your_private_key> -p %s %s@%s",
-            external_port,
-            tenant_user,
-            vm_host_ip,
-        )
+        ssh_command = f"ssh -i <your_private_key> -p {external_port} {tenant_user}@{vm_host_ip}"
+        logger.info("SSH command: %s", ssh_command)
 
-    return result.stdout
+    return ssh_command


### PR DESCRIPTION
# Overview
- Adds the Compute Provisioning Infrastructure-as-Code repository as submodule
- Adds utilities for executing Ansible as subprocess
- Modifies the `fulfill_compute_obligation` Action to now provision an actual VM

# Testing

## Prerequisites
- Edit the IAC `inventory/hosts` to point to your privkey
- Make sure you don't already have a VM running; provisioning will fail. Run `shutdown`/`destroy` if necessary.
- Run test chain: `make test-env`
- Run Registry: `make serve`
- Register Alice's and Bob's Agents with `make register`

## Main Flow
Set Alice (buyer)'s `SSH_PUBLIC_KEY` to the actual public key whose privkey you'll use for accessing the VM.

Create the deficit order for Alice:
```
curl -X POST http://{ZEROTIER_IP}:8000/alerts/resource \
  -H "Content-Type: application/json" \
  -d '{"event_type": "resource_imbalance", "resource": {"gpu_model": "H200", "quantity": 1, "sla": 90.0, "region": "California, US"}, "value": 0.95, "label": "HIGH DEMAND", "threshold": ">=0.70"}'
```

Create the surplus order for Bob:
```
curl -X POST http://{ZEROTIER_IP}:8001/alerts/resource \
  -H "Content-Type: application/json" \
  -d '{"event_type": "resource_imbalance", "resource": {"gpu_model": "H200", "quantity": 1, "sla": 90.0, "region": "California, US"}, "value": 0.05, "label": "LOW UTILIZATION", "threshold": "<=0.30"}'
```

It take 3-6 minutes to provision the VM.
<img width="1791" height="243" alt="image" src="https://github.com/user-attachments/assets/509972d7-5fd7-41c8-9380-4d834f09807c" />

Once the connection string is sent, connect to it. You should not be asked to provide a password.


# Next Steps
1. Arbitration is currently failing. This may be due to drift between the Python and Rust SDK. For investigation.
2. On Alice's (buyer's) end, the connection string is currently buried. We should modify return values to surface this.
3. Automatically schedule lease expiry.