### PR TITLE
feat(alkahest): Use refactored alkahest-py from monorepo

### DIFF
--- a/agents/a2a-agent-trader/app/utils/action_executor.py
+++ b/agents/a2a-agent-trader/app/utils/action_executor.py
@@ -1163,8 +1163,8 @@ async def fulfill_compute_obligation(
     When the maker fulfills, this sets maker_attestation in the registry.
     """
     oracle_address = _resolve_oracle_address(oracle_address)
-    connection_details = await mock_provision_machine(ssh_public_key)
-    # connection_details = await provision_machine(ssh_public_key)
+    # connection_details = await mock_provision_machine(ssh_public_key)
+    connection_details = await provision_machine(ssh_public_key)
     fulfillment_uid = None
     maker_attestation = None
 

--- a/agents/a2a-agent-trader/app/utils/action_executor.py
+++ b/agents/a2a-agent-trader/app/utils/action_executor.py
@@ -47,7 +47,7 @@ REMOTE_AGENT_PORT = CONFIG.remote_agent_port
 AGENT_ID = CONFIG.agent_id
 SSH_PUBLIC_KEY = CONFIG.ssh_public_key
 
-TRUSTED_ORACLE_ARBITER = "0x77154e8F4204e484e12fAA68d50964e793224d02"
+TRUSTED_ORACLE_ARBITER = "0x8a791620dd6260079bf849dc5567adc3f2fdc318"
 DEMO_ORACLE_ADDRESS = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
 
 logger = logging.getLogger(__name__)
@@ -1156,7 +1156,7 @@ async def fulfill_compute_obligation(
     escrow_uid: str,
     ssh_public_key: str,
     oracle_address: str | None = None,
-    order: str | None = None,
+    order: str | dict | None = None,
 ):
     """Provision compute and fulfill the obligation. Falls back to simulated flow if no client.
     
@@ -1275,7 +1275,7 @@ async def arbitrate_compute_fulfillment(
             "decisions": decisions,
         }
 
-    mode = ArbitrationMode.AllUnarbitrated
+    mode = ArbitrationMode.PastUnarbitrated
 
     try:
         decisions = await client.oracle.arbitrate_many(
@@ -1320,6 +1320,7 @@ async def collect_escrow(
         logger.info("[ALKAHEST] (Simulated) Escrow collected {result}")
     else:
         try:
+            logger.info(f"[ALKAHEST] Collecting escrow: escrow_uid={escrow_uid}, fulfillment_uid={fulfillment_uid}")
             result = await client.erc20.escrow.non_tierable.collect(
                 escrow_uid,
                 fulfillment_uid,

--- a/agents/a2a-agent-trader/app/utils/action_executor.py
+++ b/agents/a2a-agent-trader/app/utils/action_executor.py
@@ -48,7 +48,7 @@ AGENT_ID = CONFIG.agent_id
 SSH_PUBLIC_KEY = CONFIG.ssh_public_key
 
 TRUSTED_ORACLE_ARBITER = "0x77154e8F4204e484e12fAA68d50964e793224d02"
-DEMO_ORACLE_ADDRESS = "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"
+DEMO_ORACLE_ADDRESS = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
 
 logger = logging.getLogger(__name__)
 
@@ -456,6 +456,24 @@ async def provision_machine(ssh_public_key: str) -> str:
         logger.error("[TOOL] Provisioning failed: %s", exc)
         return f"Provisioning failed: {exc}"
 
+def extract_compute_and_token_from_order_dict(order: dict) -> tuple[dict, dict]:
+    """Given an order, take the demand and offer and extract which is compute and which is tokens."""
+    offer_resource = order.get("offer_resource", {})
+    demand_resource = order.get("demand_resource", {})
+
+    offer_is_compute = "gpu_model" in offer_resource
+    demand_is_compute = "gpu_model" in demand_resource
+
+    if offer_is_compute:
+        compute_resource = offer_resource
+        token_resource = demand_resource
+    elif demand_is_compute:
+        compute_resource = demand_resource
+        token_resource = offer_resource
+    else:
+        raise ValueError("Neither offer nor demand resource is compute in the provided order.")
+
+    return compute_resource, token_resource
 
 async def accept_offer(
     *,
@@ -488,22 +506,7 @@ async def accept_offer(
     escrow_receipt = None
     
     if alkahest_client:
-        offer_res = order_dict.get("offer_resource", {})
-        demand_res = order_dict.get("demand_resource", {})
-        
-        # Determine resource types
-        offer_is_compute = "gpu_model" in offer_res
-        demand_is_compute = "gpu_model" in demand_res
-        
-        # Map resources based on what maker is offering
-        if offer_is_compute:
-            # Maker offers compute (surplus): taker buys compute (offer_resource) and pays tokens (demand_resource)
-            compute_resource = offer_res
-            token_resource = demand_res
-        else:
-            # Maker offers tokens (deficit): taker buys compute (demand_resource) and pays tokens (offer_resource)
-            compute_resource = demand_res
-            token_resource = offer_res
+        compute_resource, token_resource = extract_compute_and_token_from_order_dict(order_dict)
         
         # Retry logic with exponential backoff
         max_retries = 3
@@ -1160,8 +1163,8 @@ async def fulfill_compute_obligation(
     When the maker fulfills, this sets maker_attestation in the registry.
     """
     oracle_address = _resolve_oracle_address(oracle_address)
-    # connection_details = await mock_provision_machine(ssh_public_key)
-    connection_details = await provision_machine(ssh_public_key)
+    connection_details = await mock_provision_machine(ssh_public_key)
+    # connection_details = await provision_machine(ssh_public_key)
     fulfillment_uid = None
     maker_attestation = None
 
@@ -1179,10 +1182,15 @@ async def fulfill_compute_obligation(
             order_bytes = order.encode("utf-8")
         elif isinstance(order, dict):
             order_dict = order
-            order_bytes = json.dumps(order_dict, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+            compute_resource, token_resource = extract_compute_and_token_from_order_dict(order_dict)
+            order_bytes = encode_compute_lease(
+                compute_resource=compute_resource,
+                token_resource=token_resource,
+                duration_days=1,
+            )
         if order_dict:
             order_id = order_dict.get("order_id")
-    
+
     if not client or not oracle_address:
         # Demo fallback: skip on-chain, return simulated fulfillment uid
         fulfillment_uid = f"fulfill_{uuid.uuid4()}"

--- a/agents/a2a-agent-trader/app/utils/action_executor.py
+++ b/agents/a2a-agent-trader/app/utils/action_executor.py
@@ -17,8 +17,8 @@ from google.adk.agents.remote_a2a_agent import (
 
 from alkahest_py import (
     AlkahestClient,
-    ArbitrateOptions,
-    TrustedOracleArbiterDemandData
+    ArbitrationMode,
+    TrustedOracleArbiterDemandData,
 )
 import json
 
@@ -47,7 +47,7 @@ REMOTE_AGENT_PORT = CONFIG.remote_agent_port
 AGENT_ID = CONFIG.agent_id
 SSH_PUBLIC_KEY = CONFIG.ssh_public_key
 
-TRUSTED_ORACLE_ARBITER = "0xa51c1fc2f0d1a1b8494ed1fe312d7c3a78ed91c0"
+TRUSTED_ORACLE_ARBITER = "0x77154e8F4204e484e12fAA68d50964e793224d02"
 DEMO_ORACLE_ADDRESS = "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"
 
 logger = logging.getLogger(__name__)
@@ -176,7 +176,7 @@ async def execute_action(
             logger.info(f"[ACTION] Fulfilling compute obligation with params: {parameters}")
             escrow_uid = parameters.get("escrow_uid")
             ssh_public_key = parameters.get("ssh_public_key")
-            order_id = parameters.get("order_id")
+            order = parameters.get("order")
 
             if not escrow_uid:
                 raise ValueError("escrow_uid is required for fulfill_compute_obligation")
@@ -188,7 +188,7 @@ async def execute_action(
                 escrow_uid=escrow_uid,
                 oracle_address=parameters.get("oracle_address") or DEMO_ORACLE_ADDRESS,
                 ssh_public_key=ssh_public_key,
-                order_id=order_id,
+                order=order,
             )
             # Include event_type for downstream parsing and propagate to remote agent.
             result["event_type"] = EventType.RECEIVE_COMPUTE_OBLIGATION_FULFILLMENT.value
@@ -1068,10 +1068,11 @@ async def approve_token_escrow(
         price_data,
     )
     try:
-        escrow_approval = await alkahest_client.erc20.approve(price_data, "escrow")
+        escrow_approval = await alkahest_client.erc20.util.approve(price_data, "escrow")
         logger.info(f"[ALKAHEST]: Escrow approved: {escrow_approval}")
     except Exception as error:
         logger.info(f"[ALKAHEST] Escrow approval error: {error}")
+        raise RuntimeError("Escrow approval failed") from error
     return escrow_approval
 
 
@@ -1088,7 +1089,8 @@ async def buy_compute_with_erc20(
     wishes to trade it for a ComputeResource.
 
     Encodes the compute lease as a JSON demand payload, approves the ERC20 amount,
-    and purchases via buy_with_erc20. Expiration is set to 0 (non-expiring) for now.
+    and creates escrow via the non-tierable escrow client. Expiration is set to 0
+    (non-expiring) for now.
     """
     if not client:
         raise RuntimeError("buy_with_erc20 requires an AlkahestClient instance")
@@ -1125,7 +1127,7 @@ async def buy_compute_with_erc20(
     expiration = 0  # non-expiring escrow for now; may become time-limited later
 
     logger.info(
-        "[ALKAHEST] buy_with_erc20 price_data=%s arbiter=%s expiration=%s",
+        "[ALKAHEST] escrow.create price_data=%s arbiter=%s expiration=%s",
         price_data,
         arbiter_address,
         expiration,
@@ -1134,10 +1136,15 @@ async def buy_compute_with_erc20(
     escrow_receipt = None
 
     try:
-        escrow_receipt =  await client.erc20.buy_with_erc20(price_data, arbiter_data, expiration)
+        escrow_receipt = await client.erc20.escrow.non_tierable.create(
+            price_data,
+            arbiter_data,
+            expiration,
+        )
         logger.info(f"[ALKAHEST]: {escrow_receipt}")
     except Exception as buy_with_erc20_err:
-        logger.warning("[ALKAHEST] Failed to buy_with_erc20: %s", buy_with_erc20_err)
+        logger.error("[ALKAHEST] Failed to create escrow: %s", buy_with_erc20_err)
+        raise RuntimeError("Escrow creation failed") from buy_with_erc20_err
 
     return escrow_receipt
 
@@ -1146,16 +1153,35 @@ async def fulfill_compute_obligation(
     escrow_uid: str,
     ssh_public_key: str,
     oracle_address: str | None = None,
-    order_id: str | None = None,
+    order: str | None = None,
 ):
     """Provision compute and fulfill the obligation. Falls back to simulated flow if no client.
     
     When the maker fulfills, this sets maker_attestation in the registry.
     """
     oracle_address = _resolve_oracle_address(oracle_address)
+    # connection_details = await mock_provision_machine(ssh_public_key)
     connection_details = await provision_machine(ssh_public_key)
     fulfillment_uid = None
     maker_attestation = None
+
+    logger.info(f"[ALKAHEST] Order for fulfillment: {order}")
+    order_dict = None
+    order_id = None
+    order_bytes = b""
+
+    if order:
+        if isinstance(order, str):
+            try:
+                order_dict = json.loads(order)
+            except json.JSONDecodeError:
+                order_dict = None
+            order_bytes = order.encode("utf-8")
+        elif isinstance(order, dict):
+            order_dict = order
+            order_bytes = json.dumps(order_dict, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+        if order_dict:
+            order_id = order_dict.get("order_id")
     
     if not client or not oracle_address:
         # Demo fallback: skip on-chain, return simulated fulfillment uid
@@ -1170,13 +1196,18 @@ async def fulfill_compute_obligation(
             )
             maker_attestation = fulfillment_uid  # Use fulfillment_uid as maker_attestation
             logger.info("[ALKAHEST] Fulfilled compute obligation with on-chain client; machine provisioned.")
-            request_arbitration_result = await client.oracle.request_arbitration(fulfillment_uid, oracle_address)
+            demand_bytes = order_bytes
+            request_arbitration_result = await client.oracle.request_arbitration(
+                fulfillment_uid,
+                oracle_address,
+                demand_bytes,
+            )
             logger.info(f"[ALKAHEST] Arbitration requested: {request_arbitration_result}")
         except Exception as error:
             logger.info(f"[ALKAHEST] Fulfillment error: {error}")
     
     # Update registry with maker_attestation when maker fulfills
-    if order_id and maker_attestation and CONFIG.enable_registry_discovery:
+    if order and maker_attestation and CONFIG.enable_registry_discovery and order_id:
         try:
             registry_client = get_registry_client()
             updates = {
@@ -1208,8 +1239,16 @@ async def arbitrate_compute_fulfillment(
     oracle_address = _resolve_oracle_address(oracle_address)
     logger.info(f"[ALKAHEST] Oracle address: {oracle_address}")
     
-    async def decision_function (attestation):
+    async def decision_function(attestation, demand):
         logger.info(f"[ALKAHEST] Attestation: {attestation}")
+
+        # Parse the demand directly from callback argument (no need to fetch from escrow!)
+        try:
+            demand_json = json.loads(bytes(demand).decode('utf-8'))
+            logger.info(f"[ALKAHEST] Parsed demand data: {demand_json}")
+        except Exception as e:
+            logger.error(f"Failed to parse demand: {e}")
+
         return True
 
     def callback(decision):
@@ -1228,17 +1267,17 @@ async def arbitrate_compute_fulfillment(
             "decisions": decisions,
         }
 
-    options = ArbitrateOptions(skip_arbitrated=True, only_new=False)
+    mode = ArbitrationMode.AllUnarbitrated
 
     try:
-        result = await client.oracle.listen_and_arbitrate_no_spawn(
+        decisions = await client.oracle.arbitrate_many(
             decision_function,
             callback,
-            options,
+            mode,
             timeout_seconds=2.0
         )
 
-        decisions = getattr(result, "decisions", None) or getattr(result, "decision", None) or []
+        logger.info(f"[ALKAHEST] Arbitration result: {decisions}")
         if not decisions:
             logger.warning("[ALKAHEST] Warning: No fulfillments were arbitrated.")
         logger.info("[ALKAHEST] Arbitration decisions: %s", decisions)
@@ -1273,7 +1312,10 @@ async def collect_escrow(
         logger.info("[ALKAHEST] (Simulated) Escrow collected {result}")
     else:
         try:
-            result = await client.erc20.collect_escrow(escrow_uid, fulfillment_uid)
+            result = await client.erc20.escrow.non_tierable.collect(
+                escrow_uid,
+                fulfillment_uid,
+            )
             logger.info(f"[ALKAHEST]: Escrow collected: {result}")
         except Exception as error:
             logger.info(f"[ALKAHEST] Escrow collection error: {error}")

--- a/agents/a2a-agent-trader/app/utils/action_executor.py
+++ b/agents/a2a-agent-trader/app/utils/action_executor.py
@@ -1212,7 +1212,7 @@ async def fulfill_compute_obligation(
             )
             logger.info(f"[ALKAHEST] Arbitration requested: {request_arbitration_result}")
         except Exception as error:
-            logger.info(f"[ALKAHEST] Fulfillment error: {error}")
+            logger.error(f"[ALKAHEST] Fulfillment error: {error}")
     
     # Update registry with maker_attestation when maker fulfills
     if order and maker_attestation and CONFIG.enable_registry_discovery and order_id:

--- a/agents/a2a-agent-trader/app/utils/action_executor.py
+++ b/agents/a2a-agent-trader/app/utils/action_executor.py
@@ -1327,5 +1327,5 @@ async def collect_escrow(
             )
             logger.info(f"[ALKAHEST]: Escrow collected: {result}")
         except Exception as error:
-            logger.info(f"[ALKAHEST] Escrow collection error: {error}")
+            logger.error(f"[ALKAHEST] Escrow collection error: {error}")
     return result

--- a/agents/a2a-agent-trader/app/utils/test_env.py
+++ b/agents/a2a-agent-trader/app/utils/test_env.py
@@ -9,33 +9,67 @@ async def test_approval(client):
     )
     return hash
 
+async def test_escrow_creation(client, arbiter):
+    price = {"address": "0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0", "value": 100}
+    
+    arbiter = {
+        "arbiter": arbiter,
+        "demand": b""
+    }
+    
+    expiration = 0
+    hash = await client.erc20.escrow.non_tierable.permit_and_create(
+        price, arbiter, expiration
+    )
+    return hash
+
 def main() -> None:
     env = EnvTestManager()
     pp = pprint.PrettyPrinter()
+    run_tests = False
 
     mock_erc20 = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
     mock_erc20.transfer(env.alice, 90000000000)
     mock_erc20.transfer(env.bob, 90000000000)
 
+    port = int(env.rpc_url.split(":")[2].split("/")[0])
+    
     print("rpc_url:", env.rpc_url)
+    print(f"rpc_port: {port}")
+    print("For local development, deploy contracts with:")
+    print(f"  ANVIL_RPC_URL=https://localhost:{port} npm run deploy:anvil")
+
     print("alice:", env.alice)
     print("bob:", env.bob)
-    print("addresses:")
-    pp.pprint(env.addresses)
-    print("mock_addresses:")
-    pp.pprint(env.mock_addresses)
-    pp.pprint(f"Trusted Oracle Arbiter: {env.addresses.arbiters_addresses.trusted_oracle_arbiter}")
-    pp.pprint(f"Mock ERC20: {env.mock_addresses.erc20_a}")
 
-    pp.pprint("Testing...")
+    if run_tests:
+        print("addresses:")
+        pp.pprint(env.addresses)
+        print("mock_addresses:")
+        pp.pprint(env.mock_addresses)
+        pp.pprint(f"Trusted Oracle Arbiter: {env.addresses.arbiters_addresses.trusted_oracle_arbiter}")
+        pp.pprint(f"Mock ERC20: {env.mock_addresses.erc20_a}")
 
-    pp.pprint(f"bob_client: {asyncio.run(test_approval(env.bob_client))}")
+        pp.pprint("Testing...")
 
-    client = AlkahestClient(
-        private_key="0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d",
-        rpc_url=env.rpc_url,
-    )
-    pp.pprint(f"new_client: {asyncio.run(test_approval(client))}")
+        pp.pprint(f"bob_client:")
+        pp.pprint(f"  escrow approve: {asyncio.run(test_approval(env.bob_client))}")
+        pp.pprint(f"  escrow create: {asyncio.run(test_escrow_creation(
+            env.bob_client,
+            env.addresses.arbiters_addresses.trusted_oracle_arbiter
+            ))}")
+
+        client = AlkahestClient(
+            private_key="0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d",
+            rpc_url=env.rpc_url,
+            address_config=env.addresses,
+        )
+        pp.pprint(f"new_client:")
+        pp.pprint(f"  escrow approve: {asyncio.run(test_approval(client))}")
+        pp.pprint(f"  escrow create: {asyncio.run(test_escrow_creation(
+            client,
+            env.addresses.arbiters_addresses.trusted_oracle_arbiter
+            ))}")
 
     print("\nEnvTestManager running. Press Enter to shut down...")
     input()

--- a/agents/a2a-agent-trader/app/utils/test_env.py
+++ b/agents/a2a-agent-trader/app/utils/test_env.py
@@ -37,7 +37,7 @@ def main() -> None:
     print("rpc_url:", env.rpc_url)
     print(f"rpc_port: {port}")
     print("For local development, deploy contracts with:")
-    print(f"  ANVIL_RPC_URL=https://localhost:{port} npm run deploy:anvil")
+    print(f"  ANVIL_RPC_URL=http://localhost:{port} npm run deploy:anvil")
 
     print("alice:", env.alice)
     print("bob:", env.bob)

--- a/agents/a2a-agent-trader/app/utils/test_env.py
+++ b/agents/a2a-agent-trader/app/utils/test_env.py
@@ -3,7 +3,7 @@ import pprint
 import asyncio
 
 async def test_approval(client):
-    hash = await client.erc20.approve(
+    hash = await client.erc20.util.approve(
         {"address": "0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0", "value": 100},
         "escrow",
     )
@@ -34,7 +34,6 @@ def main() -> None:
     client = AlkahestClient(
         private_key="0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d",
         rpc_url=env.rpc_url,
-        address_config=env.addresses
     )
     pp.pprint(f"new_client: {asyncio.run(test_approval(client))}")
 

--- a/agents/a2a-agent-trader/app/utils/test_env.py
+++ b/agents/a2a-agent-trader/app/utils/test_env.py
@@ -2,31 +2,9 @@ from alkahest_py import EnvTestManager, MockERC20, AlkahestClient
 import pprint
 import asyncio
 
-async def test_approval(client):
-    hash = await client.erc20.util.approve(
-        {"address": "0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0", "value": 100},
-        "escrow",
-    )
-    return hash
-
-async def test_escrow_creation(client, arbiter):
-    price = {"address": "0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0", "value": 100}
-    
-    arbiter = {
-        "arbiter": arbiter,
-        "demand": b""
-    }
-    
-    expiration = 0
-    hash = await client.erc20.escrow.non_tierable.permit_and_create(
-        price, arbiter, expiration
-    )
-    return hash
-
 def main() -> None:
     env = EnvTestManager()
     pp = pprint.PrettyPrinter()
-    run_tests = False
 
     mock_erc20 = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
     mock_erc20.transfer(env.alice, 90000000000)
@@ -38,38 +16,6 @@ def main() -> None:
     print(f"rpc_port: {port}")
     print("For local development, deploy contracts with:")
     print(f"  ANVIL_RPC_URL=http://localhost:{port} npm run deploy:anvil")
-
-    print("alice:", env.alice)
-    print("bob:", env.bob)
-
-    if run_tests:
-        print("addresses:")
-        pp.pprint(env.addresses)
-        print("mock_addresses:")
-        pp.pprint(env.mock_addresses)
-        pp.pprint(f"Trusted Oracle Arbiter: {env.addresses.arbiters_addresses.trusted_oracle_arbiter}")
-        pp.pprint(f"Mock ERC20: {env.mock_addresses.erc20_a}")
-
-        pp.pprint("Testing...")
-
-        pp.pprint(f"bob_client:")
-        pp.pprint(f"  escrow approve: {asyncio.run(test_approval(env.bob_client))}")
-        pp.pprint(f"  escrow create: {asyncio.run(test_escrow_creation(
-            env.bob_client,
-            env.addresses.arbiters_addresses.trusted_oracle_arbiter
-            ))}")
-
-        client = AlkahestClient(
-            private_key="0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d",
-            rpc_url=env.rpc_url,
-            address_config=env.addresses,
-        )
-        pp.pprint(f"new_client:")
-        pp.pprint(f"  escrow approve: {asyncio.run(test_approval(client))}")
-        pp.pprint(f"  escrow create: {asyncio.run(test_escrow_creation(
-            client,
-            env.addresses.arbiters_addresses.trusted_oracle_arbiter
-            ))}")
 
     print("\nEnvTestManager running. Press Enter to shut down...")
     input()

--- a/agents/a2a-agent-trader/pyproject.toml
+++ b/agents/a2a-agent-trader/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "a2a-sdk>=0.3.9",
     "torch>=2.7.0",
     "pufferlib>=3.0.0",
-    "alkahest-py @ git+https://github.com/arkhai-io/alkahest-py@main",
+    "alkahest-py @ git+https://github.com/arkhai-io/alkahest@main#subdirectory=sdks/py",
     "web3>=7.14.0",
     "websockets>=15.0.1",
     "aiohttp>=3.12.15",

--- a/agents/a2a-agent-trader/tests/unit/test_alkahest.py
+++ b/agents/a2a-agent-trader/tests/unit/test_alkahest.py
@@ -5,7 +5,7 @@ from alkahest_py import (
     TrustedOracleArbiterDemandData,
     ArbitrationMode,
 )
-import pprint
+
 import uuid
 import asyncio
 
@@ -72,33 +72,28 @@ async def full_arbitration_flow(
 
     return escrow_collection_uid
 
-# def test_rust():
-#     env = EnvTestManager()
-
-#     mock_erc20 = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
-#     mock_erc20.transfer(env.alice, 90000000000)
-#     mock_erc20.transfer(env.bob, 90000000000)
-
-# def test_python():
-#     env = EnvTestManager()
-
-#     mock_erc20 = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
-#     mock_erc20.transfer(env.alice, 90000000000)
-#     mock_erc20.transfer(env.bob, 90000000000)
-
-def test_escrow_approval_and_creation():
+def test_rust():
     env = EnvTestManager()
 
     mock_erc20 = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
     mock_erc20.transfer(env.alice, 90000000000)
     mock_erc20.transfer(env.bob, 90000000000)
 
-    alice_rs_client = env.alice_client
-    bob_rs_client = env.bob_client
+    arbitration_flow = asyncio.run(full_arbitration_flow(
+        arbiter_address = env.addresses.arbiters_addresses.trusted_oracle_arbiter,
+        seller_client = env.alice_client,
+        buyer_client = env.bob_client,
+        oracle_address = env.bob
+    ))
 
-    rs_escrow_approve = asyncio.run(approve_escrow(alice_rs_client))
+    assert arbitration_flow is not None
 
-    assert rs_escrow_approve
+def test_python():
+    env = EnvTestManager()
+
+    mock_erc20 = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
+    mock_erc20.transfer(env.alice, 90000000000)
+    mock_erc20.transfer(env.bob, 90000000000)
 
     alice_py_client = AlkahestClient(
         private_key="0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d",

--- a/agents/a2a-agent-trader/tests/unit/test_alkahest.py
+++ b/agents/a2a-agent-trader/tests/unit/test_alkahest.py
@@ -1,0 +1,67 @@
+from alkahest_py import EnvTestManager, MockERC20, AlkahestClient
+import pprint
+import asyncio
+
+async def approve_escrow(client):
+    hash = await client.erc20.util.approve(
+        {"address": "0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0", "value": 100},
+        "escrow",
+    )
+    return hash
+
+async def create_escrow(client, arbiter):
+    price = {"address": "0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0", "value": 100}
+    
+    arbiter = {
+        "arbiter": arbiter,
+        "demand": b""
+    }
+    
+    expiration = 0
+    hash = await client.erc20.escrow.non_tierable.permit_and_create(
+        price, arbiter, expiration
+    )
+    return hash
+
+def test_escrow_approval_and_creation():
+    env = EnvTestManager()
+
+    mock_erc20 = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
+    mock_erc20.transfer(env.alice, 90000000000)
+    mock_erc20.transfer(env.bob, 90000000000)
+
+    alice_rs_client = env.alice_client
+    bob_rs_client = env.bob_client
+
+    rs_escrow_approve = asyncio.run(approve_escrow(alice_rs_client))
+    rs_escrow_create = asyncio.run(create_escrow(
+        alice_rs_client,
+        env.addresses.arbiters_addresses.trusted_oracle_arbiter
+        ))
+    
+    assert rs_escrow_approve
+    assert rs_escrow_create
+
+    alice_py_client = AlkahestClient(
+        private_key="0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d",
+        rpc_url=env.rpc_url,
+        address_config=env.addresses,
+    )
+
+    bob_py_client = AlkahestClient(
+        private_key="0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a",
+        rpc_url=env.rpc_url,
+        address_config=env.addresses,
+    )
+
+    assert alice_py_client
+    assert bob_py_client
+
+    py_escrow_approve = asyncio.run(approve_escrow(alice_py_client))
+    py_escrow_create = asyncio.run(create_escrow(
+        alice_py_client,
+        env.addresses.arbiters_addresses.trusted_oracle_arbiter
+        ))
+
+    assert py_escrow_approve
+    assert py_escrow_create

--- a/agents/a2a-agent-trader/tests/unit/test_alkahest.py
+++ b/agents/a2a-agent-trader/tests/unit/test_alkahest.py
@@ -1,27 +1,90 @@
-from alkahest_py import EnvTestManager, MockERC20, AlkahestClient
+from alkahest_py import (
+    EnvTestManager,
+    MockERC20,
+    AlkahestClient,
+    TrustedOracleArbiterDemandData,
+    ArbitrationMode,
+)
 import pprint
+import uuid
 import asyncio
+
+MOCK_TOKEN_ADDR = "0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0"
 
 async def approve_escrow(client):
     hash = await client.erc20.util.approve(
-        {"address": "0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0", "value": 100},
+        {"address": MOCK_TOKEN_ADDR, "value": 100},
         "escrow",
     )
     return hash
 
-async def create_escrow(client, arbiter):
-    price = {"address": "0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0", "value": 100}
-    
-    arbiter = {
-        "arbiter": arbiter,
-        "demand": b""
-    }
-    
-    expiration = 0
+async def create_escrow(client, arbiter, demand=b"", expiration=0):
+    price = {"address": MOCK_TOKEN_ADDR, "value": 100}
     hash = await client.erc20.escrow.non_tierable.permit_and_create(
         price, arbiter, expiration
     )
     return hash
+
+async def full_arbitration_flow(
+        arbiter_address,
+        seller_client,
+        buyer_client,
+        oracle_address,
+    ):
+    await approve_escrow(buyer_client)
+
+    secret_code = f"{uuid.uuid4()}"
+
+    inner_demand_data = f"test arbitration data {secret_code}".encode("utf-8")
+
+    demand_data = TrustedOracleArbiterDemandData(oracle_address, inner_demand_data)
+    arbiter = {
+        "arbiter": arbiter_address,
+        "demand": demand_data.encode_self(),
+    }
+    expiration = 0
+
+    escrow_receipt = await create_escrow(
+        buyer_client,
+        arbiter=arbiter,
+        expiration=expiration
+    )
+    escrow_uid = escrow_receipt['log']['uid']
+    assert escrow_uid is not None
+
+    fulfillment_uid = await seller_client.string_obligation.do_obligation(secret_code, escrow_uid)
+    
+    await seller_client.oracle.request_arbitration(fulfillment_uid, oracle_address, inner_demand_data)
+
+    def decision_function(attestation, demand):
+        # print("Arbitration requested with attestation:", attestation)
+        # print("Demand data:", demand)
+        return True
+
+    decisions = await buyer_client.oracle.arbitrate_many(decision_function, None, ArbitrationMode.PastUnarbitrated)
+
+    assert len(decisions) > 0
+    
+    escrow_collection_uid = await seller_client.erc20.escrow.non_tierable.collect(escrow_uid, fulfillment_uid)
+
+    assert escrow_uid is not None
+    assert escrow_collection_uid is not None
+
+    return escrow_collection_uid
+
+# def test_rust():
+#     env = EnvTestManager()
+
+#     mock_erc20 = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
+#     mock_erc20.transfer(env.alice, 90000000000)
+#     mock_erc20.transfer(env.bob, 90000000000)
+
+# def test_python():
+#     env = EnvTestManager()
+
+#     mock_erc20 = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
+#     mock_erc20.transfer(env.alice, 90000000000)
+#     mock_erc20.transfer(env.bob, 90000000000)
 
 def test_escrow_approval_and_creation():
     env = EnvTestManager()
@@ -34,13 +97,8 @@ def test_escrow_approval_and_creation():
     bob_rs_client = env.bob_client
 
     rs_escrow_approve = asyncio.run(approve_escrow(alice_rs_client))
-    rs_escrow_create = asyncio.run(create_escrow(
-        alice_rs_client,
-        env.addresses.arbiters_addresses.trusted_oracle_arbiter
-        ))
-    
+
     assert rs_escrow_approve
-    assert rs_escrow_create
 
     alice_py_client = AlkahestClient(
         private_key="0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d",
@@ -57,11 +115,11 @@ def test_escrow_approval_and_creation():
     assert alice_py_client
     assert bob_py_client
 
-    py_escrow_approve = asyncio.run(approve_escrow(alice_py_client))
-    py_escrow_create = asyncio.run(create_escrow(
-        alice_py_client,
-        env.addresses.arbiters_addresses.trusted_oracle_arbiter
-        ))
+    arbitration_flow = asyncio.run(full_arbitration_flow(
+        arbiter_address = env.addresses.arbiters_addresses.trusted_oracle_arbiter,
+        seller_client = alice_py_client,
+        buyer_client = bob_py_client,
+        oracle_address = env.bob
+    ))
 
-    assert py_escrow_approve
-    assert py_escrow_create
+    assert arbitration_flow is not None

--- a/agents/a2a-agent-trader/uv.lock
+++ b/agents/a2a-agent-trader/uv.lock
@@ -61,7 +61,7 @@ dev = [
 requires-dist = [
     { name = "a2a-sdk", specifier = ">=0.3.9" },
     { name = "aiohttp", specifier = ">=3.12.15" },
-    { name = "alkahest-py", git = "https://github.com/arkhai-io/alkahest-py?rev=main" },
+    { name = "alkahest-py", git = "https://github.com/arkhai-io/alkahest?subdirectory=sdks%2Fpy&rev=main" },
     { name = "codespell", marker = "extra == 'lint'", specifier = ">=2.2.0,<3.0.0" },
     { name = "fastapi", specifier = "~=0.115.8" },
     { name = "google-adk", extras = ["a2a"], git = "https://github.com/google/adk-python?rev=5eca72f9bfd05c7c28a3d738391138a59a31167d" },
@@ -240,7 +240,7 @@ wheels = [
 [[package]]
 name = "alkahest-py"
 version = "0.1.0"
-source = { git = "https://github.com/arkhai-io/alkahest-py?rev=main#36161fe83456fc53f02e8cf92e9a597abe33b562" }
+source = { git = "https://github.com/arkhai-io/alkahest?subdirectory=sdks%2Fpy&rev=main#96cc1662a7347dab6339d1d78169d1d647d44749" }
 
 [[package]]
 name = "annotated-types"

--- a/agents/a2a-agent-trader/uv.lock
+++ b/agents/a2a-agent-trader/uv.lock
@@ -61,7 +61,7 @@ dev = [
 requires-dist = [
     { name = "a2a-sdk", specifier = ">=0.3.9" },
     { name = "aiohttp", specifier = ">=3.12.15" },
-    { name = "alkahest-py", git = "https://github.com/arkhai-io/alkahest?subdirectory=sdks%2Fpy&rev=main" },
+    { name = "alkahest-py", git = "https://github.com/wwald/alkahest?subdirectory=sdks%2Fpy&rev=fix%2Fadd-py-native-token-addresses" },
     { name = "codespell", marker = "extra == 'lint'", specifier = ">=2.2.0,<3.0.0" },
     { name = "fastapi", specifier = "~=0.115.8" },
     { name = "google-adk", extras = ["a2a"], git = "https://github.com/google/adk-python?rev=5eca72f9bfd05c7c28a3d738391138a59a31167d" },
@@ -240,7 +240,7 @@ wheels = [
 [[package]]
 name = "alkahest-py"
 version = "0.1.0"
-source = { git = "https://github.com/arkhai-io/alkahest?subdirectory=sdks%2Fpy&rev=main#96cc1662a7347dab6339d1d78169d1d647d44749" }
+source = { git = "https://github.com/wwald/alkahest?subdirectory=sdks%2Fpy&rev=fix%2Fadd-py-native-token-addresses#bc6d0f164c49cbeec2405e312c5d1a9a75005c81" }
 
 [[package]]
 name = "annotated-types"

--- a/agents/a2a-agent-trader/uv.lock
+++ b/agents/a2a-agent-trader/uv.lock
@@ -61,7 +61,7 @@ dev = [
 requires-dist = [
     { name = "a2a-sdk", specifier = ">=0.3.9" },
     { name = "aiohttp", specifier = ">=3.12.15" },
-    { name = "alkahest-py", git = "https://github.com/wwald/alkahest?subdirectory=sdks%2Fpy&rev=fix%2Fadd-py-native-token-addresses" },
+    { name = "alkahest-py", git = "https://github.com/arkhai-io/alkahest?subdirectory=sdks%2Fpy&rev=main" },
     { name = "codespell", marker = "extra == 'lint'", specifier = ">=2.2.0,<3.0.0" },
     { name = "fastapi", specifier = "~=0.115.8" },
     { name = "google-adk", extras = ["a2a"], git = "https://github.com/google/adk-python?rev=5eca72f9bfd05c7c28a3d738391138a59a31167d" },
@@ -240,7 +240,7 @@ wheels = [
 [[package]]
 name = "alkahest-py"
 version = "0.1.0"
-source = { git = "https://github.com/wwald/alkahest?subdirectory=sdks%2Fpy&rev=fix%2Fadd-py-native-token-addresses#bc6d0f164c49cbeec2405e312c5d1a9a75005c81" }
+source = { git = "https://github.com/arkhai-io/alkahest?subdirectory=sdks%2Fpy&rev=main#75ff1c631957e315b145f4544e5b44cbcc751b91" }
 
 [[package]]
 name = "annotated-types"


### PR DESCRIPTION
# Changes Made
- Dependency: alkahest-py changed from `https://github.com/arkhai-io/alkahest-py@main` to the combined repository at `https://github.com/arkhai-io/alkahest@main#subdirectory=sdks/py`
- Refactor: `ArbitrationOptions` to `ArbitrationMode`
- Refactor: demand bytes are now also sent in `fulfill_compute_obligation` to reflect updated flow in Alkahest SDK
- Refactor: new `extract_compute_and_token_from_order_dict` as its own function, reusable across both `accept_offer` (buyer, when creating escrow) and `fulfill_compute_obligation` (seller, when requesting arbitration)
- Refactor: Alkahest flow functions are now mostly under `client.erc20.util.*` or `client.erc20.escrow.non_tierable.*`
- Env Setup: `make test-env` now outputs commands for easy setup of environment variables in the other components
- Refactor: took the testing logic out of `make test-env`; created `tests/unit/test_alkahest` that steps through full flow in both Alkahest Rust and Python clients to establish baseline that Alkahest (outside of Arkhai) is functioning as expected

# Testing

```
# Alice as Maker + Buyer
curl -X POST http://10.10.10.185:8000/alerts/resource \
  -H "Content-Type: application/json" \
  -d '{"event_type": "resource_imbalance", "resource": {"gpu_model": "H200", "quantity": 1, "sla": 90.0, "region": "California, US"}, "value": 0.95, "label": "HIGH DEMAND", "threshold": ">=0.70"}'

# Bob as Taker + Seller
curl -X POST http://10.10.10.185:8001/alerts/resource \
  -H "Content-Type: application/json" \
  -d '{"event_type": "resource_imbalance", "resource": {"gpu_model": "H200", "quantity": 1, "sla": 90.0, "region": "California, US"}, "value": 0.05, "label": "LOW UTILIZATION", "threshold": "<=0.30"}'
```