### PR TITLE
Feature: SSH Lease Lifecycle

### DIFF
--- a/agents/a2a-agent-trader/app/environment/seller/test_torchscript.py
+++ b/agents/a2a-agent-trader/app/environment/seller/test_torchscript.py
@@ -26,7 +26,7 @@ OBSERVATION_FEATURES = [
     "[9] request.nodes[0] / max_nodes",
     "[10] request.nodes[1] / max_nodes",
     "[11] request.space_tb / max_space_tb",
-    "[12] request.duration / max_job_duration",
+    "[12] request.duration_hours / max_job_duration",
     "[13] prev_reward",
 ]
 
@@ -152,4 +152,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/agents/a2a-agent-trader/app/policies/torch_market_seller.py
+++ b/agents/a2a-agent-trader/app/policies/torch_market_seller.py
@@ -92,7 +92,7 @@ def _build_market_observation(
     [9] request.nodes[0] / max_nodes
     [10] request.nodes[1] / max_nodes
     [11] request.space_tb / max_space_tb
-    [12] request.duration / max_job_duration
+    [12] request.duration_hours / max_job_duration
     [13] prev_reward
     
     Args:
@@ -288,7 +288,7 @@ def mo_action_torch_market_seller(context: DecisionContext) -> DomainAction | No
       * Energy sale proceeds are added to reward
     
     The Market environment models a seller-side controller for:
-    - Cloud compute marketplace (nodes per type, storage TB, duration)
+    - Cloud compute marketplace (nodes per type, storage TB, duration_hours)
     - Energy marketplace (buy/sell energy based on time-varying prices)
     
     Args:
@@ -338,7 +338,7 @@ def mo_action_torch_market_seller(context: DecisionContext) -> DomainAction | No
     # [0-3]: Node capacity (total/free for types 0 and 1)
     # [4-5]: Storage capacity (total/free)
     # [6-8]: Energy state (charge, gen, storage)
-    # [9-12]: Request details (nodes, storage, duration)
+    # [9-12]: Request details (nodes, storage, duration_hours)
     # [13]: Previous reward
     observation = _build_market_observation(context, offer_resource, demand_resource)
     if observation is None:
@@ -446,4 +446,3 @@ def mo_action_torch_market_seller(context: DecisionContext) -> DomainAction | No
     )
     
     return DomainAction(action_type=action_type, parameters=parameters)
-

--- a/agents/a2a-agent-trader/app/schema/pydantic_models.py
+++ b/agents/a2a-agent-trader/app/schema/pydantic_models.py
@@ -198,7 +198,7 @@ class MarketOrder(BaseModel):
     demand_resource: Union[ComputeResource, TokenResource] = Field(
         description="The resource being demanded, which may be a token or compute resource."
     )
-    duration: int = Field(description="The duration of the order in days")
+    duration: int = Field(description="The duration of the order in hours")
     maker_attestation: str | None = Field(
         default=None,
         description="The attestation for the offer in escrow (None for open orders)",

--- a/agents/a2a-agent-trader/app/schema/pydantic_models.py
+++ b/agents/a2a-agent-trader/app/schema/pydantic_models.py
@@ -198,7 +198,7 @@ class MarketOrder(BaseModel):
     demand_resource: Union[ComputeResource, TokenResource] = Field(
         description="The resource being demanded, which may be a token or compute resource."
     )
-    duration: int = Field(description="The duration of the order in hours")
+    duration_hours: int = Field(description="The duration of the order in hours")
     maker_attestation: str | None = Field(
         default=None,
         description="The attestation for the offer in escrow (None for open orders)",
@@ -287,7 +287,7 @@ class MakeOfferEvent(DomainEvent):
                 "order_id": order.order_id,
                 "offer_resource": order.offer_resource.model_dump(mode="json"),
                 "demand_resource": order.demand_resource.model_dump(mode="json"),
-                "duration": order.duration,
+                "duration_hours": order.duration_hours,
             },
         )
 
@@ -324,7 +324,7 @@ class AcceptOfferEvent(DomainEvent):
                 "order_id": order.order_id,
                 "offer_resource": order.offer_resource.model_dump(mode="json"),
                 "demand_resource": order.demand_resource.model_dump(mode="json"),
-                "duration": order.duration,
+                "duration_hours": order.duration_hours,
                 "escrow_uid": escrow_uid,
                 "ssh_public_key": ssh_public_key,
             },

--- a/agents/a2a-agent-trader/app/utils/action_executor.py
+++ b/agents/a2a-agent-trader/app/utils/action_executor.py
@@ -469,10 +469,10 @@ async def provision_machine(ssh_public_key: str) -> str:
             logger.info(f"[TOOL] Machine provisioned: {connection_info}")
             return connection_info
         logger.warning("[TOOL] Provisioning completed but connection info was not available.")
-        return "Provisioning completed, but SSH connection info unavailable."
+        raise RuntimeError("Provisioning completed, but SSH connection info unavailable.")
     except Exception as exc:
         logger.error("[TOOL] Provisioning failed: %s", exc)
-        return f"Provisioning failed: {exc}"
+        raise RuntimeError(f"Provisioning failed: {exc}") from exc
 
 def extract_compute_and_token_from_order_dict(order: dict) -> tuple[dict, dict]:
     """Given an order, take the demand and offer and extract which is compute and which is tokens."""
@@ -1389,7 +1389,17 @@ async def fulfill_compute_obligation(
     """
     oracle_address = _resolve_oracle_address(oracle_address)
     # connection_details = await mock_provision_machine(ssh_public_key)
-    connection_details = await provision_machine(ssh_public_key)
+    try:
+        connection_details = await provision_machine(ssh_public_key)
+    except Exception as error:
+        logger.error("[ALKAHEST] Provisioning failed, skipping obligation fulfillment: %s", error)
+        return {
+            "status": "error",
+            "message": f"Provisioning failed: {error}",
+            "escrow_uid": escrow_uid,
+            "connection_details": None,
+            "ssh_public_key": ssh_public_key,
+        }
     fulfillment_uid = None
     maker_attestation = None
     duration_hours = 1

--- a/agents/a2a-agent-trader/app/utils/action_executor.py
+++ b/agents/a2a-agent-trader/app/utils/action_executor.py
@@ -1212,14 +1212,14 @@ async def make_offer(ctx: InvocationContext, order: MarketOrder | dict, alkahest
 def encode_compute_lease(
     compute_resource: ComputeResource | dict[str, Any],
     token_resource: TokenResource | dict[str, Any],
-    duration_days: int = 1,
+    duration_hours: int = 1,
 ) -> bytes:
     """Encode a compute-for-token trade as JSON bytes for use as Alkahest demand payload.
 
     Args:
         compute_resource: ComputeResource (or dict payload) describing the offered compute.
-        token_resource: TokenResource (or dict) describing the payment token and amount (base units).
-        duration_days: Lease duration in days (defaults to 1, must be >=1).
+        token_resource: TokenResource (or dict) describing the payment token and amount (base units) for the hourly rate.
+        duration_hours: Lease duration in hours (defaults to 1, must be >=1).
     """
     compute = compute_resource
     if isinstance(compute_resource, dict):
@@ -1227,29 +1227,34 @@ def encode_compute_lease(
     if not isinstance(compute, ComputeResource):
         raise ValueError("encode_compute_lease expects a ComputeResource")
 
-    payment = token_resource
+    hourly_rate = token_resource
     if isinstance(token_resource, dict):
         payment = TokenResource.model_validate(token_resource)
-    if not isinstance(payment, TokenResource):
+    if not isinstance(hourly_rate, TokenResource):
         raise ValueError("encode_compute_lease expects a TokenResource")
 
-    if duration_days < 1:
-        raise ValueError("duration_days must be >= 1")
+    if duration_hours < 1:
+        raise ValueError("duration_hours must be >= 1")
 
-    token_meta = payment.token
-    human_total_price = Decimal(payment.amount) / Decimal(10**token_meta.decimals)
-    human_price_per_day = human_total_price / Decimal(duration_days)
+    token_meta = hourly_rate.token
+    total_price = hourly_rate.amount * duration_hours
+    total_payment_resource = TokenResource(token=token_meta, amount=total_price)
+    
+    # Human-readable prices
+    human_total_payment = Decimal(payment.amount) / Decimal(10**token_meta.decimals)
+    human_price_per_hour = Decimal(hourly_rate.amount) / (10**token_meta.decimals)
 
     lease_terms = {
         "gpu_model": compute.gpu_model.value if hasattr(compute.gpu_model, "value") else str(compute.gpu_model),
         "region": compute.region.value if hasattr(compute.region, "value") else str(compute.region),
         "quantity": compute.quantity,
         "sla": compute.sla,
-        "duration_days": duration_days,
+        "duration_hours": duration_hours,
         "token_symbol": token_meta.symbol,
         "token_address": token_meta.contract_address,
-        "price_per_day": float(human_price_per_day),
-        "total_price": float(human_total_price),
+        "price_per_hour_decimal": float(human_price_per_hour),
+        "total_price_decimal": float(human_total_payment),
+        "total_price_int": total_payment_resource.amount,
     }
 
     logger.info("[ALKAHEST] Encoding compute lease terms: %s", lease_terms)
@@ -1319,7 +1324,7 @@ async def buy_compute_with_erc20(
         encode_compute_lease(
             compute_resource=compute_resource,
             token_resource=token_resource,
-            duration_days=1,
+            duration_hours=1,
         )
     )
 
@@ -1376,10 +1381,9 @@ async def fulfill_compute_obligation(
     oracle_address = _resolve_oracle_address(oracle_address)
     # connection_details = await mock_provision_machine(ssh_public_key)
     connection_details = await provision_machine(ssh_public_key)
-    lease_end_utc = (datetime.now(timezone.utc) + timedelta(days=duration_days)).strftime("%Y-%m-%d %H:%M")
-    schedule_vm_shutdown(lease_end_utc)
     fulfillment_uid = None
     maker_attestation = None
+    duration_hours = 1
 
     logger.info(f"[ALKAHEST] Order for fulfillment: {order}")
     order_dict = None
@@ -1395,15 +1399,18 @@ async def fulfill_compute_obligation(
             order_bytes = order.encode("utf-8")
         elif isinstance(order, dict):
             order_dict = order
-            duration_days = order_dict.get("duration", 1)
+            duration_hours = order_dict.get("duration", 1)
             compute_resource, token_resource = extract_compute_and_token_from_order_dict(order_dict)
             order_bytes = encode_compute_lease(
                 compute_resource=compute_resource,
                 token_resource=token_resource,
-                duration_days=duration_days,
+                duration_hours=duration_hours,
             )
         if order_dict:
             order_id = order_dict.get("order_id")
+
+    lease_end_utc = (datetime.now(timezone.utc) + timedelta(hours=duration_hours)).strftime("%Y-%m-%d %H:%M")
+    schedule_vm_shutdown(lease_end_utc)
 
     if not client or not oracle_address:
         # Demo fallback: skip on-chain, return simulated fulfillment uid

--- a/agents/a2a-agent-trader/app/utils/action_executor.py
+++ b/agents/a2a-agent-trader/app/utils/action_executor.py
@@ -1331,16 +1331,21 @@ async def buy_compute_with_erc20(
 
     demand_bytes = demand_data.encode_self()
 
-    # 2) Build price data from token resource
+    # 2) Build price data from token resource, computing duration * rate
     if isinstance(token_resource, TokenResource):
-        payment = token_resource
+        hourly_rate = token_resource
     else:
-        payment = TokenResource.model_validate(token_resource)
+        hourly_rate = TokenResource.model_validate(token_resource)
 
-    price_data = {"address": payment.token.contract_address, "value": payment.amount}
+    total_payment = TokenResource(
+        token=hourly_rate.token,
+        amount=hourly_rate.amount * duration_hours,
+    )
+
+    price_data = {"address": total_payment.token.contract_address, "value": total_payment.amount}
 
     # 3) Approve escrow spend
-    await approve_token_escrow(payment, alkahest_client=client)
+    await approve_token_escrow(total_payment, alkahest_client=client)
 
     # 4) Buy with ERC20, tying demand to arbiter data
     arbiter_data = {"arbiter": arbiter_address, "demand": demand_bytes}

--- a/agents/a2a-agent-trader/app/utils/action_executor.py
+++ b/agents/a2a-agent-trader/app/utils/action_executor.py
@@ -676,6 +676,7 @@ async def accept_offer(
                 escrow_receipt = await buy_compute_with_erc20(
                     compute_resource=compute_resource,
                     token_resource=token_resource,
+                    duration_hours=order_dict.get("duration_hours", 1),
                     oracle_address=DEMO_ORACLE_ADDRESS,
                     client=alkahest_client,
                 )
@@ -1212,7 +1213,7 @@ async def make_offer(ctx: InvocationContext, order: MarketOrder | dict, alkahest
 def encode_compute_lease(
     compute_resource: ComputeResource | dict[str, Any],
     token_resource: TokenResource | dict[str, Any],
-    duration_hours: int = 1,
+    duration_hours: int,
 ) -> bytes:
     """Encode a compute-for-token trade as JSON bytes for use as Alkahest demand payload.
 
@@ -1298,7 +1299,7 @@ async def approve_token_escrow(
 async def buy_compute_with_erc20(
     compute_resource: ComputeResource | dict[str, Any],
     token_resource: TokenResource | dict[str, Any],
-    *,
+    duration_hours: int,
     oracle_address: str,
     client: AlkahestClient,
 ) -> Any:
@@ -1324,7 +1325,7 @@ async def buy_compute_with_erc20(
         encode_compute_lease(
             compute_resource=compute_resource,
             token_resource=token_resource,
-            duration_hours=1,
+            duration_hours=duration_hours,
         )
     )
 
@@ -1399,15 +1400,16 @@ async def fulfill_compute_obligation(
             order_bytes = order.encode("utf-8")
         elif isinstance(order, dict):
             order_dict = order
-            duration_hours = order_dict.get("duration_hours", 1)
-            compute_resource, token_resource = extract_compute_and_token_from_order_dict(order_dict)
-            order_bytes = encode_compute_lease(
-                compute_resource=compute_resource,
-                token_resource=token_resource,
-                duration_hours=duration_hours,
-            )
-        if order_dict:
-            order_id = order_dict.get("order_id")
+
+    if order_dict:
+        order_id = order_dict.get("order_id")
+        duration_hours = order_dict.get("duration_hours", 1)
+        compute_resource, token_resource = extract_compute_and_token_from_order_dict(order_dict)
+        order_bytes = encode_compute_lease(
+            compute_resource=compute_resource,
+            token_resource=token_resource,
+            duration_hours=duration_hours,
+        )
 
     lease_end_utc = (datetime.now(timezone.utc) + timedelta(hours=duration_hours)).strftime("%Y-%m-%d %H:%M")
     schedule_vm_shutdown(lease_end_utc)

--- a/agents/a2a-agent-trader/app/utils/action_executor.py
+++ b/agents/a2a-agent-trader/app/utils/action_executor.py
@@ -146,7 +146,8 @@ async def execute_action(
                 gpu_model_str=parameters.get("gpu_model"),
                 sla=parameters.get("sla"),
                 region_str=parameters.get("region"),
-                imbalance_type=imbalance_type
+                imbalance_type=imbalance_type,
+                duration_hours=parameters.get("duration_hours", 1),
             )
             outcome["result"] = {"order_id": f"sim_{action.timestamp.isoformat()}"}
             outcome["message"] = f"Order created for {gpu_model}"
@@ -807,6 +808,7 @@ def create_order(
     publish_to_registry: bool = True,
     offer_resource: ComputeResource | TokenResource = None,
     demand_resource: ComputeResource | TokenResource = None,
+    duration_hours: int = 1,
 ) -> dict | None:
     """Create an order in the market.
 
@@ -823,6 +825,7 @@ def create_order(
         publish_to_registry: Whether to publish order to registry (default: True)
         offer_resource: Pre-constructed offer resource (optional, overrides gpu_model_str/sla/region_str)
         demand_resource: Pre-constructed demand resource (optional)
+        duration_hours: Duration of the order in hours (default: 1); 1 if seller (rate), else total if buyer
 
     Returns:
         The created order as a dictionary if the order was successfully created, or None otherwise.
@@ -873,11 +876,11 @@ def create_order(
         order_taker=None,
         offer_resource=offer_resource,
         demand_resource=demand_resource,
-        duration_hours=1,
+        duration_hours=duration_hours,
         maker_attestation=None,
         taker_attestation=None
     )
-    
+
     order_dict = order.model_dump(mode='json')
     
     # Note: Order publishing to registry happens in make_offer() to ensure

--- a/agents/a2a-agent-trader/app/utils/action_executor.py
+++ b/agents/a2a-agent-trader/app/utils/action_executor.py
@@ -1233,7 +1233,7 @@ def encode_compute_lease(
 
     hourly_rate = token_resource
     if isinstance(token_resource, dict):
-        payment = TokenResource.model_validate(token_resource)
+        hourly_rate = TokenResource.model_validate(token_resource)
     if not isinstance(hourly_rate, TokenResource):
         raise ValueError("encode_compute_lease expects a TokenResource")
 
@@ -1245,7 +1245,7 @@ def encode_compute_lease(
     total_payment_resource = TokenResource(token=token_meta, amount=total_price)
     
     # Human-readable prices
-    human_total_payment = Decimal(payment.amount) / Decimal(10**token_meta.decimals)
+    human_total_payment = Decimal(total_payment_resource.amount) / Decimal(10**token_meta.decimals)
     human_price_per_hour = Decimal(hourly_rate.amount) / (10**token_meta.decimals)
 
     lease_terms = {

--- a/agents/a2a-agent-trader/app/utils/action_executor.py
+++ b/agents/a2a-agent-trader/app/utils/action_executor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import uuid
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 import logging
 from typing import Any
@@ -38,7 +39,7 @@ from app.schema.pydantic_models import (
 from .config import CONFIG
 from .token_registry import TOKEN_REGISTRY
 from .registry_client import get_registry_client
-from .provisioning import run_vm_provisioning_playbook
+from .provisioning import run_vm_provisioning_playbook, schedule_vm_shutdown
 from ..policies.negotiation_thread import get_thread_store, NegotiationThreadTransaction
 from ..policies.action_builders import CounterOfferParams
 from .validation import determine_strategy_from_order
@@ -1375,6 +1376,8 @@ async def fulfill_compute_obligation(
     oracle_address = _resolve_oracle_address(oracle_address)
     # connection_details = await mock_provision_machine(ssh_public_key)
     connection_details = await provision_machine(ssh_public_key)
+    lease_end_utc = (datetime.now(timezone.utc) + timedelta(days=duration_days)).strftime("%Y-%m-%d %H:%M")
+    schedule_vm_shutdown(lease_end_utc)
     fulfillment_uid = None
     maker_attestation = None
 
@@ -1392,11 +1395,12 @@ async def fulfill_compute_obligation(
             order_bytes = order.encode("utf-8")
         elif isinstance(order, dict):
             order_dict = order
+            duration_days = order_dict.get("duration", 1)
             compute_resource, token_resource = extract_compute_and_token_from_order_dict(order_dict)
             order_bytes = encode_compute_lease(
                 compute_resource=compute_resource,
                 token_resource=token_resource,
-                duration_days=1,
+                duration_days=duration_days,
             )
         if order_dict:
             order_id = order_dict.get("order_id")

--- a/agents/a2a-agent-trader/app/utils/action_executor.py
+++ b/agents/a2a-agent-trader/app/utils/action_executor.py
@@ -195,29 +195,35 @@ async def execute_action(
                 ssh_public_key=ssh_public_key,
                 order=order,
             )
-            # Include event_type for downstream parsing and propagate to remote agent.
-            result["event_type"] = EventType.RECEIVE_COMPUTE_OBLIGATION_FULFILLMENT.value
-            if ctx:
-                try:
-                    event = Event(
-                        author=AGENT_ID,
-                        content=genai_types.Content(
-                            role="model",
-                            parts=[
-                                genai_types.Part.from_function_response(
-                                    name=EventType.RECEIVE_COMPUTE_OBLIGATION_FULFILLMENT.value,
-                                    response=result,
-                                )
-                            ],
-                        ),
-                        invocation_id=ctx.invocation_id,
-                        branch=ctx.branch,
-                    )
-                    await send_to_remote_agent(ctx, event)
-                except Exception as send_err:
-                    logger.warning("[ACTION] Failed to send fulfillment to remote agent: %s", send_err)
+            if result.get("status") == "fulfilled":
+                # Include event_type for downstream parsing and propagate to remote agent.
+                result["event_type"] = EventType.RECEIVE_COMPUTE_OBLIGATION_FULFILLMENT.value
+                if ctx:
+                    try:
+                        event = Event(
+                            author=AGENT_ID,
+                            content=genai_types.Content(
+                                role="model",
+                                parts=[
+                                    genai_types.Part.from_function_response(
+                                        name=EventType.RECEIVE_COMPUTE_OBLIGATION_FULFILLMENT.value,
+                                        response=result,
+                                    )
+                                ],
+                            ),
+                            invocation_id=ctx.invocation_id,
+                            branch=ctx.branch,
+                        )
+                        await send_to_remote_agent(ctx, event)
+                    except Exception as send_err:
+                        logger.warning("[ACTION] Failed to send fulfillment to remote agent: %s", send_err)
+            else:
+                logger.warning(
+                    "[ACTION] Skipping fulfillment event; status=%s",
+                    result.get("status"),
+                )
             outcome["result"] = result
-            outcome["message"] = result.get("message", "Compute obligation fulfilled")
+            outcome["message"] = result.get("message")
 
         case ActionType.TRUST_COMPUTE_OBLIGATION_FULFILLMENT.value:
             logger.info(f"[ACTION] Trusting compute fulfillment with params: {parameters}")

--- a/agents/a2a-agent-trader/app/utils/action_executor.py
+++ b/agents/a2a-agent-trader/app/utils/action_executor.py
@@ -872,7 +872,7 @@ def create_order(
         order_taker=None,
         offer_resource=offer_resource,
         demand_resource=demand_resource,
-        duration=1,
+        duration_hours=1,
         maker_attestation=None,
         taker_attestation=None
     )
@@ -1399,7 +1399,7 @@ async def fulfill_compute_obligation(
             order_bytes = order.encode("utf-8")
         elif isinstance(order, dict):
             order_dict = order
-            duration_hours = order_dict.get("duration", 1)
+            duration_hours = order_dict.get("duration_hours", 1)
             compute_resource, token_resource = extract_compute_and_token_from_order_dict(order_dict)
             order_bytes = encode_compute_lease(
                 compute_resource=compute_resource,

--- a/agents/a2a-agent-trader/app/utils/provisioning.py
+++ b/agents/a2a-agent-trader/app/utils/provisioning.py
@@ -75,9 +75,14 @@ def _lookup_vm_host_ip(vm_host: str) -> Optional[str]:
     return None
 
 
-def run_vm_provisioning_playbook(ssh_pubkey: str, vm_host: str = "vm1") -> Optional[str]:
+def run_vm_provisioning_playbook(ssh_pubkey: str, vm_host: str = "vm1", vm_target: str = "tenant-vm") -> Optional[str]:
     """
     Run the Ansible playbook that provisions a VM using the shared inventory and vars file.
+
+    Args:
+        ssh_pubkey: The SSH public key to inject into the VM.
+        vm_host: The host where the VM is located.
+        vm_target: The name of the VM to schedule for shutdown.
 
     Returns:
         SSH command string if all connection details were found, otherwise None.
@@ -91,7 +96,7 @@ def run_vm_provisioning_playbook(ssh_pubkey: str, vm_host: str = "vm1") -> Optio
 
     vm_vars_payload = (
         f"vm_host: {vm_host}\n"
-        "vm_target: tenant-vm\n"
+        f"vm_target: {vm_target}\n"
         "vm_action: create\n"
         "vm_ram: 2048\n"
         "vm_vcpus: 2\n"
@@ -114,8 +119,7 @@ def run_vm_provisioning_playbook(ssh_pubkey: str, vm_host: str = "vm1") -> Optio
         f"@{vm_vars_path}",
         "--extra-vars",
         f"@{management_vars_path}",
-        "--limit",
-        vm_host,
+        "--limit kvm_hosts",
     ]
     cwd = project_root
 
@@ -164,3 +168,55 @@ def run_vm_provisioning_playbook(ssh_pubkey: str, vm_host: str = "vm1") -> Optio
         logger.info("SSH command: %s", ssh_command)
 
     return ssh_command
+
+def schedule_vm_shutdown(lease_end_utc: str, vm_host: str = "vm1", vm_target: str = "tenant-vm") -> None:
+    """
+    Schedule a VM shutdown by setting its lease end time.
+
+    Args:
+        lease_end_utc: The UTC time string for when the VM should be shut down (format: 'YYYY-MM-DD HH:MM').
+        vm_host: The host where the VM is located.
+        vm_target: The name of the VM to schedule for shutdown.
+    """
+    project_root = _find_project_root()
+
+    management_vars_path = project_root / "compute-provisioning-iac/ansible/inventory/management_vars.yml"
+
+    cmd = [
+        "ansible-playbook",
+        "-i",
+        str(project_root / "compute-provisioning-iac/ansible/inventory/hosts"),
+        str(project_root / "compute-provisioning-iac/ansible/playbooks/single-tenant/vm-operations.yaml"),
+        "--extra-vars",
+        f"vm_host={vm_host}",
+        "--extra-vars",
+        f"@{management_vars_path}",
+        "--extra-vars",
+        f"vm_target={vm_target}",
+        "--extra-vars",
+        "vm_action=lease_end",
+        "--extra-vars",
+        f"vm_lease_end='{lease_end_utc}'",
+        "--limit kvm_hosts",
+    ]
+    cwd = project_root
+
+    try:
+        result = subprocess.run(
+            cmd,
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+        )
+        logger.info("Scheduled VM shutdown for %s on %s at %s UTC.", vm_target, vm_host, lease_end_utc)
+    except subprocess.CalledProcessError as exc:
+        logger.error(
+            "Failed to schedule VM shutdown (code %s). stdout:\n%s\nstderr:\n%s",
+            exc.returncode,
+            exc.stdout,
+            exc.stderr,
+        )
+        raise
+
+    logger.info("VM shutdown scheduling playbook output:\n%s", result.stdout)

--- a/agents/a2a-agent-trader/app/utils/provisioning.py
+++ b/agents/a2a-agent-trader/app/utils/provisioning.py
@@ -169,6 +169,7 @@ def run_vm_provisioning_playbook(ssh_pubkey: str, vm_host: str = "vm1", vm_targe
 
     return ssh_command
 
+
 def schedule_vm_shutdown(lease_end_utc: str, vm_host: str = "vm1", vm_target: str = "tenant-vm") -> None:
     """
     Schedule a VM shutdown by setting its lease end time.
@@ -178,6 +179,16 @@ def schedule_vm_shutdown(lease_end_utc: str, vm_host: str = "vm1", vm_target: st
         vm_host: The host where the VM is located.
         vm_target: The name of the VM to schedule for shutdown.
     """
+    nonce = uuid.uuid4().hex
+    vm_vars_path = Path(f"/tmp/vm_lease_vars_{nonce}.yml")
+    vm_vars_payload = (
+        f"vm_host: {vm_host}\n"
+        f"vm_target: {vm_target}\n"
+        "vm_action: lease_end\n"
+        f"vm_lease_end: {lease_end_utc}\n"
+    )
+    vm_vars_path.write_text(vm_vars_payload, encoding="utf-8")
+
     project_root = _find_project_root()
 
     management_vars_path = project_root / "compute-provisioning-iac/ansible/inventory/management_vars.yml"
@@ -188,15 +199,9 @@ def schedule_vm_shutdown(lease_end_utc: str, vm_host: str = "vm1", vm_target: st
         str(project_root / "compute-provisioning-iac/ansible/inventory/hosts"),
         str(project_root / "compute-provisioning-iac/ansible/playbooks/single-tenant/vm-operations.yaml"),
         "--extra-vars",
-        f"vm_host={vm_host}",
+        f"@{vm_vars_path}",
         "--extra-vars",
         f"@{management_vars_path}",
-        "--extra-vars",
-        f"vm_target={vm_target}",
-        "--extra-vars",
-        "vm_action=lease_end",
-        "--extra-vars",
-        f"vm_lease_end='{lease_end_utc}'",
         "--limit kvm_hosts",
     ]
     cwd = project_root

--- a/agents/a2a-agent-trader/app/utils/provisioning.py
+++ b/agents/a2a-agent-trader/app/utils/provisioning.py
@@ -103,6 +103,8 @@ def run_vm_provisioning_playbook(ssh_pubkey: str, vm_host: str = "vm1") -> Optio
 
     project_root = _find_project_root()
 
+    management_vars_path = project_root / "compute-provisioning-iac/ansible/inventory/management_vars.yml"
+
     cmd = [
         "ansible-playbook",
         "-i",
@@ -110,6 +112,8 @@ def run_vm_provisioning_playbook(ssh_pubkey: str, vm_host: str = "vm1") -> Optio
         str(project_root / "compute-provisioning-iac/ansible/playbooks/single-tenant/vm-operations.yaml"),
         "--extra-vars",
         f"@{vm_vars_path}",
+        "--extra-vars",
+        f"@{management_vars_path}",
         "--limit",
         vm_host,
     ]

--- a/agents/a2a-agent-trader/app/utils/provisioning.py
+++ b/agents/a2a-agent-trader/app/utils/provisioning.py
@@ -119,7 +119,8 @@ def run_vm_provisioning_playbook(ssh_pubkey: str, vm_host: str = "vm1", vm_targe
         f"@{vm_vars_path}",
         "--extra-vars",
         f"@{management_vars_path}",
-        "--limit kvm_hosts",
+        "--limit",
+        "kvm_hosts"
     ]
     cwd = project_root
 
@@ -202,7 +203,8 @@ def schedule_vm_shutdown(lease_end_utc: str, vm_host: str = "vm1", vm_target: st
         f"@{vm_vars_path}",
         "--extra-vars",
         f"@{management_vars_path}",
-        "--limit kvm_hosts",
+        "--limit",
+        "kvm_hosts",
     ]
     cwd = project_root
 

--- a/agents/a2a-agent-trader/app/utils/provisioning.py
+++ b/agents/a2a-agent-trader/app/utils/provisioning.py
@@ -108,7 +108,7 @@ def run_vm_provisioning_playbook(ssh_pubkey: str, vm_host: str = "vm1", vm_targe
 
     project_root = _find_project_root()
 
-    management_vars_path = project_root / "compute-provisioning-iac/ansible/inventory/management_vars.yml"
+    management_vars_path = project_root / "compute-provisioning-iac/ansible/inventory/management-vars.yml"
 
     cmd = [
         "ansible-playbook",
@@ -192,7 +192,7 @@ def schedule_vm_shutdown(lease_end_utc: str, vm_host: str = "vm1", vm_target: st
 
     project_root = _find_project_root()
 
-    management_vars_path = project_root / "compute-provisioning-iac/ansible/inventory/management_vars.yml"
+    management_vars_path = project_root / "compute-provisioning-iac/ansible/inventory/management-vars.yml"
 
     cmd = [
         "ansible-playbook",

--- a/agents/a2a-agent-trader/app/utils/provisioning.py
+++ b/agents/a2a-agent-trader/app/utils/provisioning.py
@@ -8,6 +8,15 @@ from typing import Optional
 logger = logging.getLogger(__name__)
 
 
+def _cleanup_temp_file(path: Path) -> None:
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return
+    except Exception as exc:
+        logger.warning("Failed to remove temp file %s: %s", path, exc)
+
+
 def _find_project_root() -> Path:
     """Walk up the tree to locate the repo root (uses compute-provisioning-iac or .git as sentinels)."""
     current = Path(__file__).resolve()
@@ -140,6 +149,8 @@ def run_vm_provisioning_playbook(ssh_pubkey: str, vm_host: str = "vm1", vm_targe
             exc.stderr,
         )
         raise
+    finally:
+        _cleanup_temp_file(vm_vars_path)
 
     logger.info("VM provisioning playbook output:\n%s", result.stdout)
     if result.stderr:
@@ -225,5 +236,7 @@ def schedule_vm_shutdown(lease_end_utc: str, vm_host: str = "vm1", vm_target: st
             exc.stderr,
         )
         raise
+    finally:
+        _cleanup_temp_file(vm_vars_path)
 
     logger.info("VM shutdown scheduling playbook output:\n%s", result.stdout)

--- a/agents/a2a-agent-trader/tests/unit/test_action_executor.py
+++ b/agents/a2a-agent-trader/tests/unit/test_action_executor.py
@@ -1,12 +1,16 @@
 """Unit tests for action executor helpers."""
 
 import json
+from datetime import datetime
 
 import pytest
 
 from app.schema.pydantic_models import (
+    Action,
+    ActionType,
     ComputeResource,
     ERC20TokenMetadata,
+    EventType,
     GPUModel,
     Region,
     TokenResource,
@@ -111,6 +115,12 @@ class _FakeClient:
         self.erc20 = _ERC20(records)
 
 
+class _FakeCtx:
+    def __init__(self) -> None:
+        self.invocation_id = "invocation-1"
+        self.branch = "main"
+
+
 @pytest.mark.asyncio
 async def test_buy_compute_with_erc20_approves_total_and_creates_total(monkeypatch):
     """Test buying compute with ERC20 approves total payment and creates escrow with total price."""
@@ -174,3 +184,67 @@ async def test_accept_offer_passes_duration_and_hourly_rate(monkeypatch):
     if isinstance(token_payload, dict):
         token_payload = TokenResource.model_validate(token_payload)
     assert token_payload.amount == rate
+
+
+@pytest.mark.asyncio
+async def test_execute_action_fulfill_skips_event_on_error(monkeypatch):
+    """Ensure fulfillment errors do not send events to the counterparty."""
+    async def fake_fulfill_compute_obligation(**_kwargs):
+        return {"status": "error", "message": "Provisioning failed"}
+
+    called = {"count": 0}
+
+    async def fake_send_to_remote_agent(_ctx, _event):
+        called["count"] += 1
+
+    monkeypatch.setattr(action_executor, "fulfill_compute_obligation", fake_fulfill_compute_obligation)
+    monkeypatch.setattr(action_executor, "send_to_remote_agent", fake_send_to_remote_agent)
+
+    action = Action(
+        action_type=ActionType.FULFILL_COMPUTE_OBLIGATION,
+        parameters={"escrow_uid": "escrow-1", "ssh_public_key": "ssh-rsa AAA"},
+        timestamp=datetime.now(),
+    )
+
+    await action_executor.execute_action(action, alkahest_client=None, ctx=_FakeCtx())
+
+    assert called["count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_execute_action_fulfill_sends_event_on_success(monkeypatch):
+    """Ensure fulfillment success sends event with event type set."""
+    async def fake_fulfill_compute_obligation(**_kwargs):
+        return {"status": "fulfilled", "message": "ok"}
+
+    captured: dict = {}
+
+    async def fake_send_to_remote_agent(_ctx, event):
+        captured["event"] = event
+
+    monkeypatch.setattr(action_executor, "fulfill_compute_obligation", fake_fulfill_compute_obligation)
+    monkeypatch.setattr(action_executor, "send_to_remote_agent", fake_send_to_remote_agent)
+
+    action = Action(
+        action_type=ActionType.FULFILL_COMPUTE_OBLIGATION,
+        parameters={"escrow_uid": "escrow-2", "ssh_public_key": "ssh-rsa AAA"},
+        timestamp=datetime.now(),
+    )
+
+    await action_executor.execute_action(action, alkahest_client=None, ctx=_FakeCtx())
+
+    assert "event" in captured
+    response = captured["event"].content.parts[0].function_response.response
+    assert response["event_type"] == EventType.RECEIVE_COMPUTE_OBLIGATION_FULFILLMENT.value
+
+
+@pytest.mark.asyncio
+async def test_provision_machine_raises_on_missing_connection_info(monkeypatch):
+    """Ensure missing connection info raises a RuntimeError."""
+    def fake_run_vm_provisioning_playbook(_ssh_public_key):
+        return None
+
+    monkeypatch.setattr(action_executor, "run_vm_provisioning_playbook", fake_run_vm_provisioning_playbook)
+
+    with pytest.raises(RuntimeError, match="SSH connection info unavailable"):
+        await action_executor.provision_machine("ssh-rsa AAA")

--- a/agents/a2a-agent-trader/tests/unit/test_action_executor.py
+++ b/agents/a2a-agent-trader/tests/unit/test_action_executor.py
@@ -1,0 +1,176 @@
+"""Unit tests for action executor helpers."""
+
+import json
+
+import pytest
+
+from app.schema.pydantic_models import (
+    ComputeResource,
+    ERC20TokenMetadata,
+    GPUModel,
+    Region,
+    TokenResource,
+)
+from app.utils import action_executor
+
+
+USDT_METADATA = ERC20TokenMetadata(
+    symbol="USDT",
+    contract_address="0xdac17f958d2ee523a2206206994597c13d831ec7",
+    decimals=6,
+)
+
+
+def _compute_resource() -> ComputeResource:
+    return ComputeResource(
+        gpu_model=GPUModel.H200,
+        quantity=1,
+        sla=99.0,
+        region=Region.CALIFORNIA_US,
+    )
+
+
+def _token_rate(amount: int) -> TokenResource:
+    return TokenResource(token=USDT_METADATA, amount=amount)
+
+
+def test_encode_compute_lease_uses_rate_times_duration_token_instance():
+    """Test encoding compute lease with TokenResource instance."""
+    rate = 1_500_000
+    duration_hours = 3
+    lease_bytes = action_executor.encode_compute_lease(
+        compute_resource=_compute_resource(),
+        token_resource=_token_rate(rate),
+        duration_hours=duration_hours,
+    )
+    payload = json.loads(lease_bytes.decode("utf-8"))
+
+    assert payload["duration_hours"] == duration_hours
+    assert payload["total_price_int"] == rate * duration_hours
+    assert payload["price_per_hour_decimal"] == pytest.approx(rate / 10**USDT_METADATA.decimals)
+    assert payload["total_price_decimal"] == pytest.approx((rate * duration_hours) / 10**USDT_METADATA.decimals)
+
+
+def test_encode_compute_lease_uses_rate_times_duration_token_dict():
+    """Test encoding compute lease with token resource as dict."""
+    rate = 2_000_000
+    duration_hours = 2
+    token_dict = {
+        "token": {
+            "symbol": USDT_METADATA.symbol,
+            "contract_address": USDT_METADATA.contract_address,
+            "decimals": USDT_METADATA.decimals,
+        },
+        "amount": rate,
+    }
+    lease_bytes = action_executor.encode_compute_lease(
+        compute_resource=_compute_resource().model_dump(mode="json"),
+        token_resource=token_dict,
+        duration_hours=duration_hours,
+    )
+    payload = json.loads(lease_bytes.decode("utf-8"))
+
+    assert payload["total_price_int"] == rate * duration_hours
+    assert payload["price_per_hour_decimal"] == pytest.approx(rate / 10**USDT_METADATA.decimals)
+    assert payload["total_price_decimal"] == pytest.approx((rate * duration_hours) / 10**USDT_METADATA.decimals)
+
+
+class _FakeEscrow:
+    def __init__(self, records: dict) -> None:
+        self._records = records
+
+    async def create(self, price_data, arbiter_data, expiration):
+        self._records["price_data"] = price_data
+        self._records["arbiter_data"] = arbiter_data
+        self._records["expiration"] = expiration
+        return {"log": {"uid": "escrow123"}}
+
+
+class _FakeClient:
+    def __init__(self, records: dict) -> None:
+        class _Util:
+            async def approve(self, *_args, **_kwargs):
+                return "approved"
+
+        class _NonTierable:
+            def __init__(self, recs: dict) -> None:
+                self._recs = recs
+
+            async def create(self, price_data, arbiter_data, expiration):
+                return await _FakeEscrow(self._recs).create(price_data, arbiter_data, expiration)
+
+        class _Escrow:
+            def __init__(self, recs: dict) -> None:
+                self.non_tierable = _NonTierable(recs)
+
+        class _ERC20:
+            def __init__(self, recs: dict) -> None:
+                self.escrow = _Escrow(recs)
+                self.util = _Util()
+
+        self.erc20 = _ERC20(records)
+
+
+@pytest.mark.asyncio
+async def test_buy_compute_with_erc20_approves_total_and_creates_total(monkeypatch):
+    """Test buying compute with ERC20 approves total payment and creates escrow with total price."""
+    records: dict = {}
+    rate = 1_250_000
+    duration_hours = 4
+
+    async def fake_approve_token_escrow(payment, *, alkahest_client):
+        records["approved_payment"] = payment
+        return "approved"
+
+    monkeypatch.setattr(action_executor, "approve_token_escrow", fake_approve_token_escrow)
+
+    await action_executor.buy_compute_with_erc20(
+        compute_resource=_compute_resource(),
+        token_resource=_token_rate(rate),
+        duration_hours=duration_hours,
+        oracle_address="0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
+        client=_FakeClient(records),
+    )
+
+    assert records["approved_payment"].amount == rate * duration_hours
+    assert records["price_data"]["value"] == rate * duration_hours
+
+
+@pytest.mark.asyncio
+async def test_accept_offer_passes_duration_and_hourly_rate(monkeypatch):
+    """Test accept_offer passes duration_hours and hourly rate to buy_compute_with_erc20."""
+    records: dict = {}
+    rate = 1_000_000
+    duration_hours = 5
+    order_dict = {
+        "order_id": "order-123",
+        "order_maker": "seller",
+        "offer_resource": _compute_resource().model_dump(mode="json"),
+        "demand_resource": _token_rate(rate).model_dump(mode="json"),
+        "duration_hours": duration_hours,
+    }
+
+    async def fake_buy_compute_with_erc20(
+        compute_resource,
+        token_resource,
+        duration_hours,
+        oracle_address,
+        client,
+    ):
+        records["token_resource"] = token_resource
+        records["duration_hours"] = duration_hours
+        return {"log": {"uid": "escrow123"}}
+
+    monkeypatch.setattr(action_executor, "buy_compute_with_erc20", fake_buy_compute_with_erc20)
+
+    await action_executor.accept_offer(
+        alkahest_client=_FakeClient(records),
+        ctx=None,
+        parameters={"order": order_dict},
+    )
+
+    assert records["duration_hours"] == duration_hours
+    token_payload = records["token_resource"]
+    if isinstance(token_payload, dict):
+        token_payload = TokenResource.model_validate(token_payload)
+    assert token_payload.amount == rate

--- a/agents/a2a-agent-trader/tests/unit/test_validation.py
+++ b/agents/a2a-agent-trader/tests/unit/test_validation.py
@@ -241,7 +241,7 @@ class TestMarketOrderResourceDeserialization:
                 "token": "USDT",
                 "amount": 9000000000000000000,
             },
-            "duration": 1,
+            "duration_hours": 1,
         }
         order = MarketOrder.model_validate(order_data)
         
@@ -265,7 +265,7 @@ class TestMarketOrderResourceDeserialization:
                 "sla": 99.9,
                 "region": "New York, US",
             },
-            "duration": 1,
+            "duration_hours": 1,
         }
         order = MarketOrder.model_validate(order_data)
         
@@ -287,7 +287,7 @@ class TestMarketOrderResourceDeserialization:
                 "token": "USDT",
                 "amount": 9000000000000000000,
             },
-            "duration": 1,
+            "duration_hours": 1,
         }
         with pytest.raises(ValidationError):
             MarketOrder.model_validate(order_data)
@@ -312,7 +312,7 @@ class TestMarketOrderResourceDeserialization:
                 "token": "USDT",
                 "amount": 9000000000000000000,
             },
-            "duration": 1,
+            "duration_hours": 1,
         }
         order = MarketOrder.model_validate(order_data)
         assert isinstance(order.offer_resource, TokenResource)
@@ -336,7 +336,7 @@ class TestMarketOrderResourceDeserialization:
             order_maker="agent1",
             offer_resource=compute_res,
             demand_resource=token_res,
-            duration=1,
+            duration_hours=1,
         )
         
         # Resources should be unchanged
@@ -391,7 +391,7 @@ class TestParseDomainEvent:
                         "token": "USDT",
                         "amount": 9000000000000000000,
                     },
-                    "duration": 1,
+                    "duration_hours": 1,
                 },
             },
         }
@@ -452,7 +452,7 @@ class TestValidationUtilities:
                 "token": "USDT",
                 "amount": 9000000000000000000,
             },
-            "duration": 1,
+            "duration_hours": 1,
         }
         order = validate_market_order(order_data)
         assert isinstance(order, MarketOrder)
@@ -495,7 +495,7 @@ class TestValidationUtilities:
                 region=Region.CALIFORNIA_US,
             ),
             demand_resource=TokenResource(token=USDT_METADATA, amount=1000000000000000000),
-            duration=1,
+            duration_hours=1,
         )
         make_offer_event = MakeOfferEvent.from_order(order)
         
@@ -528,7 +528,7 @@ class TestValidationUtilities:
                 sla=99.9,
                 region=Region.NEW_YORK_US,
             ),
-            duration=1,
+            duration_hours=1,
         )
         make_offer_event = MakeOfferEvent.from_order(order)
         

--- a/erc-8004-registry-py/alembic/versions/006_rename_duration_to_duration_hours.py
+++ b/erc-8004-registry-py/alembic/versions/006_rename_duration_to_duration_hours.py
@@ -1,0 +1,40 @@
+"""rename_duration_to_duration_hours
+
+Revision ID: 006_rename_duration_to_duration_hours
+Revises: 005_simplify_to_erc8004_canonical_ids
+Create Date: 2026-01-21 19:56:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "006_rename_duration_to_duration_hours"
+down_revision = "005_simplify_to_erc8004_canonical_ids"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    if "market_orders" not in inspector.get_table_names():
+        return
+
+    existing_columns = [col["name"] for col in inspector.get_columns("market_orders")]
+    if "duration" in existing_columns and "duration_hours" not in existing_columns:
+        with op.batch_alter_table("market_orders") as batch_op:
+            batch_op.alter_column("duration", new_column_name="duration_hours")
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    if "market_orders" not in inspector.get_table_names():
+        return
+
+    existing_columns = [col["name"] for col in inspector.get_columns("market_orders")]
+    if "duration_hours" in existing_columns and "duration" not in existing_columns:
+        with op.batch_alter_table("market_orders") as batch_op:
+            batch_op.alter_column("duration_hours", new_column_name="duration")

--- a/erc-8004-registry-py/src/api/order_routes.py
+++ b/erc-8004-registry-py/src/api/order_routes.py
@@ -50,7 +50,7 @@ async def publish_order(
             "order_maker": order_data.get("order_maker"),
             "offer_resource": order_data.get("offer_resource"),
             "demand_resource": order_data.get("demand_resource"),
-            "duration": order_data.get("duration"),
+            "duration_hours": order_data.get("duration_hours"),
             "maker_attestation": order_data.get("maker_attestation"),
             "taker_attestation": order_data.get("taker_attestation"),
         }
@@ -73,7 +73,7 @@ async def publish_order(
             order_taker=order_data.get("order_taker"),
             offer_resource=order_data.get("offer_resource", {}),
             demand_resource=order_data.get("demand_resource", {}),
-            duration=order_data.get("duration", 1),
+            duration_hours=order_data.get("duration_hours", 1),
             maker_attestation=order_data.get("maker_attestation"),
             taker_attestation=order_data.get("taker_attestation"),
             status=validate_order_status(status_str),

--- a/erc-8004-registry-py/src/api/utils.py
+++ b/erc-8004-registry-py/src/api/utils.py
@@ -298,7 +298,7 @@ def order_to_dict(order: MarketOrder) -> dict:
         "order_taker": order.order_taker,
         "offer_resource": order.offer_resource or {},
         "demand_resource": order.demand_resource or {},
-        "duration": order.duration,
+        "duration_hours": order.duration_hours,
         "maker_attestation": order.maker_attestation,
         "taker_attestation": order.taker_attestation,
         "status": order.status.value,

--- a/erc-8004-registry-py/src/db/models.py
+++ b/erc-8004-registry-py/src/db/models.py
@@ -108,7 +108,7 @@ class MarketOrder(Base):
     order_taker = Column(Text, nullable=True)  # Agent card URL of taker
     offer_resource = Column(JSON, nullable=False)  # JSON representation of ComputeResource or TokenResource
     demand_resource = Column(JSON, nullable=False)  # JSON representation of ComputeResource or TokenResource
-    duration = Column(Integer, nullable=False)
+    duration_hours = Column(Integer, nullable=False)
     maker_attestation = Column(Text, nullable=True)
     taker_attestation = Column(Text, nullable=True)
     status = Column(SQLEnum(OrderStatusEnum), nullable=False, default=OrderStatusEnum.open)

--- a/erc-8004-registry-py/tests/conftest.py
+++ b/erc-8004-registry-py/tests/conftest.py
@@ -55,7 +55,7 @@ def sample_order(db_session, sample_agent):
         order_maker="http://localhost:8001/.well-known/agent-card.json",
         offer_resource={"gpu_model": "A100", "region": "us-west"},
         demand_resource={"token": "USDC"},
-        duration=3600,
+        duration_hours=3600,
         status=OrderStatusEnum.open,
     )
     db_session.add(order)

--- a/erc-8004-registry-py/tests/integration/test_order_flow.py
+++ b/erc-8004-registry-py/tests/integration/test_order_flow.py
@@ -70,7 +70,7 @@ def test_complete_order_lifecycle(client, agent_a, agent_b, db_session):
             "order_maker": agent_a.token_uri,
             "offer_resource": {"gpu_model": "A100", "region": "us-west"},
             "demand_resource": {"token": "USDC"},
-            "duration": 3600,
+            "duration_hours": 3600,
             "status": "open",
         },
     )
@@ -85,7 +85,7 @@ def test_complete_order_lifecycle(client, agent_a, agent_b, db_session):
             "order_maker": agent_b.token_uri,
             "offer_resource": {"token": "USDC"},
             "demand_resource": {"gpu_model": "A100", "region": "us-west"},
-            "duration": 3600,
+            "duration_hours": 3600,
             "status": "open",
         },
     )
@@ -145,7 +145,7 @@ def test_agent_id_resolution_canonical_only(client, agent_a, db_session):
             "order_maker": agent_a.token_uri,
             "offer_resource": {"gpu_model": "A100"},
             "demand_resource": {"token": "USDC"},
-            "duration": 3600,
+            "duration_hours": 3600,
         },
     )
     assert response_canonical.status_code == 201

--- a/erc-8004-registry-py/tests/unit/test_order_routes.py
+++ b/erc-8004-registry-py/tests/unit/test_order_routes.py
@@ -31,7 +31,7 @@ def test_create_order(client, sample_agent):
             "order_maker": "http://localhost:8001/.well-known/agent-card.json",
             "offer_resource": {"gpu_model": "A100", "region": "us-west"},
             "demand_resource": {"token": "USDC"},
-            "duration": 3600,
+            "duration_hours": 3600,
             "status": "open",
         },
     )
@@ -50,7 +50,7 @@ def test_create_order_duplicate(client, sample_agent, sample_order):
             "order_maker": "http://localhost:8001/.well-known/agent-card.json",
             "offer_resource": {"gpu_model": "H100", "region": "us-east"},
             "demand_resource": {"token": "USDC"},
-            "duration": 7200,
+            "duration_hours": 7200,
             "status": "closed",
         },
     )
@@ -97,7 +97,7 @@ def test_get_agent_orders(client, sample_agent, db_session):
             order_maker="http://localhost:8001/.well-known/agent-card.json",
             offer_resource={"gpu_model": "A100"},
             demand_resource={"token": "USDC"},
-            duration=3600,
+            duration_hours=3600,
             status=OrderStatusEnum.open,
         )
         db_session.add(order)
@@ -119,7 +119,7 @@ def test_get_agent_orders_filtered_by_status(client, sample_agent, db_session):
         order_maker="http://localhost:8001/.well-known/agent-card.json",
         offer_resource={"gpu_model": "A100"},
         demand_resource={"token": "USDC"},
-        duration=3600,
+        duration_hours=3600,
         status=OrderStatusEnum.open,
     )
     order_closed = MarketOrder(
@@ -128,7 +128,7 @@ def test_get_agent_orders_filtered_by_status(client, sample_agent, db_session):
         order_maker="http://localhost:8001/.well-known/agent-card.json",
         offer_resource={"gpu_model": "A100"},
         demand_resource={"token": "USDC"},
-        duration=3600,
+        duration_hours=3600,
         status=OrderStatusEnum.closed,
     )
     db_session.add(order_open)
@@ -150,7 +150,7 @@ def test_query_orders_with_filters(client, db_session, sample_agent):
         order_maker="http://localhost:8001/.well-known/agent-card.json",
         offer_resource={"gpu_model": "A100", "region": "us-west"},
         demand_resource={"token": "USDC"},
-        duration=3600,
+        duration_hours=3600,
         status=OrderStatusEnum.open,
     )
     db_session.add(order)
@@ -172,7 +172,7 @@ def test_query_orders_bidirectional(client, db_session, sample_agent):
         order_maker="http://localhost:8001/.well-known/agent-card.json",
         offer_resource={"gpu_model": "A100"},
         demand_resource={"token": "USDC"},
-        duration=3600,
+        duration_hours=3600,
         status=OrderStatusEnum.open,
     )
     # Create order B: offer token, demand GPU
@@ -182,7 +182,7 @@ def test_query_orders_bidirectional(client, db_session, sample_agent):
         order_maker="http://localhost:8002/.well-known/agent-card.json",
         offer_resource={"token": "USDC"},
         demand_resource={"gpu_model": "A100"},
-        duration=3600,
+        duration_hours=3600,
         status=OrderStatusEnum.open,
     )
     db_session.add(order_a)
@@ -217,7 +217,7 @@ def test_update_order_symmetric(client, db_session, sample_agent):
         order_taker="http://localhost:8002/.well-known/agent-card.json",
         offer_resource={"gpu_model": "A100"},
         demand_resource={"token": "USDC"},
-        duration=3600,
+        duration_hours=3600,
         status=OrderStatusEnum.open,
     )
     # Create order B: offer token, demand GPU (symmetric)
@@ -227,7 +227,7 @@ def test_update_order_symmetric(client, db_session, sample_agent):
         order_maker="http://localhost:8002/.well-known/agent-card.json",
         offer_resource={"token": "USDC"},
         demand_resource={"gpu_model": "A100"},
-        duration=3600,
+        duration_hours=3600,
         status=OrderStatusEnum.open,
     )
     db_session.add(order_a)

--- a/erc-8004-registry-py/tests/unit/test_resource_filters.py
+++ b/erc-8004-registry-py/tests/unit/test_resource_filters.py
@@ -13,7 +13,7 @@ def test_matches_resource_filters_compute(db_session, sample_agent):
         order_maker="http://localhost:8001/.well-known/agent-card.json",
         offer_resource={"gpu_model": "A100", "region": "us-west"},
         demand_resource={"token": "USDC"},
-        duration=3600,
+        duration_hours=3600,
         status=OrderStatusEnum.open,
     )
     
@@ -29,7 +29,7 @@ def test_matches_resource_filters_region(db_session, sample_agent):
         order_maker="http://localhost:8001/.well-known/agent-card.json",
         offer_resource={"gpu_model": "A100", "region": "us-west"},
         demand_resource={"token": "USDC"},
-        duration=3600,
+        duration_hours=3600,
         status=OrderStatusEnum.open,
     )
     
@@ -45,7 +45,7 @@ def test_matches_resource_filters_bidirectional(db_session, sample_agent):
         order_maker="http://localhost:8001/.well-known/agent-card.json",
         offer_resource={"gpu_model": "A100", "region": "us-west"},
         demand_resource={"token": "USDC"},
-        duration=3600,
+        duration_hours=3600,
         status=OrderStatusEnum.open,
     )
     
@@ -62,7 +62,7 @@ def test_matches_resource_filters_gpu_model(db_session, sample_agent):
         order_maker="http://localhost:8001/.well-known/agent-card.json",
         offer_resource={"gpu_model": "A100", "region": "us-west"},
         demand_resource={"token": "USDC"},
-        duration=3600,
+        duration_hours=3600,
         status=OrderStatusEnum.open,
     )
     
@@ -78,7 +78,7 @@ def test_matches_resource_filters_sla(db_session, sample_agent):
         order_maker="http://localhost:8001/.well-known/agent-card.json",
         offer_resource={"gpu_model": "A100", "region": "us-west", "sla": 0.99},
         demand_resource={"token": "USDC"},
-        duration=3600,
+        duration_hours=3600,
         status=OrderStatusEnum.open,
     )
     

--- a/erc-8004-registry-py/tests/unit/test_symmetric_orders.py
+++ b/erc-8004-registry-py/tests/unit/test_symmetric_orders.py
@@ -15,7 +15,7 @@ def test_find_symmetric_order(db_session, sample_agent):
         order_taker="http://localhost:8002/.well-known/agent-card.json",
         offer_resource={"gpu_model": "A100", "region": "us-west"},
         demand_resource={"token": "USDC"},
-        duration=3600,
+        duration_hours=3600,
         status=OrderStatusEnum.open,
     )
     db_session.add(order_a)
@@ -27,7 +27,7 @@ def test_find_symmetric_order(db_session, sample_agent):
         order_maker="http://localhost:8002/.well-known/agent-card.json",
         offer_resource={"token": "USDC"},
         demand_resource={"gpu_model": "A100", "region": "us-west"},
-        duration=3600,
+        duration_hours=3600,
         status=OrderStatusEnum.open,
     )
     db_session.add(order_b)
@@ -50,7 +50,7 @@ def test_find_symmetric_order_not_found(db_session, sample_agent):
         order_taker="http://localhost:8002/.well-known/agent-card.json",
         offer_resource={"gpu_model": "A100", "region": "us-west"},
         demand_resource={"token": "USDC"},
-        duration=3600,
+        duration_hours=3600,
         status=OrderStatusEnum.open,
     )
     db_session.add(order)
@@ -72,7 +72,7 @@ def test_find_symmetric_order_no_taker(db_session, sample_agent):
         order_taker=None,
         offer_resource={"gpu_model": "A100", "region": "us-west"},
         demand_resource={"token": "USDC"},
-        duration=3600,
+        duration_hours=3600,
         status=OrderStatusEnum.open,
     )
     db_session.add(order)


### PR DESCRIPTION
# Changes Made
- Added function to schedule VM shutdown by lease end
- Updated compute-provisioning-iac to latest version with `management_vars`
- Updated lease pricing to treat token amounts as hourly rates and compute total payment by duration; this was previously days but is now hours to match market expectations.
- Supporting the above, refactored `duration` to `duration_hours` across trader + registry models, API payloads, and DB schema (with Alembic migration)
- With hourly rate now available, this is multiplied with the `duration_hours` to compute the actual value for escrow
- Added fulfillment safeguards (skip remote event on error, raise on provisioning failure)
- Added/updated unit tests for action executor, validation, and order flow to cover `duration_hours` and escrow totals.

# Testing
From the agent dir, run the new unit tests with `pytest /tests/unit/test_action_executor.py`