### PR TITLE
Feature: Role-Aware Policy for Bilateral Price Negotiation

### DIFF
--- a/agents/a2a-agent-trader/app/agent.py
+++ b/agents/a2a-agent-trader/app/agent.py
@@ -652,7 +652,6 @@ class TraderAgent(BaseAgent):
         except Exception as e:
             logger.error(f"[PIPELINE] Failed to record decision: {e}")
         
-        # Return response string for backward compatibility
         action_type_str = action.action_type.value if hasattr(action.action_type, "value") else str(action.action_type)
         action_mappings = {
             "accept_offer": "ACCEPT the offer.",

--- a/agents/a2a-agent-trader/app/agent.py
+++ b/agents/a2a-agent-trader/app/agent.py
@@ -521,15 +521,22 @@ class TraderAgent(BaseAgent):
         
         # Load negotiation history from thread store if this is a NegotiationEvent
         negotiation_history = []
+        thread_info = {}
         if isinstance(domain_event, NegotiationEvent):
             thread_store = get_thread_store()
             negotiation_id = domain_event.negotiation_id
             if negotiation_id:
                 negotiation_history = await thread_store.get_thread(negotiation_id)
+                thread_info = await thread_store.get_thread_info(
+                    negotiation_id=negotiation_id,
+                    owner_id=self.name
+                ) or {}
+        
+        market_state_with_thread = {**market_state, "thread_info": thread_info}
         
         return (domain_event, {
             "resource_portfolio": resource_portfolio,
-            "market_state": market_state,
+            "market_state": market_state_with_thread,
             "past_experiences": past_experiences,
             "negotiation_history": negotiation_history,
         })
@@ -543,10 +550,8 @@ class TraderAgent(BaseAgent):
         domain_event, context_data = context
         event_type = domain_event.event_type
         
-        # Ensure policy exists for this event type (lazy policy setup)
         await self._policy_manager.ensure_policy_for_event_type(event_type)
         
-        # Build DecisionContext for PolicyStore
         decision_context = DecisionContext(
             event=domain_event,
             agent_id=self.name,
@@ -556,7 +561,6 @@ class TraderAgent(BaseAgent):
             past_experiences=context_data.get("past_experiences", []),
         )
         
-        # Evaluate policy using PolicyStore
         try:
             action = await self._policy_store.evaluate_policy(
                 agent_id=self.name,

--- a/agents/a2a-agent-trader/app/policies/action_builders.py
+++ b/agents/a2a-agent-trader/app/policies/action_builders.py
@@ -1,0 +1,250 @@
+"""Action builders for creating DomainAction objects with consistent parameter structure.
+
+This module provides builder classes that simplify the creation of DomainAction objects
+throughout the policy system. Instead of manually constructing DomainAction objects
+with repeated parameter extraction logic, policies can use these builders for cleaner,
+more maintainable code.
+"""
+
+from dataclasses import dataclass
+from typing import Any
+import logging
+
+from app.schema.pydantic_models import Action as DomainAction, ActionType
+
+logger = logging.getLogger(__name__)
+
+
+def _generate_negotiation_id(our_order_id: str | None, their_order_id: str | None) -> str:
+    """Generate a deterministic negotiation ID from order IDs.
+
+    This ensures that the same pair of orders always results in the same
+    negotiation ID, preventing duplicate negotiations.
+
+    Args:
+        our_order_id: Our order ID (may be None for incoming offers)
+        their_order_id: Their order ID
+
+    Returns:
+        A deterministic negotiation ID
+    """
+    # Sort order IDs to ensure bidirectional consistency
+    # (agent A and agent B should generate the same ID for the same pair of orders)
+    orders = sorted([
+        our_order_id or "no_our_order",
+        their_order_id or "no_their_order"
+    ])
+    return f"{orders[0]}_{orders[1]}"
+
+
+@dataclass
+class NegotiationActionBuilder:
+    """Builder for negotiation-related actions.
+
+    This builder provides a clean interface for creating negotiation actions
+    without repetitive parameter extraction and DomainAction construction.
+
+    Example usage:
+        data = context.event.data or {}
+        actions = NegotiationActionBuilder(data)
+
+        # Simple, readable action creation
+        if our_price == their_price:
+            return actions.accept("price_equal")
+
+        if price_too_far:
+            return actions.exit("price_unreasonable")
+
+        return actions.counter(proposed_price)
+    """
+
+    data: dict[str, Any]
+
+    def _get_negotiation_id(self) -> str:
+        """Get or generate a negotiation ID from the event data.
+
+        Returns:
+            A negotiation ID (from data or generated deterministically)
+        """
+        negotiation_id = self.data.get("negotiation_id")
+        if negotiation_id:
+            return negotiation_id
+
+        # Generate deterministic ID if none exists
+        return _generate_negotiation_id(
+            self.data.get("our_order_id"),
+            self.data.get("their_order_id")
+        )
+
+    def accept(self, reason: str) -> DomainAction:
+        """Build ACCEPT_OFFER action.
+
+        Args:
+            reason: Human-readable reason for accepting (e.g., "within_band", "price_equal")
+
+        Returns:
+            DomainAction configured for accepting an offer
+        """
+        return DomainAction(
+            action_type=ActionType.ACCEPT_OFFER,
+            parameters={
+                "order_id": self.data.get("their_order_id"),
+                "negotiation_id": self._get_negotiation_id(),
+                "reason": reason,
+                "our_price": self.data.get("our_price"),
+                "their_price": self.data.get("their_price"),
+                "our_order_id": self.data.get("our_order_id"),
+                "their_order_id": self.data.get("their_order_id"),
+            },
+        )
+
+    def reject(self, reason: str) -> DomainAction:
+        """Build REJECT_OFFER action.
+
+        Args:
+            reason: Human-readable reason for rejecting (e.g., "invalid_data", "price_too_low")
+
+        Returns:
+            DomainAction configured for rejecting an offer
+        """
+        return DomainAction(
+            action_type=ActionType.REJECT_OFFER,
+            parameters={
+                "order_id": self.data.get("their_order_id"),
+                "negotiation_id": self._get_negotiation_id(),
+                "reason": reason,
+            },
+        )
+
+    def counter(self, proposed_price: int) -> DomainAction:
+        """Build COUNTER_OFFER action.
+
+        Args:
+            proposed_price: The counter-offer price to propose
+
+        Returns:
+            DomainAction configured for making a counter-offer
+        """
+        return DomainAction(
+            action_type=ActionType.COUNTER_OFFER,
+            parameters={
+                "order_id": self.data.get("their_order_id"),
+                "negotiation_id": self._get_negotiation_id(),
+                "proposed_price": proposed_price,
+                "our_price": self.data.get("our_price"),
+                "their_price": self.data.get("their_price"),
+                "our_order_id": self.data.get("our_order_id"),
+                "their_order_id": self.data.get("their_order_id"),
+            },
+        )
+
+    def exit(self, reason: str) -> DomainAction:
+        """Build EXIT_NEGOTIATION action.
+
+        Args:
+            reason: Human-readable reason for exiting (e.g., "timeout", "max_rounds", "stale")
+
+        Returns:
+            DomainAction configured for exiting negotiation
+        """
+        return DomainAction(
+            action_type=ActionType.EXIT_NEGOTIATION,
+            parameters={
+                "order_id": self.data.get("their_order_id"),
+                "negotiation_id": self._get_negotiation_id(),
+                "reason": reason,
+            },
+        )
+
+
+@dataclass
+class ResourceActionBuilder:
+    """Builder for resource-related actions (offers, requests, etc.).
+
+    Example usage:
+        resources = ResourceActionBuilder(context)
+        return resources.make_offer(order_details)
+    """
+
+    context: Any  # DecisionContext, but avoiding circular import
+
+    def make_offer(self, order_details: dict[str, Any]) -> DomainAction:
+        """Build MAKE_OFFER action.
+
+        Args:
+            order_details: Dictionary containing offer details
+
+        Returns:
+            DomainAction configured for making an offer
+        """
+        return DomainAction(
+            action_type=ActionType.MAKE_OFFER,
+            parameters=order_details,
+        )
+
+    def cancel_offer(self, order_id: str, reason: str) -> DomainAction:
+        """Build CANCEL_OFFER action.
+
+        Args:
+            order_id: ID of the order to cancel
+            reason: Reason for cancellation
+
+        Returns:
+            DomainAction configured for canceling an offer
+        """
+        return DomainAction(
+            action_type=ActionType.CANCEL_OFFER,
+            parameters={
+                "order_id": order_id,
+                "reason": reason,
+            },
+        )
+
+
+@dataclass
+class CounterOfferParams:
+    """Parameters for counter_offer action with validation.
+
+    This dataclass provides type-safe parameter extraction and validation
+    for the counter_offer action executor function.
+
+    Example usage:
+        params = CounterOfferParams.from_dict(parameters)
+        if not params:
+            return {"status": "error", "message": "Missing required parameters"}
+
+        # Use params.negotiation_id, params.order_id, etc.
+    """
+
+    negotiation_id: str
+    order_id: str  # Their order ID
+    proposed_price: int
+    our_price: int
+    their_price: int
+    our_order_id: str | None = None
+
+    @classmethod
+    def from_dict(cls, params: dict[str, Any]) -> "CounterOfferParams | None":
+        """Create from parameters dict with validation.
+
+        Args:
+            params: Dictionary of parameters from action executor
+
+        Returns:
+            CounterOfferParams instance if all required parameters present, None otherwise
+        """
+        try:
+            return cls(
+                negotiation_id=params["negotiation_id"],
+                order_id=params["order_id"],
+                proposed_price=params["proposed_price"],
+                our_price=params["our_price"],
+                their_price=params["their_price"],
+                our_order_id=params.get("our_order_id"),
+            )
+        except KeyError as e:
+            logger.error(f"Missing required parameter for counter_offer: {e}")
+            return None
+        except (TypeError, ValueError) as e:
+            logger.error(f"Invalid parameter type for counter_offer: {e}")
+            return None

--- a/agents/a2a-agent-trader/app/policies/action_builders.py
+++ b/agents/a2a-agent-trader/app/policies/action_builders.py
@@ -91,8 +91,6 @@ class NegotiationActionBuilder:
                 "order_id": self.data.get("their_order_id"),
                 "negotiation_id": self._get_negotiation_id(),
                 "reason": reason,
-                "our_price": self.data.get("our_price"),
-                "their_price": self.data.get("their_price"),
                 "our_order_id": self.data.get("our_order_id"),
                 "their_order_id": self.data.get("their_order_id"),
             },

--- a/agents/a2a-agent-trader/app/policies/evaluator.py
+++ b/agents/a2a-agent-trader/app/policies/evaluator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Callable
 
 from app.schema.pydantic_models import Action, DecisionContext
@@ -10,5 +11,9 @@ class CallableEvaluator:
         self.func = func
 
     async def evaluate(self, context: DecisionContext) -> Action | None:
-        return self.func(context)
+        result = self.func(context)
+        # Handle async policy callables (e.g., negotiation_respond_to_make_offer)
+        if asyncio.iscoroutine(result):
+            return await result
+        return result
 

--- a/agents/a2a-agent-trader/app/policies/negotiation_thread.py
+++ b/agents/a2a-agent-trader/app/policies/negotiation_thread.py
@@ -6,8 +6,12 @@ from typing import Any, Dict, List, Optional
 from dataclasses import dataclass, asdict
 
 from app.policies.sqlite_client import SQLiteClient
+from app.utils.config import CONFIG
 
 logger = logging.getLogger(__name__)
+
+# Agent ID for negotiation tracking
+AGENT_ID = CONFIG.agent_id
 
 
 @dataclass
@@ -21,6 +25,137 @@ class NegotiationMessage:
     action_taken: str  # ACCEPT_OFFER, REJECT_OFFER, COUNTER_OFFER, EXIT_NEGOTIATION
     timestamp: str
     message_type: str  # initial_proposal, counter_proposal, etc.
+
+
+class NegotiationThreadTransaction:
+    """Context manager for transactional negotiation operations.
+
+    This context manager provides clean error handling and transactional semantics
+    for negotiation database operations. It automatically handles exceptions and
+    logs errors consistently.
+
+    Example usage:
+        async with NegotiationThreadTransaction() as txn:
+            await txn.cancel_competing(order_id, their_order_id, negotiation_id)
+
+        # Or with custom component name for logging:
+        async with NegotiationThreadTransaction("ACCEPT_OFFER") as txn:
+            await txn.cancel_competing(order_id, their_order_id, negotiation_id)
+    """
+
+    def __init__(self, component: str = "NEGOTIATION"):
+        """Initialize transaction context manager.
+
+        Args:
+            component: Component name for logging (e.g., "NEGOTIATION", "ACCEPT_OFFER")
+        """
+        self.component = component
+        self.thread_store = None
+
+    async def __aenter__(self):
+        """Enter context manager and get thread store."""
+        self.thread_store = get_thread_store()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Exit context manager and handle any exceptions.
+
+        Args:
+            exc_type: Exception type if an exception occurred
+            exc_val: Exception value if an exception occurred
+            exc_tb: Exception traceback if an exception occurred
+
+        Returns:
+            False to propagate the exception (True would suppress it)
+        """
+        if exc_type:
+            logger.error(
+                f"[{self.component}] Transaction failed: {exc_val}",
+                exc_info=(exc_type, exc_val, exc_tb),
+            )
+            # Return False to propagate exceptions - failures should be visible
+            return False
+        return False
+
+    async def cancel_competing(
+        self,
+        order_id: str | None,
+        their_order_id: str | None,
+        except_negotiation_id: str | None,
+    ) -> None:
+        """Cancel competing negotiations for both orders.
+
+        Args:
+            order_id: Our order ID
+            their_order_id: Their order ID
+            except_negotiation_id: Negotiation ID to exclude from cancellation
+        """
+        if not self.thread_store:
+            logger.warning(f"[{self.component}] No thread store available")
+            return
+
+        for oid in [order_id, their_order_id]:
+            if not oid:
+                continue
+            canceled = await self.thread_store._sqlite.cancel_negotiations_for_order(
+                order_id=oid,
+                except_negotiation_id=except_negotiation_id,
+            )
+            if canceled:
+                logger.info(
+                    f"[{self.component}] Canceled {len(canceled)} competing "
+                    f"negotiations for {oid}"
+                )
+
+    async def filter_active(self, order_id: str) -> set[str]:
+        """Get set of order IDs already in active negotiations.
+
+        Args:
+            order_id: Our order ID
+
+        Returns:
+            Set of order IDs currently in active negotiations with our order
+        """
+        if not self.thread_store:
+            logger.warning(f"[{self.component}] No thread store available")
+            return set()
+
+        active_negotiations = await self.thread_store._sqlite.get_active_negotiations_for_order(
+            order_id=order_id
+        )
+
+        active_order_ids = set()
+        for neg in active_negotiations:
+            if neg["our_order_id"] == order_id:
+                active_order_ids.add(neg["their_order_id"])
+            elif neg["their_order_id"] == order_id:
+                active_order_ids.add(neg["our_order_id"])
+
+        return active_order_ids
+
+    async def check_duplicate(
+        self,
+        our_order_id: str,
+        their_order_id: str,
+    ) -> bool:
+        """Check if a negotiation already exists between two orders.
+
+        Args:
+            our_order_id: Our order ID
+            their_order_id: Their order ID
+
+        Returns:
+            True if negotiation already exists, False otherwise
+        """
+        if not self.thread_store:
+            logger.warning(f"[{self.component}] No thread store available")
+            return False
+
+        existing = await self.thread_store._sqlite.check_existing_negotiation(
+            our_order_id=our_order_id,
+            their_order_id=their_order_id,
+        )
+        return existing is not None
 
 
 class NegotiationThreadStore:
@@ -85,7 +220,7 @@ class NegotiationThreadStore:
         message_type: str = "proposal",
     ) -> int:
         """Add a message to the negotiation thread.
-        
+
         Args:
             negotiation_id: Unique negotiation identifier
             sender: Agent ID or card URL of the sender
@@ -94,19 +229,16 @@ class NegotiationThreadStore:
             proposed_price: Proposed counter price (if action is COUNTER_OFFER)
             action_taken: Action taken (ACCEPT_OFFER, REJECT_OFFER, COUNTER_OFFER, EXIT_NEGOTIATION)
             message_type: Type of message (initial_proposal, counter_proposal, etc.)
-            
+
         Returns:
-            Round number (0-indexed)
+            Round number that was assigned (computed atomically)
         """
-        # Load existing thread to determine next round number
-        existing_thread = await self.get_thread(negotiation_id)
-        round_num = len(existing_thread)
-        
         timestamp = datetime.now().isoformat()
-        
-        await self._sqlite.save_negotiation_message(
+
+        # Let SQLite compute the next round number atomically to avoid race conditions
+        round_num = await self._sqlite.save_negotiation_message(
             negotiation_id=negotiation_id,
-            round=round_num,
+            round=None,  # Computed atomically in SQLite
             sender=sender,
             our_price=our_price,
             their_price=their_price,
@@ -115,9 +247,9 @@ class NegotiationThreadStore:
             message_type=message_type,
             timestamp=timestamp,
         )
-        
+
         logger.debug(f"[NEGOTIATION THREAD] Added message to {negotiation_id}, round {round_num}, action: {action_taken}")
-        
+
         return round_num
     
     async def check_terminal(self, negotiation_id: str) -> tuple[bool, str | None]:
@@ -176,6 +308,58 @@ class NegotiationThreadStore:
         """Clear a negotiation thread (after terminal condition reached)."""
         await self._sqlite.delete_negotiation_thread(negotiation_id=negotiation_id)
         logger.debug(f"[NEGOTIATION THREAD] Cleared thread {negotiation_id}")
+
+    async def get_or_create_thread_for_incoming_offer(
+        self,
+        their_order_id: str,
+        their_agent_id: str,
+        our_order_id: str | None = None,
+    ) -> str | None:
+        """Get existing thread or create one for an incoming offer.
+
+        This prevents duplicate negotiations when the same counterparty sends
+        multiple offers before we respond.
+
+        Args:
+            their_order_id: The order ID from the incoming offer
+            their_agent_id: The agent URL/ID of the sender
+            our_order_id: Our order ID (if we have one)
+
+        Returns:
+            The negotiation_id if thread exists or was created, None otherwise
+        """
+        # First check if a thread already exists
+        existing = await self._sqlite.check_existing_negotiation(
+            our_order_id=our_order_id or "",
+            their_order_id=their_order_id,
+            our_agent_id=AGENT_ID if our_order_id else None,
+            their_agent_id=their_agent_id,
+        )
+        if existing:
+            logger.debug(
+                f"[NEGOTIATION THREAD] Found existing thread {existing['negotiation_id']} "
+                f"for incoming offer from {their_agent_id}"
+            )
+            return existing["negotiation_id"]
+
+        # Create new thread to track this incoming offer
+        negotiation_id = f"{our_order_id or 'no_our_order'}_{their_order_id}_{their_agent_id[:8]}"
+        try:
+            await self.create_thread(
+                negotiation_id=negotiation_id,
+                our_order_id=our_order_id or "",
+                their_order_id=their_order_id,
+                our_agent_id=AGENT_ID,
+                their_agent_id=their_agent_id,
+            )
+            logger.info(
+                f"[NEGOTIATION THREAD] Created thread {negotiation_id} for incoming offer "
+                f"from {their_agent_id}, order {their_order_id}"
+            )
+            return negotiation_id
+        except Exception as e:
+            logger.warning(f"[NEGOTIATION THREAD] Failed to create thread for incoming offer: {e}")
+            return None
 
 
 # Global thread store instance (will be initialized by agent)

--- a/agents/a2a-agent-trader/app/policies/negotiation_thread.py
+++ b/agents/a2a-agent-trader/app/policies/negotiation_thread.py
@@ -184,8 +184,10 @@ class NegotiationThreadTransaction:
         their_order_id: str,
         our_agent_id: str,
         their_agent_id: str,
+        our_initial_price: int | None = None,
+        our_strategy: str | None = None,
     ) -> None:
-        """Get or create negotiation thread.
+        """Get or create negotiation thread
 
         Args:
             negotiation_id: Unique ID for this negotiation
@@ -193,12 +195,18 @@ class NegotiationThreadTransaction:
             their_order_id: Their order ID
             our_agent_id: Our agent ID
             their_agent_id: Their agent ID
+            our_initial_price: Our initial price (floor for maximizer, ceiling for minimizer)
+            our_strategy: Our strategy ('minimize' or 'maximize')
         """
         if not self.thread_store:
             logger.warning(f"[{self.component}] No thread store available")
             return
 
-        existing = await self.thread_store.get_thread(negotiation_id)
+        # Pass owner_id=AGENT_ID to identify which agent's private state to access
+        existing = await self.thread_store.get_thread_info(
+            negotiation_id=negotiation_id,
+            owner_id=AGENT_ID
+        )
         if not existing:
             await self.thread_store.create_thread(
                 negotiation_id=negotiation_id,
@@ -206,6 +214,9 @@ class NegotiationThreadTransaction:
                 their_order_id=their_order_id,
                 our_agent_id=our_agent_id,
                 their_agent_id=their_agent_id,
+                owner_id=AGENT_ID,  # We are the owner of this private state
+                our_initial_price=our_initial_price,
+                our_strategy=our_strategy,
             )
             logger.debug(f"[{self.component}] Created thread {negotiation_id}")
 
@@ -270,19 +281,56 @@ class NegotiationThreadStore:
         their_order_id: str,
         our_agent_id: str,
         their_agent_id: str,
+        owner_id: str,
+        our_initial_price: int | None = None,
+        our_strategy: str | None = None,
     ) -> None:
-        """Create a new negotiation thread with order and agent tracking."""
+        """Create a new negotiation thread with private local state.
+        
+        Args:
+            negotiation_id: Unique negotiation identifier
+            our_order_id: Our order ID
+            their_order_id: Their order ID
+            our_agent_id: Our agent ID
+            their_agent_id: Their agent ID
+            owner_id: ID of the agent owning this private state
+            our_initial_price: Private initial price
+            our_strategy: Private strategy
+        """
         await self._sqlite.create_negotiation_thread(
             negotiation_id=negotiation_id,
             our_order_id=our_order_id,
             their_order_id=their_order_id,
             our_agent_id=our_agent_id,
             their_agent_id=their_agent_id,
+            owner_id=owner_id,
+            our_initial_price=our_initial_price,
+            our_strategy=our_strategy,
         )
         logger.debug(
             f"[NEGOTIATION THREAD] Created thread {negotiation_id} "
             f"for orders {our_order_id} <-> {their_order_id} "
             f"agents {our_agent_id} <-> {their_agent_id}"
+        )
+    
+    async def get_thread_info(
+        self,
+        negotiation_id: str,
+        owner_id: str,
+    ) -> Dict[str, Any] | None:
+        """Get negotiation thread metadata.
+        
+        Args:
+            negotiation_id: Unique negotiation identifier
+            owner_id: ID of the agent requesting the info
+            
+        Returns:
+            Dictionary with thread info including our_initial_price and our_strategy,
+            or None if thread doesn't exist.
+        """
+        return await self._sqlite.get_thread_info(
+            negotiation_id=negotiation_id,
+            owner_id=owner_id
         )
     
     async def get_thread(self, negotiation_id: str) -> List[Dict[str, Any]]:

--- a/agents/a2a-agent-trader/app/policies/negotiation_thread.py
+++ b/agents/a2a-agent-trader/app/policies/negotiation_thread.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from datetime import datetime
 from typing import Any, Dict, List, Optional
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass
 
 from app.policies.sqlite_client import SQLiteClient
 from app.utils.config import CONFIG
@@ -156,6 +156,93 @@ class NegotiationThreadTransaction:
             their_order_id=their_order_id,
         )
         return existing is not None
+
+    async def mark_terminal(self, negotiation_id: str, state: str) -> None:
+        """Mark negotiation as terminal (success/failure/timeout).
+
+        Args:
+            negotiation_id: The negotiation to mark as terminal
+            state: Terminal state - one of "success", "failure", "timeout"
+        """
+        if not self.thread_store:
+            logger.warning(f"[{self.component}] No thread store available")
+            return
+
+        try:
+            await self.thread_store._sqlite.update_negotiation_thread_terminal(
+                negotiation_id=negotiation_id,
+                terminal_state=state,
+            )
+            logger.info(f"[{self.component}] Marked negotiation {negotiation_id} as {state}")
+        except Exception as e:
+            logger.error(f"[{self.component}] Failed to mark terminal: {e}")
+
+    async def ensure_thread(
+        self,
+        negotiation_id: str,
+        our_order_id: str,
+        their_order_id: str,
+        our_agent_id: str,
+        their_agent_id: str,
+    ) -> None:
+        """Get or create negotiation thread.
+
+        Args:
+            negotiation_id: Unique ID for this negotiation
+            our_order_id: Our order ID
+            their_order_id: Their order ID
+            our_agent_id: Our agent ID
+            their_agent_id: Their agent ID
+        """
+        if not self.thread_store:
+            logger.warning(f"[{self.component}] No thread store available")
+            return
+
+        existing = await self.thread_store.get_thread(negotiation_id)
+        if not existing:
+            await self.thread_store.create_thread(
+                negotiation_id=negotiation_id,
+                our_order_id=our_order_id,
+                their_order_id=their_order_id,
+                our_agent_id=our_agent_id,
+                their_agent_id=their_agent_id,
+            )
+            logger.debug(f"[{self.component}] Created thread {negotiation_id}")
+
+    async def add_message(
+        self,
+        negotiation_id: str,
+        sender: str,
+        our_price: int | None = None,
+        their_price: int | None = None,
+        proposed_price: int | None = None,
+        action_taken: str = "",
+        message_type: str = "",
+    ) -> None:
+        """Add message to negotiation thread.
+
+        Args:
+            negotiation_id: The negotiation thread ID
+            sender: Agent ID of sender
+            our_price: Our price in this message
+            their_price: Their price in this message
+            proposed_price: Proposed counter price
+            action_taken: Action taken (ACCEPT_OFFER, COUNTER_OFFER, etc.)
+            message_type: Type of message (initial_proposal, counter_proposal, etc.)
+        """
+        if not self.thread_store:
+            logger.warning(f"[{self.component}] No thread store available")
+            return
+
+        await self.thread_store.add_message(
+            negotiation_id=negotiation_id,
+            sender=sender,
+            our_price=our_price,
+            their_price=their_price,
+            proposed_price=proposed_price,
+            action_taken=action_taken,
+            message_type=message_type,
+        )
 
 
 class NegotiationThreadStore:

--- a/agents/a2a-agent-trader/app/policies/sqlite_client.py
+++ b/agents/a2a-agent-trader/app/policies/sqlite_client.py
@@ -104,6 +104,26 @@ class SQLiteClient:
                 cur.execute("ALTER TABLE negotiation_threads ADD COLUMN status TEXT DEFAULT 'active'")
             except sqlite3.OperationalError:
                 pass
+            try:
+                cur.execute("ALTER TABLE negotiation_threads ADD COLUMN our_initial_price INTEGER")
+            except sqlite3.OperationalError:
+                pass
+            try:
+                cur.execute("ALTER TABLE negotiation_threads ADD COLUMN our_strategy TEXT")
+            except sqlite3.OperationalError:
+                pass
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS negotiation_local_state (
+                  negotiation_id TEXT NOT NULL,
+                  owner_id TEXT NOT NULL,
+                  our_initial_price INTEGER,
+                  our_strategy TEXT,
+                  PRIMARY KEY(negotiation_id, owner_id),
+                  FOREIGN KEY(negotiation_id) REFERENCES negotiation_threads(negotiation_id)
+                )
+                """
+            )
             # Negotiation messages table
             cur.execute(
                 """
@@ -536,6 +556,11 @@ class SQLiteClient:
                     "DELETE FROM negotiation_messages WHERE negotiation_id = ?",
                     (negotiation_id,),
                 )
+                # Delete local state
+                cur.execute(
+                    "DELETE FROM negotiation_local_state WHERE negotiation_id = ?",
+                    (negotiation_id,),
+                )
                 # Delete thread
                 cur.execute(
                     "DELETE FROM negotiation_threads WHERE negotiation_id = ?",
@@ -555,17 +580,34 @@ class SQLiteClient:
         their_order_id: str,
         our_agent_id: str,
         their_agent_id: str,
+        owner_id: str,  # The agent creating this record
         status: str = "active",
+        our_initial_price: int | None = None,
+        our_strategy: str | None = None,
     ) -> None:
-        """Create a new negotiation thread with order and agent tracking."""
+        """Create a new negotiation thread with private local state.
+        
+        Args:
+            negotiation_id: Unique negotiation identifier
+            our_order_id: Our order ID
+            their_order_id: Their order ID
+            our_agent_id: Our agent ID (participant A)
+            their_agent_id: Their agent ID (participant B)
+            owner_id: ID of the agent owning this private state
+            status: Initial status (default: 'active')
+            our_initial_price: Private initial price
+            our_strategy: Private strategy
+        """
         def _create() -> None:
             conn = sqlite3.connect(self.db_path)
             try:
                 cur = conn.cursor()
                 timestamp = datetime.now().isoformat()
+                
+                # Insert public thread info (ignore if exists, it's shared)
                 cur.execute(
                     """
-                    INSERT INTO negotiation_threads(
+                    INSERT OR IGNORE INTO negotiation_threads(
                         negotiation_id, our_order_id, their_order_id,
                         our_agent_id, their_agent_id, status, created_at, updated_at
                     )
@@ -576,10 +618,74 @@ class SQLiteClient:
                         our_agent_id, their_agent_id, status, timestamp, timestamp
                     ),
                 )
+                
+                # Insert private local state (upsert if needed)
+                cur.execute(
+                    """
+                    INSERT INTO negotiation_local_state(
+                        negotiation_id, owner_id, our_initial_price, our_strategy
+                    )
+                    VALUES (?, ?, ?, ?)
+                    ON CONFLICT(negotiation_id, owner_id) DO UPDATE SET
+                        our_initial_price = excluded.our_initial_price,
+                        our_strategy = excluded.our_strategy
+                    """,
+                    (negotiation_id, owner_id, our_initial_price, our_strategy),
+                )
+                
                 conn.commit()
             finally:
                 conn.close()
         await asyncio.to_thread(_create)
+
+    async def get_thread_info(
+        self,
+        *,
+        negotiation_id: str,
+        owner_id: str,
+    ) -> dict[str, Any] | None:
+        """Get negotiation thread metadata joining public thread with private local state.
+        
+        Args:
+            negotiation_id: Unique negotiation identifier
+            owner_id: ID of the agent requesting the info
+        
+        Returns:
+            Merged dictionary with public + private info, or None if thread doesn't exist.
+        """
+        def _get() -> dict[str, Any] | None:
+            conn = sqlite3.connect(self.db_path)
+            try:
+                cur = conn.cursor()
+                cur.execute(
+                    """
+                    SELECT t.negotiation_id, t.our_order_id, t.their_order_id,
+                           t.our_agent_id, t.their_agent_id, t.status,
+                           l.our_initial_price, l.our_strategy
+                    FROM negotiation_threads t
+                    LEFT JOIN negotiation_local_state l 
+                           ON t.negotiation_id = l.negotiation_id AND l.owner_id = ?
+                    WHERE t.negotiation_id = ?
+                    """,
+                    (owner_id, negotiation_id),
+                )
+                row = cur.fetchone()
+                if row:
+                    return {
+                        "negotiation_id": row[0],
+                        "our_order_id": row[1],
+                        "their_order_id": row[2],
+                        "our_agent_id": row[3],
+                        "their_agent_id": row[4],
+                        "status": row[5],
+                        # Default to None if no local state found for this owner
+                        "our_initial_price": row[6],
+                        "our_strategy": row[7],
+                    }
+                return None
+            finally:
+                conn.close()
+        return await asyncio.to_thread(_get)
 
     async def check_existing_negotiation(
         self,

--- a/agents/a2a-agent-trader/app/policies/sqlite_client.py
+++ b/agents/a2a-agent-trader/app/policies/sqlite_client.py
@@ -369,7 +369,7 @@ class SQLiteClient:
         self,
         *,
         negotiation_id: str,
-        round: int,
+        round: int | None = None,
         sender: str,
         our_price: int | None,
         their_price: int | None,
@@ -377,9 +377,24 @@ class SQLiteClient:
         action_taken: str,
         message_type: str,
         timestamp: str,
-    ) -> None:
-        """Save a negotiation message to the database."""
-        def _save() -> None:
+    ) -> int:
+        """Save a negotiation message to the database.
+
+        Args:
+            negotiation_id: Unique negotiation identifier
+            round: Round number (if None, computed atomically as max(round) + 1)
+            sender: Agent ID or card URL of the sender
+            our_price: Our price in base units
+            their_price: Their price in base units
+            proposed_price: Proposed counter price
+            action_taken: Action taken (ACCEPT_OFFER, REJECT_OFFER, COUNTER_OFFER, EXIT_NEGOTIATION)
+            message_type: Type of message (initial_proposal, counter_proposal, etc.)
+            timestamp: ISO format timestamp
+
+        Returns:
+            The actual round number that was assigned
+        """
+        def _save() -> int:
             conn = sqlite3.connect(self.db_path)
             try:
                 cur = conn.cursor()
@@ -391,6 +406,21 @@ class SQLiteClient:
                     """,
                     (negotiation_id, timestamp, timestamp),
                 )
+
+                if round is None:
+                    # Compute next round atomically to avoid race conditions
+                    cur.execute(
+                        """
+                        SELECT COALESCE(MAX(round), -1) + 1
+                        FROM negotiation_messages
+                        WHERE negotiation_id = ?
+                        """,
+                        (negotiation_id,),
+                    )
+                    actual_round = cur.fetchone()[0]
+                else:
+                    actual_round = round
+
                 # Update thread updated_at
                 cur.execute(
                     """
@@ -398,7 +428,7 @@ class SQLiteClient:
                     """,
                     (timestamp, negotiation_id),
                 )
-                # Insert message
+                # Insert message with ON CONFLICT handling to gracefully handle races
                 cur.execute(
                     """
                     INSERT INTO negotiation_messages(
@@ -406,17 +436,26 @@ class SQLiteClient:
                         proposed_price, action_taken, message_type, timestamp
                     )
                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(negotiation_id, round) DO UPDATE SET
+                        sender = excluded.sender,
+                        our_price = excluded.our_price,
+                        their_price = excluded.their_price,
+                        proposed_price = excluded.proposed_price,
+                        action_taken = excluded.action_taken,
+                        message_type = excluded.message_type,
+                        timestamp = excluded.timestamp
                     """,
                     (
-                        negotiation_id, round, sender, our_price, their_price,
+                        negotiation_id, actual_round, sender, our_price, their_price,
                         proposed_price, action_taken, message_type, timestamp
                     ),
                 )
                 conn.commit()
+                return actual_round
             finally:
                 conn.close()
-        
-        await asyncio.to_thread(_save)
+
+        return await asyncio.to_thread(_save)
 
     async def load_negotiation_thread(
         self,

--- a/agents/a2a-agent-trader/app/policies/sqlite_client.py
+++ b/agents/a2a-agent-trader/app/policies/sqlite_client.py
@@ -104,14 +104,6 @@ class SQLiteClient:
                 cur.execute("ALTER TABLE negotiation_threads ADD COLUMN status TEXT DEFAULT 'active'")
             except sqlite3.OperationalError:
                 pass
-            try:
-                cur.execute("ALTER TABLE negotiation_threads ADD COLUMN our_initial_price INTEGER")
-            except sqlite3.OperationalError:
-                pass
-            try:
-                cur.execute("ALTER TABLE negotiation_threads ADD COLUMN our_strategy TEXT")
-            except sqlite3.OperationalError:
-                pass
             cur.execute(
                 """
                 CREATE TABLE IF NOT EXISTS negotiation_local_state (

--- a/agents/a2a-agent-trader/app/policies/store.py
+++ b/agents/a2a-agent-trader/app/policies/store.py
@@ -302,16 +302,17 @@ def negotiation_guard_always_negotiate_on_price_diff(context: DecisionContext) -
         return None
 
     data = context.event.data or {}
-    our_price = data.get("our_price")
-    their_price = data.get("their_price")
+    
+    their_price = data.get("proposed_price")
+    
+    thread_info = context.market_state.get("thread_info", {})
+    our_price = thread_info.get("our_initial_price")
 
-    # If prices are equal, short-circuit to accept (skip negotiation)
     if our_price is not None and their_price is not None and our_price == their_price:
         logger.info(f"[NEGOTIATION] Prices equal ({our_price}), accepting directly")
         actions = NegotiationActionBuilder(data)
         return actions.accept("price_equal")
 
-    # Prices differ - continue to negotiation policies
     return None
 
 
@@ -319,7 +320,11 @@ def negotiation_guard_always_negotiate_on_price_diff(context: DecisionContext) -
 def negotiation_action_price_interval_concession(context: DecisionContext) -> DomainAction | None:
     """Strategy-aware price-based counter-offer policy using minimizer/maximizer model.
 
-    Strategy types (inferred from order resource types):
+    - their_price: Derived from event's proposed_price (what they're offering)
+    - our_price: Retrieved from local thread state (our_initial_price)
+    - strategy: Retrieved from local thread state (our_strategy)
+
+    Strategy types (inferred from our own order resource types):
     - Minimizer: demanding ComputeResource (wants lowest rate, our_price = ceiling)
     - Maximizer: offering ComputeResource (wants highest rate, our_price = floor)
 
@@ -344,17 +349,23 @@ def negotiation_action_price_interval_concession(context: DecisionContext) -> Do
         return None
 
     data = context.event.data or {}
-    our_price = data.get("our_price")
-    their_price = data.get("their_price")
-    strategy = data.get("strategy")  # "minimize" or "maximize"
     negotiation_history = context.negotiation_history or []
+    their_price = data.get("proposed_price")
+
+    thread_info = context.market_state.get("thread_info", {})
+    our_price = thread_info.get("our_initial_price")
+    strategy = thread_info.get("our_strategy")
 
     if our_price is None or their_price is None:
+        logger.info(f"[NEGOTIATION] Missing price data: our_price={our_price}, their_price={their_price}")
         return None  # Pass to next policy if price data missing
 
     # Ensure negotiation_id is in data for the builder
     if context.event.negotiation_id and "negotiation_id" not in data:
         data = {**data, "negotiation_id": context.event.negotiation_id}
+    
+    # Add our_price and their_price to data for action builder
+    data = {**data, "our_price": our_price, "their_price": their_price}
 
     # Create action builder for clean action construction
     actions = NegotiationActionBuilder(data)
@@ -497,8 +508,11 @@ def negotiation_action_safe_default_reject(context: DecisionContext) -> DomainAc
         return None
 
     data = context.event.data or {}
-    our_price = data.get("our_price")
-    their_price = data.get("their_price")
+    
+    their_price = data.get("proposed_price")
+    
+    thread_info = context.market_state.get("thread_info", {})
+    our_price = thread_info.get("our_initial_price")
 
     # Build data dict for action builder
     if context.event.negotiation_id and "negotiation_id" not in data:

--- a/agents/a2a-agent-trader/app/policies/store.py
+++ b/agents/a2a-agent-trader/app/policies/store.py
@@ -19,6 +19,7 @@ from app.schema.pydantic_models import (
 )
 from app.policies.registry import policy_callable
 from app.policies.sqlite_client import SQLiteClient
+from app.policies.action_builders import NegotiationActionBuilder
 from app.utils.validation import extract_resources_from_make_offer_event
 
 CacheKey = Tuple[str, str]  # (agent_id, trigger_type)
@@ -283,37 +284,33 @@ def mo_guard_trigger_is_make_offer(context: DecisionContext) -> DomainAction | N
 @policy_callable("negotiation.guard.always_negotiate_on_price_diff")
 def negotiation_guard_always_negotiate_on_price_diff(context: DecisionContext) -> DomainAction | None:
     """Admission policy: Always negotiate when prices differ, accept when equal.
-    
+
     CGT role: Implements the "Entry Decision → Negotiation Game" handoff from
     Reactive Decision Pattern to Strategic Interaction Pattern.
-    
+
     Returns:
         None to pass to next policy (continue negotiation), or
         ACCEPT_OFFER if prices are equal (skip negotiation)
     """
-    from app.schema.pydantic_models import ActionType
-    
     et = context.event.event_type
     trigger = et.value if hasattr(et, "value") else str(et)
     if trigger != "negotiation":
         return None
-    
+
     # Check if this is a negotiation event with price data
     if not isinstance(context.event, NegotiationEvent):
         return None
-    
+
     data = context.event.data or {}
     our_price = data.get("our_price")
     their_price = data.get("their_price")
-    
+
     # If prices are equal, short-circuit to accept (skip negotiation)
     if our_price is not None and their_price is not None and our_price == their_price:
         logger.info(f"[NEGOTIATION] Prices equal ({our_price}), accepting directly")
-        return DomainAction(action_type=ActionType.ACCEPT_OFFER, parameters={
-            "order_id": data.get("their_order_id"),
-            "reason": "price_equal",
-        })
-    
+        actions = NegotiationActionBuilder(data)
+        return actions.accept("price_equal")
+
     # Prices differ - continue to negotiation policies
     return None
 
@@ -338,8 +335,6 @@ def negotiation_action_price_interval_concession(context: DecisionContext) -> Do
         COUNTER_OFFER with proposed price if outside but reasonable,
         EXIT_NEGOTIATION if far outside our band
     """
-    from app.schema.pydantic_models import ActionType
-
     et = context.event.event_type
     trigger = et.value if hasattr(et, "value") else str(et)
     if trigger != "negotiation":
@@ -357,6 +352,13 @@ def negotiation_action_price_interval_concession(context: DecisionContext) -> Do
     if our_price is None or their_price is None:
         return None  # Pass to next policy if price data missing
 
+    # Ensure negotiation_id is in data for the builder
+    if context.event.negotiation_id and "negotiation_id" not in data:
+        data = {**data, "negotiation_id": context.event.negotiation_id}
+
+    # Create action builder for clean action construction
+    actions = NegotiationActionBuilder(data)
+
     # Role-aware price acceptance logic
     if role == "buyer":
         # Buyer: our_price is the MAX we're willing to pay
@@ -367,12 +369,7 @@ def negotiation_action_price_interval_concession(context: DecisionContext) -> Do
         max_acceptable = int(our_price * 1.2)
         if min_acceptable <= their_price <= max_acceptable:
             logger.info(f"[NEGOTIATION][BUYER] Their price {their_price} in range [{min_acceptable}, {max_acceptable}], accepting")
-            return DomainAction(action_type=ActionType.ACCEPT_OFFER, parameters={
-                "order_id": data.get("their_order_id"),
-                "reason": "within_buyer_band",
-                "our_price": their_price,
-                "their_price": their_price,
-            })
+            return actions.accept("within_buyer_band")
 
         # Check if reasonable for counter-offer (50%-200% of our price)
         reasonable_min = int(our_price * 0.5)
@@ -389,21 +386,11 @@ def negotiation_action_price_interval_concession(context: DecisionContext) -> Do
 
             proposed_price = (last_our_proposal + their_price) // 2
             logger.info(f"[NEGOTIATION][BUYER] Counter-offering {proposed_price} (between {last_our_proposal} and {their_price})")
-            return DomainAction(action_type=ActionType.COUNTER_OFFER, parameters={
-                "order_id": data.get("their_order_id"),
-                "negotiation_id": context.event.negotiation_id,
-                "proposed_price": proposed_price,
-                "our_price": our_price,
-                "their_price": their_price,
-            })
+            return actions.counter(proposed_price)
         else:
             # Far outside reasonable range
             logger.info(f"[NEGOTIATION][BUYER] Their price {their_price} far outside reasonable [{reasonable_min}, {reasonable_max}], exiting")
-            return DomainAction(action_type=ActionType.EXIT_NEGOTIATION, parameters={
-                "order_id": data.get("their_order_id"),
-                "negotiation_id": context.event.negotiation_id,
-                "reason": "price_far_outside_range",
-            })
+            return actions.exit("price_far_outside_range")
 
     elif role == "seller":
         # Seller: our_price is the MIN we're willing to accept
@@ -414,12 +401,7 @@ def negotiation_action_price_interval_concession(context: DecisionContext) -> Do
         max_acceptable = int(our_price * 2.0)
         if min_acceptable <= their_price <= max_acceptable:
             logger.info(f"[NEGOTIATION][SELLER] Their price {their_price} in range [{min_acceptable}, {max_acceptable}], accepting")
-            return DomainAction(action_type=ActionType.ACCEPT_OFFER, parameters={
-                "order_id": data.get("their_order_id"),
-                "reason": "within_seller_band",
-                "our_price": their_price,
-                "their_price": their_price,
-            })
+            return actions.accept("within_seller_band")
 
         # Check if reasonable for counter-offer (50%-200% of our price)
         reasonable_min = int(our_price * 0.5)
@@ -436,21 +418,11 @@ def negotiation_action_price_interval_concession(context: DecisionContext) -> Do
 
             proposed_price = (last_our_proposal + their_price) // 2
             logger.info(f"[NEGOTIATION][SELLER] Counter-offering {proposed_price} (between {last_our_proposal} and {their_price})")
-            return DomainAction(action_type=ActionType.COUNTER_OFFER, parameters={
-                "order_id": data.get("their_order_id"),
-                "negotiation_id": context.event.negotiation_id,
-                "proposed_price": proposed_price,
-                "our_price": our_price,
-                "their_price": their_price,
-            })
+            return actions.counter(proposed_price)
         else:
             # Far outside reasonable range
             logger.info(f"[NEGOTIATION][SELLER] Their price {their_price} far outside reasonable [{reasonable_min}, {reasonable_max}], exiting")
-            return DomainAction(action_type=ActionType.EXIT_NEGOTIATION, parameters={
-                "order_id": data.get("their_order_id"),
-                "negotiation_id": context.event.negotiation_id,
-                "reason": "price_far_outside_range",
-            })
+            return actions.exit("price_far_outside_range")
 
     else:
         # No role specified - pass to next policy
@@ -461,47 +433,46 @@ def negotiation_action_price_interval_concession(context: DecisionContext) -> Do
 @policy_callable("negotiation.guard.bounded_rounds_and_timeout")
 def negotiation_guard_bounded_rounds_and_timeout(context: DecisionContext) -> DomainAction | None:
     """Thread/termination policy: Enforce round limits and timeout.
-    
+
     CGT role: Encodes the terminal checks and TIMEOUT/FAILURE outcomes
     from the Bilateral Negotiation Actions diagram.
-    
+
     Returns:
         EXIT_NEGOTIATION if limits exceeded, None otherwise
     """
-    from app.schema.pydantic_models import ActionType
-    from datetime import datetime, timedelta
-    
+    from datetime import datetime
+
     et = context.event.event_type
     trigger = et.value if hasattr(et, "value") else str(et)
     if trigger != "negotiation":
         return None
-    
+
     if not isinstance(context.event, NegotiationEvent):
         return None
-    
+
     negotiation_history = context.negotiation_history or []
     max_rounds = 5  # Configurable default
     timeout_seconds = 300  # 5 minutes default
-    
+
+    # Build data dict for action builder
+    data = context.event.data or {}
+    if context.event.negotiation_id and "negotiation_id" not in data:
+        data = {**data, "negotiation_id": context.event.negotiation_id}
+    actions = NegotiationActionBuilder(data)
+
     # Check round limit
     if len(negotiation_history) >= max_rounds:
         logger.info(f"[NEGOTIATION] Max rounds ({max_rounds}) exceeded, exiting")
-        return DomainAction(action_type=ActionType.EXIT_NEGOTIATION, parameters={
-            "negotiation_id": context.event.negotiation_id,
-            "reason": "max_rounds_exceeded",
-        })
-    
+        return actions.exit("max_rounds_exceeded")
+
     # Check for stale negotiation (no price movement in last 2 rounds)
     if len(negotiation_history) >= 2:
         last_two = negotiation_history[-2:]
         prices = [msg.get("proposed_price") or msg.get("their_price") for msg in last_two if msg.get("proposed_price") or msg.get("their_price")]
         if len(prices) >= 2 and prices[-1] == prices[-2]:
             logger.info(f"[NEGOTIATION] No price movement in last 2 rounds, exiting")
-            return DomainAction(action_type=ActionType.EXIT_NEGOTIATION, parameters={
-                "negotiation_id": context.event.negotiation_id,
-                "reason": "stale_negotiation",
-            })
-    
+            return actions.exit("stale_negotiation")
+
     # Check timeout (if first message has timestamp)
     if negotiation_history:
         first_msg = negotiation_history[0]
@@ -512,13 +483,10 @@ def negotiation_guard_bounded_rounds_and_timeout(context: DecisionContext) -> Do
                 elapsed = (datetime.now(first_timestamp.tzinfo) - first_timestamp).total_seconds()
                 if elapsed > timeout_seconds:
                     logger.info(f"[NEGOTIATION] Timeout ({timeout_seconds}s) exceeded, exiting")
-                    return DomainAction(action_type=ActionType.EXIT_NEGOTIATION, parameters={
-                        "negotiation_id": context.event.negotiation_id,
-                        "reason": "timeout",
-                    })
+                    return actions.exit("timeout")
             except Exception as e:
                 logger.warning(f"[NEGOTIATION] Failed to parse timestamp: {e}")
-    
+
     # No limits exceeded - continue negotiation
     return None
 
@@ -526,52 +494,43 @@ def negotiation_guard_bounded_rounds_and_timeout(context: DecisionContext) -> Do
 @policy_callable("negotiation.action.safe_default_reject")
 def negotiation_action_safe_default_reject(context: DecisionContext) -> DomainAction | None:
     """Fallback/safety policy: Reject if price data is malformed.
-    
+
     CGT role: Ensures all negotiation games terminate cleanly even under error conditions.
-    
+
     Returns:
         REJECT_OFFER if price data is invalid, None otherwise
     """
-    from app.schema.pydantic_models import ActionType
-    
     et = context.event.event_type
     trigger = et.value if hasattr(et, "value") else str(et)
     if trigger != "negotiation":
         return None
-    
+
     if not isinstance(context.event, NegotiationEvent):
         return None
-    
+
     data = context.event.data or {}
     our_price = data.get("our_price")
     their_price = data.get("their_price")
-    
+
+    # Build data dict for action builder
+    if context.event.negotiation_id and "negotiation_id" not in data:
+        data = {**data, "negotiation_id": context.event.negotiation_id}
+    actions = NegotiationActionBuilder(data)
+
     # If price data is missing or invalid, reject for safety
     if our_price is None or their_price is None:
         logger.warning(f"[NEGOTIATION] Missing price data, rejecting for safety")
-        return DomainAction(action_type=ActionType.REJECT_OFFER, parameters={
-            "order_id": data.get("their_order_id"),
-            "negotiation_id": context.event.negotiation_id,
-            "reason": "missing_price_data",
-        })
-    
+        return actions.reject("missing_price_data")
+
     # Check for invalid price values
     if not isinstance(our_price, (int, float)) or not isinstance(their_price, (int, float)):
         logger.warning(f"[NEGOTIATION] Invalid price types, rejecting for safety")
-        return DomainAction(action_type=ActionType.REJECT_OFFER, parameters={
-            "order_id": data.get("their_order_id"),
-            "negotiation_id": context.event.negotiation_id,
-            "reason": "invalid_price_types",
-        })
-    
+        return actions.reject("invalid_price_types")
+
     if our_price <= 0 or their_price <= 0:
         logger.warning(f"[NEGOTIATION] Non-positive prices, rejecting for safety")
-        return DomainAction(action_type=ActionType.REJECT_OFFER, parameters={
-            "order_id": data.get("their_order_id"),
-            "negotiation_id": context.event.negotiation_id,
-            "reason": "non_positive_prices",
-        })
-    
+        return actions.reject("non_positive_prices")
+
     # Price data looks valid - pass to next policy (shouldn't reach here in normal flow)
     return None
 

--- a/agents/a2a-agent-trader/app/policies/store.py
+++ b/agents/a2a-agent-trader/app/policies/store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from typing import Any, Callable, Dict, List, Tuple
 
 from app.policies.evaluator import CallableEvaluator
@@ -21,6 +22,8 @@ from app.policies.sqlite_client import SQLiteClient
 from app.utils.validation import extract_resources_from_make_offer_event
 
 CacheKey = Tuple[str, str]  # (agent_id, trigger_type)
+
+logger = logging.getLogger(__name__)
 
 
 class PolicyStore:
@@ -317,99 +320,142 @@ def negotiation_guard_always_negotiate_on_price_diff(context: DecisionContext) -
 
 @policy_callable("negotiation.action.price_interval_concession")
 def negotiation_action_price_interval_concession(context: DecisionContext) -> DomainAction | None:
-    """Price-based counter-offer policy using reservation band.
-    
+    """Role-aware price-based counter-offer policy using reservation bands.
+
+    Role determination:
+    - Buyer: demanding ComputeResource (offering tokens, wants compute)
+    - Seller: offering ComputeResource (has compute, wants tokens)
+
+    Strategy by role:
+    - Buyer (our_price = max willing to pay): accept if their_price <= our_price * 1.2
+    - Seller (our_price = min willing to accept): accept if their_price >= our_price * 0.8
+
     CGT role: Implements the per-round "Strategic Decision" in the bilateral
     negotiation game, using thread state and resource-aware thresholds.
-    
+
     Returns:
-        ACCEPT_OFFER if their price is within our reservation band,
+        ACCEPT_OFFER if their price is within our role-specific reservation band,
         COUNTER_OFFER with proposed price if outside but reasonable,
         EXIT_NEGOTIATION if far outside our band
     """
     from app.schema.pydantic_models import ActionType
-    
+
     et = context.event.event_type
     trigger = et.value if hasattr(et, "value") else str(et)
     if trigger != "negotiation":
         return None
-    
+
     if not isinstance(context.event, NegotiationEvent):
         return None
-    
+
     data = context.event.data or {}
     our_price = data.get("our_price")
     their_price = data.get("their_price")
+    role = data.get("role")  # "buyer" or "seller"
     negotiation_history = context.negotiation_history or []
-    
+
     if our_price is None or their_price is None:
         return None  # Pass to next policy if price data missing
-    
-    # Determine reservation thresholds from context
-    # Use the band to determine either minimum (selling) or maximum (buying)
-    # This allows for arbitrage opportunities where prices are very favorable
-    # For now, use a simple heuristic: ±20% of our price
-    # In production, derive from market_state, available_resources, etc.
-    min_price = int(our_price * 0.8)  # Minimum we're willing to accept (selling) - at least 80% of our price
-    max_price = int(our_price * 1.2)  # Maximum we're willing to pay (buying) - up to 20% more than our price
-    
-    # Accept if their price is favorable:
-    # - Always accept if their_price < our_price (favorable deal - arbitrage opportunity)
-    #   Example: Alice values at 5 BTC, Bob offers 1 BTC -> Alice accepts
-    # - Also accept if their_price is within our acceptable range:
-    #   * If buying: accept if their_price <= max_price (we're willing to pay up to this)
-    #   * If selling: accept if their_price >= min_price (we want at least this)
-    # Since we don't know if we're buying or selling, we accept if EITHER condition is met
-    # This allows arbitrage while still using reservation bands for less favorable deals
-    is_favorable = their_price < our_price  # Their price is better than ours (always accept)
-    is_within_buying_max = their_price <= max_price  # We're buying and their price is within our max
-    is_within_selling_min = their_price >= min_price  # We're selling and their price is at least our min
-    
-    # Accept if favorable OR within acceptable range (buying or selling)
-    if is_favorable or is_within_buying_max or is_within_selling_min:
-        logger.info(f"[NEGOTIATION] Their price {their_price} is favorable (our: {our_price}, min: {min_price}, max: {max_price}), accepting")
-        return DomainAction(action_type=ActionType.ACCEPT_OFFER, parameters={
-            "order_id": data.get("their_order_id"),
-            "reason": "within_reservation_band",
-            "our_price": their_price,
-            "their_price": their_price,
-        })
-    
-    # Their price is outside our band - check if reasonable
-    # Reasonable = within 2x or 0.5x (not completely unreasonable)
-    reasonable_min = int(our_price * 0.5)
-    reasonable_max = int(our_price * 2.0)
-    
-    if reasonable_min <= their_price <= reasonable_max:
-        # Calculate counter-offer: midpoint between our last proposal and their current
-        # For first round, use midpoint between our_price and their_price
-        last_our_proposal = our_price
-        if negotiation_history:
-            # Find our last proposal from history
-            for msg in reversed(negotiation_history):
-                if msg.get("sender") == context.agent_id and msg.get("proposed_price"):
-                    last_our_proposal = msg.get("proposed_price")
-                    break
-        
-        # Propose midpoint (concession strategy)
-        proposed_price = (last_our_proposal + their_price) // 2
-        
-        logger.info(f"[NEGOTIATION] Counter-offering {proposed_price} (between {last_our_proposal} and {their_price})")
-        return DomainAction(action_type=ActionType.COUNTER_OFFER, parameters={
-            "order_id": data.get("their_order_id"),
-            "negotiation_id": context.event.negotiation_id,
-            "proposed_price": proposed_price,
-            "our_price": our_price,
-            "their_price": their_price,
-        })
+
+    # Role-aware price acceptance logic
+    if role == "buyer":
+        # Buyer: our_price is the MAX we're willing to pay
+        # Strategy: Accept 50-120% (reasonable range), Counter 120-200% (high but reasonable), Exit otherwise
+
+        # Accept if within acceptable range (50%-120% of our max)
+        min_acceptable = int(our_price * 0.5)
+        max_acceptable = int(our_price * 1.2)
+        if min_acceptable <= their_price <= max_acceptable:
+            logger.info(f"[NEGOTIATION][BUYER] Their price {their_price} in range [{min_acceptable}, {max_acceptable}], accepting")
+            return DomainAction(action_type=ActionType.ACCEPT_OFFER, parameters={
+                "order_id": data.get("their_order_id"),
+                "reason": "within_buyer_band",
+                "our_price": their_price,
+                "their_price": their_price,
+            })
+
+        # Check if reasonable for counter-offer (50%-200% of our price)
+        reasonable_min = int(our_price * 0.5)
+        reasonable_max = int(our_price * 2.0)
+
+        if reasonable_min <= their_price <= reasonable_max:
+            # Calculate counter-offer: midpoint between our last proposal and their current
+            last_our_proposal = our_price
+            if negotiation_history:
+                for msg in reversed(negotiation_history):
+                    if msg.get("sender") == context.agent_id and msg.get("proposed_price"):
+                        last_our_proposal = msg.get("proposed_price")
+                        break
+
+            proposed_price = (last_our_proposal + their_price) // 2
+            logger.info(f"[NEGOTIATION][BUYER] Counter-offering {proposed_price} (between {last_our_proposal} and {their_price})")
+            return DomainAction(action_type=ActionType.COUNTER_OFFER, parameters={
+                "order_id": data.get("their_order_id"),
+                "negotiation_id": context.event.negotiation_id,
+                "proposed_price": proposed_price,
+                "our_price": our_price,
+                "their_price": their_price,
+            })
+        else:
+            # Far outside reasonable range
+            logger.info(f"[NEGOTIATION][BUYER] Their price {their_price} far outside reasonable [{reasonable_min}, {reasonable_max}], exiting")
+            return DomainAction(action_type=ActionType.EXIT_NEGOTIATION, parameters={
+                "order_id": data.get("their_order_id"),
+                "negotiation_id": context.event.negotiation_id,
+                "reason": "price_far_outside_range",
+            })
+
+    elif role == "seller":
+        # Seller: our_price is the MIN we're willing to accept
+        # Strategy: Accept 80-200% (reasonable range), Counter 50-80% (low but reasonable), Exit otherwise
+
+        # Accept if within acceptable range (80%-200% of our min)
+        min_acceptable = int(our_price * 0.8)
+        max_acceptable = int(our_price * 2.0)
+        if min_acceptable <= their_price <= max_acceptable:
+            logger.info(f"[NEGOTIATION][SELLER] Their price {their_price} in range [{min_acceptable}, {max_acceptable}], accepting")
+            return DomainAction(action_type=ActionType.ACCEPT_OFFER, parameters={
+                "order_id": data.get("their_order_id"),
+                "reason": "within_seller_band",
+                "our_price": their_price,
+                "their_price": their_price,
+            })
+
+        # Check if reasonable for counter-offer (50%-200% of our price)
+        reasonable_min = int(our_price * 0.5)
+        reasonable_max = int(our_price * 2.0)
+
+        if reasonable_min <= their_price <= reasonable_max:
+            # Calculate counter-offer: midpoint between our last proposal and their current
+            last_our_proposal = our_price
+            if negotiation_history:
+                for msg in reversed(negotiation_history):
+                    if msg.get("sender") == context.agent_id and msg.get("proposed_price"):
+                        last_our_proposal = msg.get("proposed_price")
+                        break
+
+            proposed_price = (last_our_proposal + their_price) // 2
+            logger.info(f"[NEGOTIATION][SELLER] Counter-offering {proposed_price} (between {last_our_proposal} and {their_price})")
+            return DomainAction(action_type=ActionType.COUNTER_OFFER, parameters={
+                "order_id": data.get("their_order_id"),
+                "negotiation_id": context.event.negotiation_id,
+                "proposed_price": proposed_price,
+                "our_price": our_price,
+                "their_price": their_price,
+            })
+        else:
+            # Far outside reasonable range
+            logger.info(f"[NEGOTIATION][SELLER] Their price {their_price} far outside reasonable [{reasonable_min}, {reasonable_max}], exiting")
+            return DomainAction(action_type=ActionType.EXIT_NEGOTIATION, parameters={
+                "order_id": data.get("their_order_id"),
+                "negotiation_id": context.event.negotiation_id,
+                "reason": "price_far_outside_range",
+            })
+
     else:
-        # Far outside reasonable range - exit negotiation
-        logger.info(f"[NEGOTIATION] Their price {their_price} far outside reasonable range [{reasonable_min}, {reasonable_max}], exiting")
-        return DomainAction(action_type=ActionType.EXIT_NEGOTIATION, parameters={
-            "order_id": data.get("their_order_id"),
-            "negotiation_id": context.event.negotiation_id,
-            "reason": "price_far_outside_range",
-        })
+        # No role specified - pass to next policy
+        logger.info(f"[NEGOTIATION] No role specified, passing to next policy")
+        return None
 
 
 @policy_callable("negotiation.guard.bounded_rounds_and_timeout")

--- a/agents/a2a-agent-trader/app/policies/store.py
+++ b/agents/a2a-agent-trader/app/policies/store.py
@@ -317,23 +317,23 @@ def negotiation_guard_always_negotiate_on_price_diff(context: DecisionContext) -
 
 @policy_callable("negotiation.action.price_interval_concession")
 def negotiation_action_price_interval_concession(context: DecisionContext) -> DomainAction | None:
-    """Role-aware price-based counter-offer policy using reservation bands.
+    """Strategy-aware price-based counter-offer policy using minimizer/maximizer model.
 
-    Role determination:
-    - Buyer: demanding ComputeResource (offering tokens, wants compute)
-    - Seller: offering ComputeResource (has compute, wants tokens)
+    Strategy types (inferred from order resource types):
+    - Minimizer: demanding ComputeResource (wants lowest rate, our_price = ceiling)
+    - Maximizer: offering ComputeResource (wants highest rate, our_price = floor)
 
-    Strategy by role:
-    - Buyer (our_price = max willing to pay): accept if their_price <= our_price * 1.2
-    - Seller (our_price = min willing to accept): accept if their_price >= our_price * 0.8
+    Strategy logic:
+    - Minimizer: accept if their_price <= our_price, counter if <= 1.5x, else exit
+    - Maximizer: accept if their_price >= our_price, counter if >= 0.67x, else exit
 
     CGT role: Implements the per-round "Strategic Decision" in the bilateral
     negotiation game, using thread state and resource-aware thresholds.
 
     Returns:
-        ACCEPT_OFFER if their price is within our role-specific reservation band,
-        COUNTER_OFFER with proposed price if outside but reasonable,
-        EXIT_NEGOTIATION if far outside our band
+        ACCEPT_OFFER if their price is favorable,
+        COUNTER_OFFER with proposed price if reasonable but not favorable,
+        EXIT_NEGOTIATION if unreasonable
     """
     et = context.event.event_type
     trigger = et.value if hasattr(et, "value") else str(et)
@@ -346,7 +346,7 @@ def negotiation_action_price_interval_concession(context: DecisionContext) -> Do
     data = context.event.data or {}
     our_price = data.get("our_price")
     their_price = data.get("their_price")
-    role = data.get("role")  # "buyer" or "seller"
+    strategy = data.get("strategy")  # "minimize" or "maximize"
     negotiation_history = context.negotiation_history or []
 
     if our_price is None or their_price is None:
@@ -359,24 +359,19 @@ def negotiation_action_price_interval_concession(context: DecisionContext) -> Do
     # Create action builder for clean action construction
     actions = NegotiationActionBuilder(data)
 
-    # Role-aware price acceptance logic
-    if role == "buyer":
-        # Buyer: our_price is the MAX we're willing to pay
-        # Strategy: Accept 50-120% (reasonable range), Counter 120-200% (high but reasonable), Exit otherwise
+    REASONABLE_MULTIPLIER = 1.5  # Exit threshold
 
-        # Accept if within acceptable range (50%-120% of our max)
-        min_acceptable = int(our_price * 0.5)
-        max_acceptable = int(our_price * 1.2)
-        if min_acceptable <= their_price <= max_acceptable:
-            logger.info(f"[NEGOTIATION][BUYER] Their price {their_price} in range [{min_acceptable}, {max_acceptable}], accepting")
-            return actions.accept("within_buyer_band")
+    # Strategy-aware price acceptance logic
+    if strategy == "minimize":
+        # Minimizer: our_price is the MAX we're willing to pay (ceiling)
+        # Accept if favorable (at or below ceiling), counter if reasonable, exit if unreasonable
 
-        # Check if reasonable for counter-offer (50%-200% of our price)
-        reasonable_min = int(our_price * 0.5)
-        reasonable_max = int(our_price * 2.0)
-
-        if reasonable_min <= their_price <= reasonable_max:
-            # Calculate counter-offer: midpoint between our last proposal and their current
+        if their_price <= our_price:
+            # Favorable - at or below our ceiling
+            logger.info(f"[NEGOTIATION][MINIMIZE] Their price {their_price} <= our_price {our_price}, accepting")
+            return actions.accept("favorable_price")
+        elif their_price <= our_price * REASONABLE_MULTIPLIER:
+            # Above ceiling but reasonable - counter with midpoint
             last_our_proposal = our_price
             if negotiation_history:
                 for msg in reversed(negotiation_history):
@@ -385,30 +380,23 @@ def negotiation_action_price_interval_concession(context: DecisionContext) -> Do
                         break
 
             proposed_price = (last_our_proposal + their_price) // 2
-            logger.info(f"[NEGOTIATION][BUYER] Counter-offering {proposed_price} (between {last_our_proposal} and {their_price})")
+            logger.info(f"[NEGOTIATION][MINIMIZE] Counter-offering {proposed_price} (between {last_our_proposal} and {their_price})")
             return actions.counter(proposed_price)
         else:
-            # Far outside reasonable range
-            logger.info(f"[NEGOTIATION][BUYER] Their price {their_price} far outside reasonable [{reasonable_min}, {reasonable_max}], exiting")
-            return actions.exit("price_far_outside_range")
+            # Unreasonable - far above ceiling
+            logger.info(f"[NEGOTIATION][MINIMIZE] Their price {their_price} > {REASONABLE_MULTIPLIER}x our_price {our_price}, exiting")
+            return actions.exit("price_unreasonable")
 
-    elif role == "seller":
-        # Seller: our_price is the MIN we're willing to accept
-        # Strategy: Accept 80-200% (reasonable range), Counter 50-80% (low but reasonable), Exit otherwise
+    elif strategy == "maximize":
+        # Maximizer: our_price is the MIN we're willing to accept (floor)
+        # Accept if favorable (at or above floor), counter if reasonable, exit if unreasonable
 
-        # Accept if within acceptable range (80%-200% of our min)
-        min_acceptable = int(our_price * 0.8)
-        max_acceptable = int(our_price * 2.0)
-        if min_acceptable <= their_price <= max_acceptable:
-            logger.info(f"[NEGOTIATION][SELLER] Their price {their_price} in range [{min_acceptable}, {max_acceptable}], accepting")
-            return actions.accept("within_seller_band")
-
-        # Check if reasonable for counter-offer (50%-200% of our price)
-        reasonable_min = int(our_price * 0.5)
-        reasonable_max = int(our_price * 2.0)
-
-        if reasonable_min <= their_price <= reasonable_max:
-            # Calculate counter-offer: midpoint between our last proposal and their current
+        if their_price >= our_price:
+            # Favorable - at or above our floor
+            logger.info(f"[NEGOTIATION][MAXIMIZE] Their price {their_price} >= our_price {our_price}, accepting")
+            return actions.accept("favorable_price")
+        elif their_price >= our_price / REASONABLE_MULTIPLIER:
+            # Below floor but reasonable - counter with midpoint
             last_our_proposal = our_price
             if negotiation_history:
                 for msg in reversed(negotiation_history):
@@ -417,16 +405,16 @@ def negotiation_action_price_interval_concession(context: DecisionContext) -> Do
                         break
 
             proposed_price = (last_our_proposal + their_price) // 2
-            logger.info(f"[NEGOTIATION][SELLER] Counter-offering {proposed_price} (between {last_our_proposal} and {their_price})")
+            logger.info(f"[NEGOTIATION][MAXIMIZE] Counter-offering {proposed_price} (between {last_our_proposal} and {their_price})")
             return actions.counter(proposed_price)
         else:
-            # Far outside reasonable range
-            logger.info(f"[NEGOTIATION][SELLER] Their price {their_price} far outside reasonable [{reasonable_min}, {reasonable_max}], exiting")
-            return actions.exit("price_far_outside_range")
+            # Unreasonable - far below floor
+            logger.info(f"[NEGOTIATION][MAXIMIZE] Their price {their_price} < our_price/{REASONABLE_MULTIPLIER} {our_price / REASONABLE_MULTIPLIER}, exiting")
+            return actions.exit("price_unreasonable")
 
     else:
-        # No role specified - pass to next policy
-        logger.info(f"[NEGOTIATION] No role specified, passing to next policy")
+        # No strategy specified - pass to next policy
+        logger.info(f"[NEGOTIATION] No strategy specified, passing to next policy")
         return None
 
 

--- a/agents/a2a-agent-trader/app/policies/store.py
+++ b/agents/a2a-agent-trader/app/policies/store.py
@@ -12,6 +12,7 @@ from app.schema.pydantic_models import (
     ArbitrationCompleteEvent,
     DecisionContext,
     MakeOfferEvent,
+    MarketOrder,
     NegotiationEvent,
     ComputeResource,
     TokenResource,
@@ -20,7 +21,13 @@ from app.schema.pydantic_models import (
 from app.policies.registry import policy_callable
 from app.policies.sqlite_client import SQLiteClient
 from app.policies.action_builders import NegotiationActionBuilder
-from app.utils.validation import extract_resources_from_make_offer_event
+from app.utils.validation import (
+    extract_resources_from_make_offer_event,
+    determine_strategy_from_order,
+)
+from app.utils.registry_client import get_registry_client
+from app.utils.action_executor import _extract_initial_price_from_order
+from app.utils.config import CONFIG
 
 CacheKey = Tuple[str, str]  # (agent_id, trigger_type)
 
@@ -594,3 +601,75 @@ def mo_action_accept_offer(context: DecisionContext) -> DomainAction | None:
             "demand_resource": demand_resource.model_dump(mode='json'),
         }
     )
+
+
+@policy_callable("negotiation.respond_to_make_offer")
+async def negotiation_respond_to_make_offer(context: DecisionContext) -> DomainAction | None:
+    et = context.event.event_type
+    if et.value != "make_offer":
+        return None
+    if not isinstance(context.event, MakeOfferEvent):
+        return None
+
+    order_obj = context.event.order
+    if not order_obj:
+        return None
+
+    # Convert to dict if it's a MarketOrder model
+    if isinstance(order_obj, MarketOrder):
+        incoming_order = order_obj.model_dump(mode="json")
+    else:
+        incoming_order = order_obj
+
+    their_proposed_price = _extract_initial_price_from_order(incoming_order)
+    registry_client = get_registry_client()
+    our_orders = await registry_client.query_orders({"status": "open"})
+    our_order = None
+
+    for order_dict in our_orders:
+        if order_dict.get("order_id") == incoming_order.get("order_id"):
+            continue
+        order = MarketOrder.model_validate(order_dict)
+        if determine_strategy_from_order(order):
+            our_order = order_dict
+            break
+
+    if not our_order:
+        actions = NegotiationActionBuilder({})
+        return actions.reject("no_matching_order")
+
+    market_order = MarketOrder.model_validate(our_order)
+    strategy = determine_strategy_from_order(market_order)
+    our_price = _extract_initial_price_from_order(our_order)
+
+    their_order_id = incoming_order.get("order_id", "")
+    our_order_id = our_order.get("order_id", "")
+    negotiation_id = f"{min(our_order_id, their_order_id)}_{max(our_order_id, their_order_id)}"
+
+    actions = NegotiationActionBuilder({
+        "negotiation_id": negotiation_id,
+        "order_id": their_order_id,
+        "our_order_id": our_order_id,
+        "our_price": our_price,
+        "their_price": their_proposed_price,
+        "proposed_price": their_proposed_price,
+        "our_strategy": strategy,
+    })
+
+    if strategy == "minimize":
+        if their_proposed_price <= our_price:
+            return actions.accept("favorable_price")
+        if their_proposed_price <= our_price * 1.5:
+            proposed_price = (our_price + their_proposed_price) // 2
+            return actions.counter(proposed_price)
+        return actions.exit("price_unreasonable")
+
+    if strategy == "maximize":
+        if their_proposed_price >= our_price:
+            return actions.accept("favorable_price")
+        if their_proposed_price >= our_price / 1.5:
+            proposed_price = (our_price + their_proposed_price) // 2
+            return actions.counter(proposed_price)
+        return actions.exit("price_unreasonable")
+
+    return actions.reject("unknown_strategy")

--- a/agents/a2a-agent-trader/app/utils/action_executor.py
+++ b/agents/a2a-agent-trader/app/utils/action_executor.py
@@ -40,6 +40,7 @@ from .token_registry import TOKEN_REGISTRY
 from .registry_client import get_registry_client
 from .provisioning import run_vm_provisioning_playbook
 from ..policies.negotiation_thread import get_thread_store
+from .validation import determine_role_from_order
 
 BASE_URL_OVERRIDE = CONFIG.base_url_override
 REMOTE_AGENT_URL_OVERRIDE = CONFIG.remote_agent_url_override
@@ -329,11 +330,19 @@ async def execute_action(
 
 def connect_to_remote_agent(agent_url: str | None = None):
     """Connect to a remote agent by URL.
-    
+
     Args:
         agent_url: Agent URL (defaults to REMOTE_AGENT_URL_OVERRIDE for backward compatibility)
+
+    Warning:
+        If agent_url is None, falls back to REMOTE_AGENT_URL_OVERRIDE which may misroute
+        counter-offers in staging environments.
     """
     if agent_url is None:
+        logger.warning(
+            "[A2A] No agent_url provided, falling back to REMOTE_AGENT_URL_OVERRIDE. "
+            "This may misroute messages in staging environments."
+        )
         agent_url = REMOTE_AGENT_URL_OVERRIDE
     agent_card_url = f"{agent_url.rstrip('/')}{AGENT_CARD_WELL_KNOWN_PATH}"
     
@@ -519,10 +528,23 @@ async def counter_offer(
         
         their_agent_id = order.get("order_maker")
         our_order_id = parameters.get("our_order_id")  # Our order ID if we have one
-        
+
+        # Determine our role by looking up our order
+        role = None
+        if our_order_id:
+            try:
+                our_order = await registry_client.get_order(our_order_id)
+                if our_order:
+                    # Parse the order dict to MarketOrder for role determination
+                    market_order = MarketOrder.model_validate(our_order)
+                    role = determine_role_from_order(market_order)
+                    logger.info(f"[ACTION] Determined role '{role}' from our order {our_order_id}")
+            except Exception as e:
+                logger.warning(f"[ACTION] Failed to determine role from order {our_order_id}: {e}")
+
         # Get thread store and create/update negotiation thread
         thread_store = get_thread_store()
-        
+
         # Check if thread exists, if not create it
         existing_thread = await thread_store.get_thread(negotiation_id)
         if not existing_thread:
@@ -535,7 +557,7 @@ async def counter_offer(
                     our_agent_id=AGENT_ID,
                     their_agent_id=their_agent_id,
                 )
-        
+
         # Add counter offer message to thread
         await thread_store.add_message(
             negotiation_id=negotiation_id,
@@ -546,7 +568,7 @@ async def counter_offer(
             action_taken=ActionType.COUNTER_OFFER.value,
             message_type="counter_proposal",
         )
-        
+
         # Create negotiation event
         event_payload = {
             "event_type": EventType.NEGOTIATION.value,
@@ -559,6 +581,148 @@ async def counter_offer(
                 "proposed_price": proposed_price,
                 "their_order_id": order_id,
                 "our_order_id": our_order_id,
+                "role": role,  # Include role for role-aware negotiation
+            },
+        }
+        
+        event = Event(
+            author=AGENT_ID,
+            content=genai_types.Content(
+                role="model",
+                parts=[
+                    genai_types.Part.from_function_response(
+                        name="counter_offer",
+                        response=event_payload,
+                    )
+                ],
+            ),
+            invocation_id=ctx.invocation_id,
+            branch=ctx.branch,
+        )
+        
+        # Send to counterparty
+        result = await send_to_remote_agent(ctx, event, agent_url=their_agent_id)
+        
+        return {
+            "status": "sent",
+            "message": "Counter offer sent",
+            "negotiation_id": negotiation_id,
+            "proposed_price": proposed_price,
+            "remote_response": getattr(result, "content", None),
+        }
+    except Exception as e:
+        logger.error(f"[ACTION] Failed to send counter offer: {e}")
+        return {
+            "status": "error",
+            "message": f"Failed to send counter offer: {e}",
+        }
+
+
+async def counter_offer(
+    *,
+    ctx: InvocationContext | None,
+    parameters: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Send a counter offer in a negotiation."""
+    parameters = parameters or {}
+    
+    negotiation_id = parameters.get("negotiation_id")
+    order_id = parameters.get("order_id")  # Their order ID
+    proposed_price = parameters.get("proposed_price")
+    our_price = parameters.get("our_price")
+    their_price = parameters.get("their_price")
+    
+    if not negotiation_id or not order_id:
+        return {
+            "status": "error",
+            "message": "Missing negotiation_id or order_id for counter_offer",
+        }
+    
+    if ctx is None:
+        return {
+            "status": "error",
+            "message": "No invocation context available for counter_offer",
+        }
+    
+    # Get order details to find the counterparty
+    try:
+        registry_client = get_registry_client()
+        order = await registry_client.get_order(order_id)
+        if not order:
+            return {
+                "status": "error",
+                "message": f"Order {order_id} not found in registry",
+            }
+
+        their_agent_id = order.get("order_maker")
+
+        # Validate that we have a valid agent URL for the counterparty
+        if not their_agent_id:
+            logger.warning(
+                f"[ACTION] Order {order_id} missing 'order_maker' field. "
+                f"Counter-offer may be misrouted to fallback REMOTE_AGENT_URL_OVERRIDE"
+            )
+        elif not their_agent_id.startswith(("http://", "https://")):
+            logger.warning(
+                f"[ACTION] Order {order_id} has invalid 'order_maker' URL: {their_agent_id}. "
+                f"Counter-offer may be misrouted to fallback REMOTE_AGENT_URL_OVERRIDE"
+            )
+
+        our_order_id = parameters.get("our_order_id")  # Our order ID if we have one
+
+        # Determine our role by looking up our order
+        role = None
+        if our_order_id:
+            try:
+                our_order = await registry_client.get_order(our_order_id)
+                if our_order:
+                    # Parse the order dict to MarketOrder for role determination
+                    market_order = MarketOrder.model_validate(our_order)
+                    role = determine_role_from_order(market_order)
+                    logger.info(f"[ACTION] Determined role '{role}' from our order {our_order_id}")
+            except Exception as e:
+                logger.warning(f"[ACTION] Failed to determine role from order {our_order_id}: {e}")
+
+        # Get thread store and create/update negotiation thread
+        thread_store = get_thread_store()
+
+        # Check if thread exists, if not create it
+        existing_thread = await thread_store.get_thread(negotiation_id)
+        if not existing_thread:
+            # Create new thread with order and agent tracking
+            if our_order_id and their_agent_id:
+                await thread_store.create_thread(
+                    negotiation_id=negotiation_id,
+                    our_order_id=our_order_id or "",
+                    their_order_id=order_id,
+                    our_agent_id=AGENT_ID,
+                    their_agent_id=their_agent_id,
+                )
+
+        # Add counter offer message to thread
+        await thread_store.add_message(
+            negotiation_id=negotiation_id,
+            sender=AGENT_ID,
+            our_price=our_price,
+            their_price=their_price,
+            proposed_price=proposed_price,
+            action_taken=ActionType.COUNTER_OFFER.value,
+            message_type="counter_proposal",
+        )
+
+        # Create negotiation event
+        event_payload = {
+            "event_type": EventType.NEGOTIATION.value,
+            "negotiation_id": negotiation_id,
+            "message_type": "counter_proposal",
+            "sender": AGENT_ID,
+            "data": {
+                "our_price": our_price,
+                "their_price": their_price,
+                "proposed_price": proposed_price,
+                "their_order_id": order_id,
+                "our_order_id": our_order_id,
+                "role": role,  # Include role for role-aware negotiation
             },
         }
         
@@ -709,10 +873,10 @@ async def accept_offer(
         thread_store = get_thread_store()
         order_id = order_dict.get("order_id")
         their_order_id = parameters.get("their_order_id")  # May be in parameters
-        
+
         # Get negotiation_id from parameters if this is part of a negotiation
         negotiation_id = parameters.get("negotiation_id")
-        
+
         if order_id:
             canceled_ours = await thread_store._sqlite.cancel_negotiations_for_order(
                 order_id=order_id,
@@ -720,7 +884,7 @@ async def accept_offer(
             )
             if canceled_ours:
                 logger.info(f"[NEGOTIATION] Canceled {len(canceled_ours)} competing negotiations for our order {order_id}")
-        
+
         if their_order_id:
             canceled_theirs = await thread_store._sqlite.cancel_negotiations_for_order(
                 order_id=their_order_id,
@@ -728,6 +892,18 @@ async def accept_offer(
             )
             if canceled_theirs:
                 logger.info(f"[NEGOTIATION] Canceled {len(canceled_theirs)} competing negotiations for their order {their_order_id}")
+
+        # Mark the current negotiation thread as terminal (success)
+        # This prevents it from showing up in future active negotiation queries
+        if negotiation_id:
+            try:
+                await thread_store._sqlite.update_negotiation_thread_terminal(
+                    negotiation_id=negotiation_id,
+                    terminal_state="success",
+                )
+                logger.info(f"[NEGOTIATION] Marked negotiation {negotiation_id} as terminal (success)")
+            except Exception as e:
+                logger.warning(f"[NEGOTIATION] Failed to mark thread as terminal: {e}")
     except Exception as e:
         logger.warning(f"[NEGOTIATION] Failed to cancel competing negotiations: {e}")
 
@@ -997,6 +1173,7 @@ async def _find_and_send_matching_offers(
                     matched_order_id = matched_order.get("order_id") if matched_order else None
                     
                     # Check for duplicate negotiation before sending
+                    negotiation_id = None
                     if matched_order_id:
                         try:
                             thread_store = get_thread_store()
@@ -1012,9 +1189,21 @@ async def _find_and_send_matching_offers(
                                     f"(existing: {existing['negotiation_id']})"
                                 )
                                 continue
+
+                            # Create thread BEFORE sending offer to track in-flight negotiations
+                            # This prevents duplicates from being sent to the same counterparty
+                            negotiation_id = f"{order_id}_{matched_order_id}_{AGENT_ID[:8]}"
+                            await thread_store.create_thread(
+                                negotiation_id=negotiation_id,
+                                our_order_id=order_id,
+                                their_order_id=matched_order_id,
+                                our_agent_id=AGENT_ID,
+                                their_agent_id=agent_url,
+                            )
+                            logger.debug(f"[REGISTRY] Created negotiation thread {negotiation_id} for offer to {agent_url}")
                         except Exception as e:
-                            logger.warning(f"[REGISTRY] Failed to check for duplicate negotiation: {e}")
-                    
+                            logger.warning(f"[REGISTRY] Failed to check/create negotiation: {e}")
+
                     logger.info(f"[REGISTRY] Sending offer to agent at {agent_url}")
                     result = await send_to_remote_agent(ctx, event, agent_url=agent_url)
                     if result:

--- a/agents/a2a-agent-trader/app/utils/action_executor.py
+++ b/agents/a2a-agent-trader/app/utils/action_executor.py
@@ -558,6 +558,8 @@ async def counter_offer(
                 their_order_id=params.order_id,
                 our_agent_id=AGENT_ID,
                 their_agent_id=their_agent_id or "",
+                our_initial_price=params.our_price,  # Store locally for future rounds
+                our_strategy=strategy,  # Store locally, never transmitted
             )
             await txn.add_message(
                 negotiation_id=params.negotiation_id,
@@ -569,19 +571,15 @@ async def counter_offer(
                 message_type="counter_proposal",
             )
 
-        # Create negotiation event
         event_payload = {
             "event_type": EventType.NEGOTIATION.value,
             "negotiation_id": params.negotiation_id,
             "message_type": "counter_proposal",
             "sender": AGENT_ID,
             "data": {
-                "our_price": params.our_price,
-                "their_price": params.their_price,
                 "proposed_price": params.proposed_price,
-                "their_order_id": params.order_id,
-                "our_order_id": params.our_order_id,
-                "strategy": strategy,  # Strategy for counterparty's policy use
+                "sender_order_id": params.our_order_id,
+                "target_order_id": params.order_id,
             },
         }
 

--- a/agents/a2a-agent-trader/app/utils/action_executor.py
+++ b/agents/a2a-agent-trader/app/utils/action_executor.py
@@ -492,6 +492,24 @@ def extract_compute_and_token_from_order_dict(order: dict) -> tuple[dict, dict]:
     return compute_resource, token_resource
 
 
+def _extract_initial_price_from_order(order: MarketOrder | dict) -> int:
+    """Extract the initial price from an order's token resource.
+
+    The token amount represents:
+    - For surplus (offering compute): The floor price (minimum willing to accept)
+    - For deficit (demanding compute): The ceiling price (maximum willing to pay)
+    """
+    if isinstance(order, dict):
+        order = MarketOrder.model_validate(order)
+
+    if isinstance(order.offer_resource, TokenResource):
+        return order.offer_resource.amount
+    if isinstance(order.demand_resource, TokenResource):
+        return order.demand_resource.amount
+
+    raise ValueError(f"Order has no token resource: {order.order_id}")
+
+
 async def counter_offer(
     *,
     ctx: InvocationContext | None,
@@ -578,8 +596,6 @@ async def counter_offer(
             "sender": AGENT_ID,
             "data": {
                 "proposed_price": params.proposed_price,
-                "sender_order_id": params.our_order_id,
-                "target_order_id": params.order_id,
             },
         }
 
@@ -997,12 +1013,21 @@ async def _find_and_send_matching_offers(
 
                             # Create thread BEFORE sending offer to track in-flight negotiations
                             negotiation_id = f"{order_id}_{matched_order_id}_{AGENT_ID[:8]}"
+
+                            # Get our order to determine strategy and initial price
+                            our_order_dict = await registry_client.get_order(order_id)
+                            our_order = MarketOrder.model_validate(our_order_dict)
+                            strategy = determine_strategy_from_order(our_order)
+                            our_initial_price = _extract_initial_price_from_order(our_order)
+
                             await txn.ensure_thread(
                                 negotiation_id=negotiation_id,
                                 our_order_id=order_id,
                                 their_order_id=matched_order_id,
                                 our_agent_id=AGENT_ID,
                                 their_agent_id=agent_url,
+                                our_initial_price=our_initial_price,
+                                our_strategy=strategy,
                             )
                             logger.debug(f"[REGISTRY] Created negotiation thread {negotiation_id} for offer to {agent_url}")
 

--- a/agents/a2a-agent-trader/app/utils/action_executor.py
+++ b/agents/a2a-agent-trader/app/utils/action_executor.py
@@ -39,7 +39,8 @@ from .config import CONFIG
 from .token_registry import TOKEN_REGISTRY
 from .registry_client import get_registry_client
 from .provisioning import run_vm_provisioning_playbook
-from ..policies.negotiation_thread import get_thread_store
+from ..policies.negotiation_thread import get_thread_store, NegotiationThreadTransaction
+from ..policies.action_builders import CounterOfferParams
 from .validation import determine_role_from_order
 
 BASE_URL_OVERRIDE = CONFIG.base_url_override
@@ -490,133 +491,6 @@ def extract_compute_and_token_from_order_dict(order: dict) -> tuple[dict, dict]:
 
     return compute_resource, token_resource
 
-async def counter_offer(
-    *,
-    ctx: InvocationContext | None,
-    parameters: dict[str, Any] | None = None,
-) -> dict[str, Any]:
-    """Send a counter offer in a negotiation."""
-    parameters = parameters or {}
-    
-    negotiation_id = parameters.get("negotiation_id")
-    order_id = parameters.get("order_id")  # Their order ID
-    proposed_price = parameters.get("proposed_price")
-    our_price = parameters.get("our_price")
-    their_price = parameters.get("their_price")
-    
-    if not negotiation_id or not order_id:
-        return {
-            "status": "error",
-            "message": "Missing negotiation_id or order_id for counter_offer",
-        }
-    
-    if ctx is None:
-        return {
-            "status": "error",
-            "message": "No invocation context available for counter_offer",
-        }
-    
-    # Get order details to find the counterparty
-    try:
-        registry_client = get_registry_client()
-        order = await registry_client.get_order(order_id)
-        if not order:
-            return {
-                "status": "error",
-                "message": f"Order {order_id} not found in registry",
-            }
-        
-        their_agent_id = order.get("order_maker")
-        our_order_id = parameters.get("our_order_id")  # Our order ID if we have one
-
-        # Determine our role by looking up our order
-        role = None
-        if our_order_id:
-            try:
-                our_order = await registry_client.get_order(our_order_id)
-                if our_order:
-                    # Parse the order dict to MarketOrder for role determination
-                    market_order = MarketOrder.model_validate(our_order)
-                    role = determine_role_from_order(market_order)
-                    logger.info(f"[ACTION] Determined role '{role}' from our order {our_order_id}")
-            except Exception as e:
-                logger.warning(f"[ACTION] Failed to determine role from order {our_order_id}: {e}")
-
-        # Get thread store and create/update negotiation thread
-        thread_store = get_thread_store()
-
-        # Check if thread exists, if not create it
-        existing_thread = await thread_store.get_thread(negotiation_id)
-        if not existing_thread:
-            # Create new thread with order and agent tracking
-            if our_order_id and their_agent_id:
-                await thread_store.create_thread(
-                    negotiation_id=negotiation_id,
-                    our_order_id=our_order_id or "",
-                    their_order_id=order_id,
-                    our_agent_id=AGENT_ID,
-                    their_agent_id=their_agent_id,
-                )
-
-        # Add counter offer message to thread
-        await thread_store.add_message(
-            negotiation_id=negotiation_id,
-            sender=AGENT_ID,
-            our_price=our_price,
-            their_price=their_price,
-            proposed_price=proposed_price,
-            action_taken=ActionType.COUNTER_OFFER.value,
-            message_type="counter_proposal",
-        )
-
-        # Create negotiation event
-        event_payload = {
-            "event_type": EventType.NEGOTIATION.value,
-            "negotiation_id": negotiation_id,
-            "message_type": "counter_proposal",
-            "sender": AGENT_ID,
-            "data": {
-                "our_price": our_price,
-                "their_price": their_price,
-                "proposed_price": proposed_price,
-                "their_order_id": order_id,
-                "our_order_id": our_order_id,
-                "role": role,  # Include role for role-aware negotiation
-            },
-        }
-        
-        event = Event(
-            author=AGENT_ID,
-            content=genai_types.Content(
-                role="model",
-                parts=[
-                    genai_types.Part.from_function_response(
-                        name="counter_offer",
-                        response=event_payload,
-                    )
-                ],
-            ),
-            invocation_id=ctx.invocation_id,
-            branch=ctx.branch,
-        )
-        
-        # Send to counterparty
-        result = await send_to_remote_agent(ctx, event, agent_url=their_agent_id)
-        
-        return {
-            "status": "sent",
-            "message": "Counter offer sent",
-            "negotiation_id": negotiation_id,
-            "proposed_price": proposed_price,
-            "remote_response": getattr(result, "content", None),
-        }
-    except Exception as e:
-        logger.error(f"[ACTION] Failed to send counter offer: {e}")
-        return {
-            "status": "error",
-            "message": f"Failed to send counter offer: {e}",
-        }
-
 
 async def counter_offer(
     *,
@@ -625,33 +499,29 @@ async def counter_offer(
 ) -> dict[str, Any]:
     """Send a counter offer in a negotiation."""
     parameters = parameters or {}
-    
-    negotiation_id = parameters.get("negotiation_id")
-    order_id = parameters.get("order_id")  # Their order ID
-    proposed_price = parameters.get("proposed_price")
-    our_price = parameters.get("our_price")
-    their_price = parameters.get("their_price")
-    
-    if not negotiation_id or not order_id:
+
+    # Use type-safe parameter extraction
+    params = CounterOfferParams.from_dict(parameters)
+    if not params:
         return {
             "status": "error",
-            "message": "Missing negotiation_id or order_id for counter_offer",
+            "message": "Missing required counter_offer parameters (negotiation_id, order_id, proposed_price, our_price, their_price)",
         }
-    
+
     if ctx is None:
         return {
             "status": "error",
             "message": "No invocation context available for counter_offer",
         }
-    
+
     # Get order details to find the counterparty
     try:
         registry_client = get_registry_client()
-        order = await registry_client.get_order(order_id)
+        order = await registry_client.get_order(params.order_id)
         if not order:
             return {
                 "status": "error",
-                "message": f"Order {order_id} not found in registry",
+                "message": f"Order {params.order_id} not found in registry",
             }
 
         their_agent_id = order.get("order_maker")
@@ -659,73 +529,62 @@ async def counter_offer(
         # Validate that we have a valid agent URL for the counterparty
         if not their_agent_id:
             logger.warning(
-                f"[ACTION] Order {order_id} missing 'order_maker' field. "
+                f"[ACTION] Order {params.order_id} missing 'order_maker' field. "
                 f"Counter-offer may be misrouted to fallback REMOTE_AGENT_URL_OVERRIDE"
             )
         elif not their_agent_id.startswith(("http://", "https://")):
             logger.warning(
-                f"[ACTION] Order {order_id} has invalid 'order_maker' URL: {their_agent_id}. "
+                f"[ACTION] Order {params.order_id} has invalid 'order_maker' URL: {their_agent_id}. "
                 f"Counter-offer may be misrouted to fallback REMOTE_AGENT_URL_OVERRIDE"
             )
 
-        our_order_id = parameters.get("our_order_id")  # Our order ID if we have one
-
         # Determine our role by looking up our order
         role = None
-        if our_order_id:
+        if params.our_order_id:
             try:
-                our_order = await registry_client.get_order(our_order_id)
+                our_order = await registry_client.get_order(params.our_order_id)
                 if our_order:
-                    # Parse the order dict to MarketOrder for role determination
                     market_order = MarketOrder.model_validate(our_order)
                     role = determine_role_from_order(market_order)
-                    logger.info(f"[ACTION] Determined role '{role}' from our order {our_order_id}")
+                    logger.info(f"[ACTION] Determined role '{role}' from our order {params.our_order_id}")
             except Exception as e:
-                logger.warning(f"[ACTION] Failed to determine role from order {our_order_id}: {e}")
+                logger.warning(f"[ACTION] Failed to determine role from order {params.our_order_id}: {e}")
 
-        # Get thread store and create/update negotiation thread
-        thread_store = get_thread_store()
-
-        # Check if thread exists, if not create it
-        existing_thread = await thread_store.get_thread(negotiation_id)
-        if not existing_thread:
-            # Create new thread with order and agent tracking
-            if our_order_id and their_agent_id:
-                await thread_store.create_thread(
-                    negotiation_id=negotiation_id,
-                    our_order_id=our_order_id or "",
-                    their_order_id=order_id,
-                    our_agent_id=AGENT_ID,
-                    their_agent_id=their_agent_id,
-                )
-
-        # Add counter offer message to thread
-        await thread_store.add_message(
-            negotiation_id=negotiation_id,
-            sender=AGENT_ID,
-            our_price=our_price,
-            their_price=their_price,
-            proposed_price=proposed_price,
-            action_taken=ActionType.COUNTER_OFFER.value,
-            message_type="counter_proposal",
-        )
+        # Use transaction context manager for thread operations
+        async with NegotiationThreadTransaction("COUNTER_OFFER") as txn:
+            await txn.ensure_thread(
+                negotiation_id=params.negotiation_id,
+                our_order_id=params.our_order_id or "",
+                their_order_id=params.order_id,
+                our_agent_id=AGENT_ID,
+                their_agent_id=their_agent_id or "",
+            )
+            await txn.add_message(
+                negotiation_id=params.negotiation_id,
+                sender=AGENT_ID,
+                our_price=params.our_price,
+                their_price=params.their_price,
+                proposed_price=params.proposed_price,
+                action_taken=ActionType.COUNTER_OFFER.value,
+                message_type="counter_proposal",
+            )
 
         # Create negotiation event
         event_payload = {
             "event_type": EventType.NEGOTIATION.value,
-            "negotiation_id": negotiation_id,
+            "negotiation_id": params.negotiation_id,
             "message_type": "counter_proposal",
             "sender": AGENT_ID,
             "data": {
-                "our_price": our_price,
-                "their_price": their_price,
-                "proposed_price": proposed_price,
-                "their_order_id": order_id,
-                "our_order_id": our_order_id,
-                "role": role,  # Include role for role-aware negotiation
+                "our_price": params.our_price,
+                "their_price": params.their_price,
+                "proposed_price": params.proposed_price,
+                "their_order_id": params.order_id,
+                "our_order_id": params.our_order_id,
+                "role": role,
             },
         }
-        
+
         event = Event(
             author=AGENT_ID,
             content=genai_types.Content(
@@ -740,15 +599,15 @@ async def counter_offer(
             invocation_id=ctx.invocation_id,
             branch=ctx.branch,
         )
-        
+
         # Send to counterparty
         result = await send_to_remote_agent(ctx, event, agent_url=their_agent_id)
-        
+
         return {
             "status": "sent",
             "message": "Counter offer sent",
-            "negotiation_id": negotiation_id,
-            "proposed_price": proposed_price,
+            "negotiation_id": params.negotiation_id,
+            "proposed_price": params.proposed_price,
             "remote_response": getattr(result, "content", None),
         }
     except Exception as e:
@@ -868,44 +727,15 @@ async def accept_offer(
 
     logger.info("[TOOL] Accepting offer and notifying counterparty: %s", event_payload)
 
-    # Cancel competing negotiations for both orders
-    try:
-        thread_store = get_thread_store()
-        order_id = order_dict.get("order_id")
-        their_order_id = parameters.get("their_order_id")  # May be in parameters
+    # Cancel competing negotiations and mark as terminal using transaction
+    order_id = order_dict.get("order_id")
+    their_order_id = parameters.get("their_order_id")
+    negotiation_id = parameters.get("negotiation_id")
 
-        # Get negotiation_id from parameters if this is part of a negotiation
-        negotiation_id = parameters.get("negotiation_id")
-
-        if order_id:
-            canceled_ours = await thread_store._sqlite.cancel_negotiations_for_order(
-                order_id=order_id,
-                except_negotiation_id=negotiation_id
-            )
-            if canceled_ours:
-                logger.info(f"[NEGOTIATION] Canceled {len(canceled_ours)} competing negotiations for our order {order_id}")
-
-        if their_order_id:
-            canceled_theirs = await thread_store._sqlite.cancel_negotiations_for_order(
-                order_id=their_order_id,
-                except_negotiation_id=negotiation_id
-            )
-            if canceled_theirs:
-                logger.info(f"[NEGOTIATION] Canceled {len(canceled_theirs)} competing negotiations for their order {their_order_id}")
-
-        # Mark the current negotiation thread as terminal (success)
-        # This prevents it from showing up in future active negotiation queries
+    async with NegotiationThreadTransaction("ACCEPT_OFFER") as txn:
+        await txn.cancel_competing(order_id, their_order_id, negotiation_id)
         if negotiation_id:
-            try:
-                await thread_store._sqlite.update_negotiation_thread_terminal(
-                    negotiation_id=negotiation_id,
-                    terminal_state="success",
-                )
-                logger.info(f"[NEGOTIATION] Marked negotiation {negotiation_id} as terminal (success)")
-            except Exception as e:
-                logger.warning(f"[NEGOTIATION] Failed to mark thread as terminal: {e}")
-    except Exception as e:
-        logger.warning(f"[NEGOTIATION] Failed to cancel competing negotiations: {e}")
+            await txn.mark_terminal(negotiation_id, "success")
 
     # Update registry if order exists there
     # This updates the MAKER's order (the order we're accepting)
@@ -1096,31 +926,16 @@ async def _find_and_send_matching_offers(
         # Filter out our own orders (don't match with ourselves)
         order_id = order_dict.get("order_id")
         matching_orders = [m for m in matching_orders if m.get("order_id") != order_id]
-        
+
         # Filter out orders that are already in active negotiations with us
-        try:
-            thread_store = get_thread_store()
-            our_order_id = order_id
-            active_negotiations = await thread_store._sqlite.get_active_negotiations_for_order(
-                order_id=our_order_id
-            )
-            # Get list of order IDs we're already negotiating with
-            active_order_ids = set()
-            for neg in active_negotiations:
-                if neg["our_order_id"] == our_order_id:
-                    active_order_ids.add(neg["their_order_id"])
-                elif neg["their_order_id"] == our_order_id:
-                    active_order_ids.add(neg["our_order_id"])
-            
-            # Filter out orders we're already negotiating with
-            matching_orders = [
-                m for m in matching_orders 
-                if m.get("order_id") not in active_order_ids
-            ]
+        async with NegotiationThreadTransaction("MAKE_OFFER") as txn:
+            active_order_ids = await txn.filter_active(order_id)
             if active_order_ids:
+                matching_orders = [
+                    m for m in matching_orders
+                    if m.get("order_id") not in active_order_ids
+                ]
                 logger.info(f"[REGISTRY] Filtered out {len(active_order_ids)} orders already in active negotiations")
-        except Exception as e:
-            logger.warning(f"[REGISTRY] Failed to filter active negotiations: {e}")
         
         if not matching_orders:
             return {
@@ -1175,25 +990,16 @@ async def _find_and_send_matching_offers(
                     # Check for duplicate negotiation before sending
                     negotiation_id = None
                     if matched_order_id:
-                        try:
-                            thread_store = get_thread_store()
-                            existing = await thread_store._sqlite.check_existing_negotiation(
-                                our_order_id=order_id,
-                                their_order_id=matched_order_id,
-                                our_agent_id=AGENT_ID,
-                                their_agent_id=agent_url,
-                            )
-                            if existing:
+                        async with NegotiationThreadTransaction("MAKE_OFFER") as txn:
+                            if await txn.check_duplicate(order_id, matched_order_id):
                                 logger.info(
-                                    f"[REGISTRY] Skipping duplicate negotiation with order {matched_order_id} "
-                                    f"(existing: {existing['negotiation_id']})"
+                                    f"[REGISTRY] Skipping duplicate negotiation with order {matched_order_id}"
                                 )
                                 continue
 
                             # Create thread BEFORE sending offer to track in-flight negotiations
-                            # This prevents duplicates from being sent to the same counterparty
                             negotiation_id = f"{order_id}_{matched_order_id}_{AGENT_ID[:8]}"
-                            await thread_store.create_thread(
+                            await txn.ensure_thread(
                                 negotiation_id=negotiation_id,
                                 our_order_id=order_id,
                                 their_order_id=matched_order_id,
@@ -1201,8 +1007,6 @@ async def _find_and_send_matching_offers(
                                 their_agent_id=agent_url,
                             )
                             logger.debug(f"[REGISTRY] Created negotiation thread {negotiation_id} for offer to {agent_url}")
-                        except Exception as e:
-                            logger.warning(f"[REGISTRY] Failed to check/create negotiation: {e}")
 
                     logger.info(f"[REGISTRY] Sending offer to agent at {agent_url}")
                     result = await send_to_remote_agent(ctx, event, agent_url=agent_url)

--- a/agents/a2a-agent-trader/app/utils/action_executor.py
+++ b/agents/a2a-agent-trader/app/utils/action_executor.py
@@ -41,7 +41,7 @@ from .registry_client import get_registry_client
 from .provisioning import run_vm_provisioning_playbook
 from ..policies.negotiation_thread import get_thread_store, NegotiationThreadTransaction
 from ..policies.action_builders import CounterOfferParams
-from .validation import determine_role_from_order
+from .validation import determine_strategy_from_order
 
 BASE_URL_OVERRIDE = CONFIG.base_url_override
 REMOTE_AGENT_URL_OVERRIDE = CONFIG.remote_agent_url_override
@@ -538,17 +538,17 @@ async def counter_offer(
                 f"Counter-offer may be misrouted to fallback REMOTE_AGENT_URL_OVERRIDE"
             )
 
-        # Determine our role by looking up our order
-        role = None
+        # Determine our strategy by looking up our order (for internal policy use)
+        strategy = None
         if params.our_order_id:
             try:
                 our_order = await registry_client.get_order(params.our_order_id)
                 if our_order:
                     market_order = MarketOrder.model_validate(our_order)
-                    role = determine_role_from_order(market_order)
-                    logger.info(f"[ACTION] Determined role '{role}' from our order {params.our_order_id}")
+                    strategy = determine_strategy_from_order(market_order)
+                    logger.info(f"[ACTION] Determined strategy '{strategy}' from our order {params.our_order_id}")
             except Exception as e:
-                logger.warning(f"[ACTION] Failed to determine role from order {params.our_order_id}: {e}")
+                logger.warning(f"[ACTION] Failed to determine strategy from order {params.our_order_id}: {e}")
 
         # Use transaction context manager for thread operations
         async with NegotiationThreadTransaction("COUNTER_OFFER") as txn:
@@ -581,7 +581,7 @@ async def counter_offer(
                 "proposed_price": params.proposed_price,
                 "their_order_id": params.order_id,
                 "our_order_id": params.our_order_id,
-                "role": role,
+                "strategy": strategy,  # Strategy for counterparty's policy use
             },
         }
 

--- a/agents/a2a-agent-trader/app/utils/validation.py
+++ b/agents/a2a-agent-trader/app/utils/validation.py
@@ -106,7 +106,7 @@ def determine_strategy_from_resources(
     """Determine negotiation strategy from resource types.
 
     In a compute-for-token market:
-    - Maximizer (offering compute): offers ComputeResource, demands TokenResource
+    - Maximizer (offering compute): offers ComputeResource, demands TokenResource, maximizing TokenResource amount
     - Minimizer (demanding compute): offers TokenResource, demands ComputeResource
 
     Args:

--- a/agents/a2a-agent-trader/app/utils/validation.py
+++ b/agents/a2a-agent-trader/app/utils/validation.py
@@ -76,13 +76,13 @@ def extract_resources_from_make_offer_event(
     context: DecisionContext,
 ) -> tuple[MarketOrder | None, Resource | None, Resource | None]:
     """Safely extract offer_resource and demand_resource from MakeOfferEvent.
-    
+
     Extracts resources from a MakeOfferEvent, returning the order and both resources.
     Callers can use isinstance() to check resource types as needed.
-    
+
     Args:
         context: DecisionContext containing the event
-        
+
     Returns:
         Tuple of (order, offer_resource, demand_resource)
         - order: MarketOrder instance if event is MakeOfferEvent, None otherwise
@@ -91,10 +91,56 @@ def extract_resources_from_make_offer_event(
     """
     if not isinstance(context.event, MakeOfferEvent):
         return None, None, None
-    
+
     order = context.event.order
     offer_resource = order.offer_resource
     demand_resource = order.demand_resource
-    
+
     return order, offer_resource, demand_resource
+
+
+def determine_role_from_resources(
+    offer_resource: Resource | None,
+    demand_resource: Resource | None,
+) -> str | None:
+    """Determine market role (buyer/seller) from resource types.
+
+    In a compute-for-token market:
+    - Seller: offers ComputeResource, demands TokenResource
+    - Buyer: offers TokenResource, demands ComputeResource
+
+    Args:
+        offer_resource: Resource being offered
+        demand_resource: Resource being demanded
+
+    Returns:
+        "buyer" if demanding compute, "seller" if offering compute, None if unclear
+    """
+    if not offer_resource or not demand_resource:
+        return None
+
+    is_offering_compute = isinstance(offer_resource, ComputeResource)
+    is_demanding_compute = isinstance(demand_resource, ComputeResource)
+
+    if is_demanding_compute:
+        return "buyer"
+    elif is_offering_compute:
+        return "seller"
+    else:
+        return None
+
+
+def determine_role_from_order(order: MarketOrder | None) -> str | None:
+    """Determine market role from a MarketOrder.
+
+    Args:
+        order: MarketOrder instance
+
+    Returns:
+        "buyer" if demanding compute, "seller" if offering compute, None if unclear
+    """
+    if not order:
+        return None
+
+    return determine_role_from_resources(order.offer_resource, order.demand_resource)
 

--- a/agents/a2a-agent-trader/app/utils/validation.py
+++ b/agents/a2a-agent-trader/app/utils/validation.py
@@ -99,22 +99,22 @@ def extract_resources_from_make_offer_event(
     return order, offer_resource, demand_resource
 
 
-def determine_role_from_resources(
+def determine_strategy_from_resources(
     offer_resource: Resource | None,
     demand_resource: Resource | None,
 ) -> str | None:
-    """Determine market role (buyer/seller) from resource types.
+    """Determine negotiation strategy from resource types.
 
     In a compute-for-token market:
-    - Seller: offers ComputeResource, demands TokenResource
-    - Buyer: offers TokenResource, demands ComputeResource
+    - Maximizer (offering compute): offers ComputeResource, demands TokenResource
+    - Minimizer (demanding compute): offers TokenResource, demands ComputeResource
 
     Args:
         offer_resource: Resource being offered
         demand_resource: Resource being demanded
 
     Returns:
-        "buyer" if demanding compute, "seller" if offering compute, None if unclear
+        "minimize" if demanding compute (wants lowest rate), "maximize" if offering compute (wants highest rate), None if unclear
     """
     if not offer_resource or not demand_resource:
         return None
@@ -123,24 +123,24 @@ def determine_role_from_resources(
     is_demanding_compute = isinstance(demand_resource, ComputeResource)
 
     if is_demanding_compute:
-        return "buyer"
+        return "minimize"
     elif is_offering_compute:
-        return "seller"
+        return "maximize"
     else:
         return None
 
 
-def determine_role_from_order(order: MarketOrder | None) -> str | None:
-    """Determine market role from a MarketOrder.
+def determine_strategy_from_order(order: MarketOrder | None) -> str | None:
+    """Determine negotiation strategy from a MarketOrder.
 
     Args:
         order: MarketOrder instance
 
     Returns:
-        "buyer" if demanding compute, "seller" if offering compute, None if unclear
+        "minimize" if demanding compute (wants lowest rate), "maximize" if offering compute (wants highest rate), None if unclear
     """
     if not order:
         return None
 
-    return determine_role_from_resources(order.offer_resource, order.demand_resource)
+    return determine_strategy_from_resources(order.offer_resource, order.demand_resource)
 

--- a/agents/a2a-agent-trader/app/utils/validation.py
+++ b/agents/a2a-agent-trader/app/utils/validation.py
@@ -107,7 +107,7 @@ def determine_strategy_from_resources(
 
     In a compute-for-token market:
     - Maximizer (offering compute): offers ComputeResource, demands TokenResource, maximizing TokenResource amount
-    - Minimizer (demanding compute): offers TokenResource, demands ComputeResource
+    - Minimizer (demanding compute): offers TokenResource, demands ComputeResource, minimizing TokenResource amount
 
     Args:
         offer_resource: Resource being offered

--- a/agents/a2a-agent-trader/tests/unit/test_incoming_offer_handling.py
+++ b/agents/a2a-agent-trader/tests/unit/test_incoming_offer_handling.py
@@ -1,0 +1,645 @@
+"""Tests for incoming MAKE_OFFER event handling and thread creation.
+
+Tests the negotiation.respond_to_make_offer policy and thread creation
+with our_initial_price and our_strategy.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from app.schema.pydantic_models import (
+    DecisionContext,
+    MakeOfferEvent,
+    MarketOrder,
+    TokenResource,
+    ComputeResource,
+    EventType,
+    ERC20TokenMetadata,
+    GPUModel,
+    Region,
+)
+from app.policies.store import PolicyStore, negotiation_respond_to_make_offer
+from app.policies.sqlite_client import SQLiteClient
+from app.utils.action_executor import _extract_initial_price_from_order
+from app.utils.validation import determine_strategy_from_order
+import tempfile
+import os
+
+
+@pytest.fixture
+def temp_db():
+    fd, path = tempfile.mkstemp(suffix='.db')
+    os.close(fd)
+    yield path
+    if os.path.exists(path):
+        os.remove(path)
+
+
+@pytest.fixture
+def token_resource():
+    return TokenResource(
+        token=ERC20TokenMetadata(
+            symbol="USDC",
+            contract_address="0x1234",
+            decimals=6,
+        ),
+        amount=100,
+    )
+
+
+@pytest.fixture
+def compute_resource():
+    return ComputeResource(
+        gpu_model=GPUModel.H200,
+        quantity=1,
+        sla=99.9,
+        region=Region.CALIFORNIA_US,
+    )
+
+
+@pytest.fixture
+def minimizer_order(token_resource, compute_resource):
+    """Minimizer order: demanding compute, offering tokens."""
+    return MarketOrder(
+        order_id="order_minimizer",
+        order_maker="agent_minimizer",
+        offer_resource=token_resource,
+        demand_resource=compute_resource,
+        duration=3600,
+    )
+
+
+@pytest.fixture
+def maximizer_order(token_resource, compute_resource):
+    """Maximizer order: offering compute, demanding tokens."""
+    return MarketOrder(
+        order_id="order_maximizer",
+        order_maker="agent_maximizer",
+        offer_resource=compute_resource,
+        demand_resource=token_resource,
+        duration=3600,
+    )
+
+
+class TestExtractInitialPrice:
+    """Test _extract_initial_price_from_order helper function."""
+
+    def test_extract_from_minimizer_order(self, minimizer_order):
+        """Minimizer: token is in offer_resource (amount they will pay)."""
+        price = _extract_initial_price_from_order(minimizer_order)
+        assert price == 100
+
+    def test_extract_from_maximizer_order(self, maximizer_order):
+        """Maximizer: token is in demand_resource (amount they want to receive)."""
+        price = _extract_initial_price_from_order(maximizer_order)
+        assert price == 100
+
+    def test_extract_from_dict(self, minimizer_order):
+        """Test extraction from order dict."""
+        order_dict = minimizer_order.model_dump(mode="json")
+        price = _extract_initial_price_from_order(order_dict)
+        assert price == 100
+
+    def test_extract_no_token_raises_error(self):
+        """Order with no token resource raises ValueError."""
+        order = MarketOrder(
+            order_id="order_compute_only",
+            order_maker="agent_compute",
+            offer_resource=ComputeResource(
+                gpu_model=GPUModel.H200,
+                quantity=1,
+                sla=99.9,
+                region=Region.CALIFORNIA_US,
+            ),
+            demand_resource=ComputeResource(
+                gpu_model=GPUModel.TESLA_V100,
+                quantity=1,
+                sla=99.9,
+                region=Region.NEW_YORK_US,
+            ),
+            duration=3600,
+        )
+
+        with pytest.raises(ValueError, match="Order has no token resource"):
+            _extract_initial_price_from_order(order)
+
+
+class TestRespondToMakeOffer:
+    """Test negotiation.respond_to_make_offer policy."""
+
+    @pytest.fixture
+    def policy_store(self, temp_db):
+        from app.policies.registry import CALLABLE_REGISTRY
+
+        CALLABLE_REGISTRY.clear()
+
+        from app.policies.store import negotiation_respond_to_make_offer
+
+        sqlite_client = SQLiteClient(db_path=temp_db)
+        store = PolicyStore(sqlite_client=sqlite_client)
+        store.register_callables({
+            "negotiation.respond_to_make_offer": negotiation_respond_to_make_offer,
+        })
+
+        yield store
+
+        CALLABLE_REGISTRY.clear()
+
+    @pytest.mark.asyncio
+    async def test_minimizer_accepts_favorable_price(self, policy_store, maximizer_order):
+        """Minimizer accepts when their_price <= our_price."""
+        minimizer_our_order = MarketOrder(
+            order_id="our_order",
+            order_maker="our_agent",
+            offer_resource=TokenResource(
+                token=ERC20TokenMetadata(
+                    symbol="USDC",
+                    contract_address="0x1234",
+                    decimals=6,
+                ),
+                amount=100,
+            ),
+            demand_resource=ComputeResource(
+                gpu_model=GPUModel.H200,
+                quantity=1,
+                sla=99.9,
+                region=Region.CALIFORNIA_US,
+            ),
+            duration=3600,
+        )
+
+        event = MakeOfferEvent(
+            event_id="evt_incoming",
+            source="agent_maximizer",
+            order=maximizer_order,
+        )
+
+        context = DecisionContext(
+            event=event,
+            agent_id="our_agent",
+            available_resources={},
+            market_state={},
+        )
+
+        with patch("app.policies.store.get_registry_client") as mock_get_registry:
+            mock_registry = AsyncMock()
+            mock_registry.query_orders = AsyncMock(return_value=[
+                minimizer_our_order.model_dump(mode="json"),
+            ])
+            mock_get_registry.return_value = mock_registry
+
+            func = policy_store._registry.get("negotiation.respond_to_make_offer")
+            result = await func(context)
+
+        assert result is not None
+        assert result.action_type.value == "accept_offer"
+        assert result.parameters.get("reason") == "favorable_price"
+
+    @pytest.mark.asyncio
+    async def test_minimizer_counters_reasonable_price(self, policy_store):
+        """Minimizer counters when our_price < their_price <= 1.5x our_price."""
+        # Our minimizer order: we offer 100 tokens
+        minimizer_our_order = MarketOrder(
+            order_id="our_order",
+            order_maker="our_agent",
+            offer_resource=TokenResource(
+                token=ERC20TokenMetadata(
+                    symbol="USDC",
+                    contract_address="0x1234",
+                    decimals=6,
+                ),
+                amount=100,
+            ),
+            demand_resource=ComputeResource(
+                gpu_model=GPUModel.H200,
+                quantity=1,
+                sla=99.9,
+                region=Region.CALIFORNIA_US,
+            ),
+            duration=3600,
+        )
+
+        # Incoming maximizer order: they demand 120 tokens (higher than our 100)
+        incoming_maximizer_order = MarketOrder(
+            order_id="order_maximizer",
+            order_maker="agent_maximizer",
+            offer_resource=ComputeResource(
+                gpu_model=GPUModel.H200,
+                quantity=1,
+                sla=99.9,
+                region=Region.CALIFORNIA_US,
+            ),
+            demand_resource=TokenResource(
+                token=ERC20TokenMetadata(
+                    symbol="USDC",
+                    contract_address="0x1234",
+                    decimals=6,
+                ),
+                amount=120,  # Higher than our 100, but within 1.5x
+            ),
+            duration=3600,
+        )
+
+        event = MakeOfferEvent(
+            event_id="evt_incoming",
+            source="agent_maximizer",
+            order=incoming_maximizer_order,
+        )
+
+        context = DecisionContext(
+            event=event,
+            agent_id="our_agent",
+            available_resources={},
+            market_state={},
+        )
+
+        with patch("app.policies.store.get_registry_client") as mock_get_registry:
+            mock_registry = AsyncMock()
+            mock_registry.query_orders = AsyncMock(return_value=[
+                minimizer_our_order.model_dump(mode="json"),
+            ])
+            mock_get_registry.return_value = mock_registry
+
+            func = policy_store._registry.get("negotiation.respond_to_make_offer")
+            result = await func(context)
+
+        assert result is not None
+        assert result.action_type.value == "counter_offer"
+        # proposed_price = (100 + 120) // 2 = 110
+        assert result.parameters.get("proposed_price") == 110
+
+    @pytest.mark.asyncio
+    async def test_minimizer_exits_unreasonable_price(self, policy_store):
+        """Minimizer exits when their_price > 1.5x our_price."""
+        expensive_order = MarketOrder(
+            order_id="expensive_order",
+            order_maker="agent_expensive",
+            offer_resource=ComputeResource(
+                gpu_model=GPUModel.H200,
+                quantity=1,
+                sla=99.9,
+                region=Region.CALIFORNIA_US,
+            ),
+            demand_resource=TokenResource(
+                token=ERC20TokenMetadata(
+                    symbol="USDC",
+                    contract_address="0x1234",
+                    decimals=6,
+                ),
+                amount=200,
+            ),
+            duration=3600,
+        )
+
+        minimizer_our_order = MarketOrder(
+            order_id="our_order",
+            order_maker="our_agent",
+            offer_resource=TokenResource(
+                token=ERC20TokenMetadata(
+                    symbol="USDC",
+                    contract_address="0x1234",
+                    decimals=6,
+                ),
+                amount=100,
+            ),
+            demand_resource=ComputeResource(
+                gpu_model=GPUModel.H200,
+                quantity=1,
+                sla=99.9,
+                region=Region.CALIFORNIA_US,
+            ),
+            duration=3600,
+        )
+
+        event = MakeOfferEvent(
+            event_id="evt_incoming",
+            source="agent_expensive",
+            order=expensive_order,
+        )
+
+        context = DecisionContext(
+            event=event,
+            agent_id="our_agent",
+            available_resources={},
+            market_state={},
+        )
+
+        with patch("app.policies.store.get_registry_client") as mock_get_registry:
+            mock_registry = AsyncMock()
+            mock_registry.query_orders = AsyncMock(return_value=[
+                minimizer_our_order.model_dump(mode="json"),
+            ])
+            mock_get_registry.return_value = mock_registry
+
+            func = policy_store._registry.get("negotiation.respond_to_make_offer")
+            result = await func(context)
+
+        assert result is not None
+        assert result.action_type.value == "exit_negotiation"
+
+    @pytest.mark.asyncio
+    async def test_maximizer_accepts_favorable_price(self, policy_store, minimizer_order):
+        """Maximizer accepts when their_price >= our_price."""
+        maximizer_our_order = MarketOrder(
+            order_id="our_order",
+            order_maker="our_agent",
+            offer_resource=ComputeResource(
+                gpu_model=GPUModel.H200,
+                quantity=1,
+                sla=99.9,
+                region=Region.CALIFORNIA_US,
+            ),
+            demand_resource=TokenResource(
+                token=ERC20TokenMetadata(
+                    symbol="USDC",
+                    contract_address="0x1234",
+                    decimals=6,
+                ),
+                amount=100,
+            ),
+            duration=3600,
+        )
+
+        event = MakeOfferEvent(
+            event_id="evt_incoming",
+            source="agent_minimizer",
+            order=minimizer_order,
+        )
+
+        context = DecisionContext(
+            event=event,
+            agent_id="our_agent",
+            available_resources={},
+            market_state={},
+        )
+
+        with patch("app.policies.store.get_registry_client") as mock_get_registry:
+            mock_registry = AsyncMock()
+            mock_registry.query_orders = AsyncMock(return_value=[
+                maximizer_our_order.model_dump(mode="json"),
+            ])
+            mock_get_registry.return_value = mock_registry
+
+            func = policy_store._registry.get("negotiation.respond_to_make_offer")
+            result = await func(context)
+
+        assert result is not None
+        assert result.action_type.value == "accept_offer"
+
+    @pytest.mark.asyncio
+    async def test_maximizer_counters_reasonable_price(self, policy_store):
+        """Maximizer counters when 0.67x our_price <= their_price < our_price."""
+        cheap_order = MarketOrder(
+            order_id="cheap_order",
+            order_maker="agent_cheap",
+            offer_resource=TokenResource(
+                token=ERC20TokenMetadata(symbol="USDC", contract_address="0x1234", decimals=6),
+                amount=70,
+            ),
+            demand_resource=ComputeResource(
+                gpu_model=GPUModel.H200, quantity=1, sla=99.9, region=Region.CALIFORNIA_US,
+            ),
+            duration=3600,
+        )
+
+        maximizer_our_order = MarketOrder(
+            order_id="our_order",
+            order_maker="our_agent",
+            offer_resource=ComputeResource(
+                gpu_model=GPUModel.H200, quantity=1, sla=99.9, region=Region.CALIFORNIA_US,
+            ),
+            demand_resource=TokenResource(
+                token=ERC20TokenMetadata(symbol="USDC", contract_address="0x1234", decimals=6),
+                amount=100,
+            ),
+            duration=3600,
+        )
+
+        event = MakeOfferEvent(
+            event_id="evt_incoming",
+            source="agent_cheap",
+            order=cheap_order,
+        )
+
+        context = DecisionContext(
+            event=event,
+            agent_id="our_agent",
+            available_resources={},
+            market_state={},
+        )
+
+        with patch("app.policies.store.get_registry_client") as mock_get_registry:
+            mock_registry = AsyncMock()
+            mock_registry.query_orders = AsyncMock(return_value=[
+                maximizer_our_order.model_dump(mode="json"),
+            ])
+            mock_get_registry.return_value = mock_registry
+
+            func = policy_store._registry.get("negotiation.respond_to_make_offer")
+            result = await func(context)
+
+        assert result is not None
+        assert result.action_type.value == "counter_offer"
+        assert result.parameters.get("proposed_price") == 85
+
+    @pytest.mark.asyncio
+    async def test_no_matching_order_returns_reject(self, policy_store, maximizer_order):
+        """Policy rejects when no matching order found."""
+        event = MakeOfferEvent(
+            event_id="evt_incoming",
+            source="agent_maximizer",
+            order=maximizer_order,
+        )
+
+        context = DecisionContext(
+            event=event,
+            agent_id="our_agent",
+            available_resources={},
+            market_state={},
+        )
+
+        with patch("app.policies.store.get_registry_client") as mock_get_registry:
+            mock_registry = AsyncMock()
+            mock_registry.query_orders = AsyncMock(return_value=[])
+            mock_get_registry.return_value = mock_registry
+
+            func = policy_store._registry.get("negotiation.respond_to_make_offer")
+            result = await func(context)
+
+        assert result is not None
+        assert result.action_type.value == "reject_offer"
+        assert result.parameters.get("reason") == "no_matching_order"
+
+    @pytest.mark.asyncio
+    async def test_non_make_offer_event_returns_none(self, policy_store):
+        """Policy returns None for non-make_offer events."""
+        from app.schema.pydantic_models import NegotiationEvent
+
+        event = NegotiationEvent.create(
+            event_id="evt_negotiation",
+            negotiation_id="test_neg",
+            message_type="counter_proposal",
+            sender="other_agent",
+            data={"proposed_price": 100},
+        )
+
+        context = DecisionContext(
+            event=event,
+            agent_id="our_agent",
+            available_resources={},
+            market_state={},
+        )
+
+        func = policy_store._registry.get("negotiation.respond_to_make_offer")
+        result = await func(context)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_negotiation_id_deterministic(self, policy_store, maximizer_order):
+        """Negotiation ID is deterministic regardless of which agent initiates."""
+        minimizer_our_order = MarketOrder(
+            order_id="order_A",
+            order_maker="our_agent",
+            offer_resource=TokenResource(
+                token=ERC20TokenMetadata(symbol="USDC", contract_address="0x1234", decimals=6),
+                amount=100,
+            ),
+            demand_resource=ComputeResource(
+                gpu_model=GPUModel.H200, quantity=1, sla=99.9, region=Region.CALIFORNIA_US,
+            ),
+            duration=3600,
+        )
+
+        incoming_order = MarketOrder(
+            order_id="order_B",
+            order_maker="agent_B",
+            offer_resource=ComputeResource(
+                gpu_model=GPUModel.H200, quantity=1, sla=99.9, region=Region.CALIFORNIA_US,
+            ),
+            demand_resource=TokenResource(
+                token=ERC20TokenMetadata(symbol="USDC", contract_address="0x1234", decimals=6),
+                amount=100,
+            ),
+            duration=3600,
+        )
+
+        event = MakeOfferEvent(
+            event_id="evt_incoming",
+            source="agent_B",
+            order=incoming_order,
+        )
+
+        context = DecisionContext(
+            event=event,
+            agent_id="our_agent",
+            available_resources={},
+            market_state={},
+        )
+
+        with patch("app.policies.store.get_registry_client") as mock_get_registry:
+            mock_registry = AsyncMock()
+            mock_registry.query_orders = AsyncMock(return_value=[
+                minimizer_our_order.model_dump(mode="json"),
+            ])
+            mock_get_registry.return_value = mock_registry
+
+            func = policy_store._registry.get("negotiation.respond_to_make_offer")
+            result = await func(context)
+
+        assert result is not None
+        neg_id = result.parameters.get("negotiation_id")
+        assert neg_id == "order_A_order_B"
+
+
+class TestThreadCreationWithInitialPriceAndStrategy:
+    """Test thread creation includes our_initial_price and our_strategy."""
+
+    @pytest.fixture
+    def thread_store(self, temp_db):
+        from app.policies.negotiation_thread import NegotiationThreadStore
+        sqlite_client = SQLiteClient(db_path=temp_db)
+        return NegotiationThreadStore(sqlite_client=sqlite_client)
+
+    @pytest.mark.asyncio
+    async def test_thread_created_with_initial_price_and_strategy(self, thread_store):
+        """Thread stores our_initial_price and our_strategy locally."""
+        await thread_store.create_thread(
+            negotiation_id="test_neg_1",
+            our_order_id="order_our",
+            their_order_id="order_their",
+            our_agent_id="agent_our",
+            their_agent_id="agent_their",
+            owner_id="agent_our",
+            our_initial_price=100,
+            our_strategy="minimize",
+        )
+
+        thread_info = await thread_store.get_thread_info(
+            negotiation_id="test_neg_1",
+            owner_id="agent_our",
+        )
+
+        assert thread_info is not None
+        assert thread_info["our_initial_price"] == 100
+        assert thread_info["our_strategy"] == "minimize"
+
+    @pytest.mark.asyncio
+    async def test_local_state_isolated_per_agent(self, thread_store):
+        """Each agent has their own local_state for the same negotiation."""
+        await thread_store.create_thread(
+            negotiation_id="test_neg_2",
+            our_order_id="order_A",
+            their_order_id="order_B",
+            our_agent_id="agent_A",
+            their_agent_id="agent_B",
+            owner_id="agent_A",
+            our_initial_price=100,
+            our_strategy="minimize",
+        )
+
+        await thread_store.create_thread(
+            negotiation_id="test_neg_2",
+            our_order_id="order_B",
+            their_order_id="order_A",
+            our_agent_id="agent_B",
+            their_agent_id="agent_A",
+            owner_id="agent_B",
+            our_initial_price=100,
+            our_strategy="maximize",
+        )
+
+        state_A = await thread_store.get_thread_info(
+            negotiation_id="test_neg_2",
+            owner_id="agent_A",
+        )
+        state_B = await thread_store.get_thread_info(
+            negotiation_id="test_neg_2",
+            owner_id="agent_B",
+        )
+
+        assert state_A["our_strategy"] == "minimize"
+        assert state_B["our_strategy"] == "maximize"
+
+    @pytest.mark.asyncio
+    async def test_public_thread_does_not_expose_strategy(self, thread_store):
+        """Public thread info does not expose private strategy."""
+        await thread_store.create_thread(
+            negotiation_id="test_neg_3",
+            our_order_id="order_our",
+            their_order_id="order_their",
+            our_agent_id="agent_our",
+            their_agent_id="agent_their",
+            owner_id="agent_our",
+            our_initial_price=100,
+            our_strategy="minimize",
+        )
+
+        thread_info = await thread_store.get_thread_info(
+            negotiation_id="test_neg_3",
+            owner_id="agent_their",  # Different owner won't see private state
+        )
+
+        assert thread_info is not None
+        # Different owner can't see private state (values are None)
+        assert thread_info.get("our_strategy") is None
+        assert thread_info.get("our_initial_price") is None

--- a/agents/a2a-agent-trader/tests/unit/test_price_negotiation.py
+++ b/agents/a2a-agent-trader/tests/unit/test_price_negotiation.py
@@ -1,20 +1,20 @@
-"""Parametrized price negotiation tests for role-aware smart policies.
+"""Parametrized price negotiation tests for strategy-aware smart policies.
 
 Tests the price_aware_decision (negotiation_action_price_interval_concession) policy.
 
-ROLE-AWARE POLICY BEHAVIOR:
+STRATEGY-AWARE POLICY BEHAVIOR:
 
-Buyer (demanding compute, our_price = max willing to pay):
-- Accepts if 50% <= their_price <= 120% of our_price (reasonable range)
-- Counters if 120% < their_price <= 200% of our_price (high but reasonable)
-- Exits if their_price < 50% or > 200% of our_price
+Minimizer (demanding compute, our_price = ceiling/max willing to pay):
+- Accepts if their_price <= our_price (favorable - at or below ceiling)
+- Counters if our_price < their_price <= 1.5x our_price (above ceiling but reasonable)
+- Exits if their_price > 1.5x our_price (unreasonable)
 
-Seller (offering compute, our_price = min willing to accept):
-- Accepts if 80% <= their_price <= 200% of our_price (reasonable range)
-- Counters if 50% <= their_price < 80% of our_price (low but reasonable)
-- Exits if their_price < 50% or > 200% of our_price
+Maximizer (offering compute, our_price = floor/min willing to accept):
+- Accepts if their_price >= our_price (favorable - at or above floor)
+- Counters if 0.67x our_price <= their_price < our_price (below floor but reasonable)
+- Exits if their_price < 0.67x our_price (unreasonable)
 
-NOTE: Policy requires role to be specified. If no role, passes to next policy.
+NOTE: Policy requires strategy to be specified. If no strategy, passes to next policy.
 """
 
 import pytest
@@ -66,36 +66,26 @@ def policy_store(temp_db):
     CALLABLE_REGISTRY.clear()
 
 
-class TestBuyerNegotiation:
-    """Test buyer role negotiation (demanding compute, offering tokens)."""
+class TestMinimizerStrategy:
+    """Test minimizer strategy (demanding compute, offering tokens)."""
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("our_price,their_price,expected_action,reason", [
-        # Buyer accepts up to 120% of max (within band)
-        (100, 70, "accept_offer", "within buyer band"),
-        (100, 80, "accept_offer", "within buyer band"),
-        (100, 90, "accept_offer", "within buyer band"),
-        (100, 100, "accept_offer", "equal to max"),
-        (100, 110, "accept_offer", "within buyer band"),
-        (100, 120, "accept_offer", "at buyer max (120%)"),
-
-        # Buyer counters if reasonable but above 120%
-        (100, 125, "counter_offer", "above band but reasonable"),
-        (100, 130, "counter_offer", "above band but reasonable"),
-        (100, 150, "counter_offer", "above band but reasonable"),
-        (100, 180, "counter_offer", "above band but reasonable"),
-        (100, 200, "counter_offer", "at reasonable upper bound"),
-
-        # Buyer exits far outside reasonable
-        (100, 40, "exit_negotiation", "far below 50%"),
-        (100, 49, "exit_negotiation", "below reasonable"),
-        (100, 250, "exit_negotiation", "far above 200%"),
+        # Minimizer accepts if their_price <= our_price (favorable - at or below ceiling)
+        (100, 50, "accept_offer", "well below ceiling"),
+        (100, 80, "accept_offer", "below ceiling"),
+        (100, 90, "accept_offer", "below ceiling"),
+        (100, 100, "accept_offer", "at ceiling"),
+        (100, 110, "counter_offer", "above ceiling - should counter"),
+        (100, 150, "counter_offer", "at 1.5x boundary - counter"),
+        (100, 151, "exit_negotiation", "beyond 1.5x - exit"),
+        (100, 200, "exit_negotiation", "way beyond - exit"),
     ])
-    async def test_buyer_price_aware_decision(self, policy_store, our_price, their_price, expected_action, reason):
-        """Test buyer negotiation policy at various price points."""
+    async def test_minimizer_decisions(self, policy_store, our_price, their_price, expected_action, reason):
+        """Test minimizer strategy at various price points."""
         event = NegotiationEvent.create(
-            event_id=f"evt_test_buyer_{our_price}_{their_price}",
-            negotiation_id=f"test_buyer_{our_price}_{their_price}",
+            event_id=f"evt_test_minimizer_{our_price}_{their_price}",
+            negotiation_id=f"test_minimizer_{our_price}_{their_price}",
             message_type="counter_proposal",
             sender="other_agent",
             data={
@@ -103,7 +93,7 @@ class TestBuyerNegotiation:
                 "their_price": their_price,
                 "our_order_id": "order_our",
                 "their_order_id": "order_their",
-                "role": "buyer",
+                "strategy": "minimize",
             }
         )
 
@@ -125,19 +115,65 @@ class TestBuyerNegotiation:
             f"Expected {expected_action}, got {result.action_type.value} for: our={our_price}, their={their_price}, reason={reason}"
 
     @pytest.mark.asyncio
-    async def test_buyer_counter_calculation(self, policy_store):
-        """Test buyer counter-offer price calculation."""
+    @pytest.mark.parametrize("our_price,their_price,expected_action", [
+        # Minimizer: accept if <= our_price
+        (100, 100, "accept_offer"),   # At ceiling - accept
+        (100, 80, "accept_offer"),    # Below ceiling - accept
+        (100, 50, "accept_offer"),    # Well below - accept
+        (100, 0, "accept_offer"),     # Zero - accept (edge case)
+        # Minimizer: counter if our_price < their_price <= 1.5x
+        (100, 110, "counter_offer"),  # Above ceiling, reasonable
+        (100, 140, "counter_offer"),  # Above ceiling, still reasonable
+        (100, 150, "counter_offer"),  # At 1.5x boundary - counter
+        # Minimizer: exit if > 1.5x
+        (100, 151, "exit_negotiation"),  # Beyond 1.5x - exit
+        (100, 200, "exit_negotiation"),  # Way beyond - exit
+        (100, 1000, "exit_negotiation"), # Extreme - exit
+    ])
+    async def test_minimizer_complete_coverage(self, policy_store, our_price, their_price, expected_action):
+        """Test minimizer strategy with complete coverage of all cases."""
         event = NegotiationEvent.create(
-            event_id="evt_test_buyer_counter",
-            negotiation_id="test_buyer_counter",
+            event_id=f"evt_test_min_{our_price}_{their_price}",
+            negotiation_id=f"test_min_{our_price}_{their_price}",
+            message_type="counter_proposal",
+            sender="other_agent",
+            data={
+                "our_price": our_price,
+                "their_price": their_price,
+                "our_order_id": "order_our",
+                "their_order_id": "order_their",
+                "strategy": "minimize",
+            }
+        )
+
+        context = DecisionContext(
+            event=event,
+            agent_id="test_agent",
+            available_resources={},
+            negotiation_history=[]
+        )
+
+        func = policy_store._registry.get("negotiation.action.price_interval_concession")
+        ce = CallableEvaluator(func)
+        result = await ce.evaluate(context)
+
+        assert result is not None
+        assert result.action_type.value == expected_action
+
+    @pytest.mark.asyncio
+    async def test_minimizer_counter_calculation(self, policy_store):
+        """Test minimizer counter-offer price calculation (midpoint)."""
+        event = NegotiationEvent.create(
+            event_id="evt_test_minimizer_counter",
+            negotiation_id="test_minimizer_counter",
             message_type="counter_proposal",
             sender="other_agent",
             data={
                 "our_price": 100,
-                "their_price": 150,
+                "their_price": 140,
                 "our_order_id": "order_our",
                 "their_order_id": "order_their",
-                "role": "buyer",
+                "strategy": "minimize",
             }
         )
 
@@ -152,44 +188,36 @@ class TestBuyerNegotiation:
         ce = CallableEvaluator(func)
         result = await ce.evaluate(context)
 
-        # Should counter with midpoint: (100 + 150) // 2 = 125
+        # Should counter with midpoint: (100 + 140) // 2 = 120
         assert result is not None
         assert result.action_type.value == "counter_offer"
-        assert result.parameters.get("proposed_price") == 125
+        assert result.parameters.get("proposed_price") == 120
 
 
-class TestSellerNegotiation:
-    """Test seller role negotiation (offering compute, demanding tokens)."""
+class TestMaximizerStrategy:
+    """Test maximizer strategy (offering compute, demanding tokens)."""
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("our_price,their_price,expected_action,reason", [
-        # Seller accepts at least 80% of min (within band)
-        (100, 80, "accept_offer", "at seller min (80%)"),
-        (100, 85, "accept_offer", "within seller band"),
-        (100, 90, "accept_offer", "within seller band"),
-        (100, 100, "accept_offer", "equal to min"),
-        (100, 110, "accept_offer", "within seller band"),
-        (100, 120, "accept_offer", "within seller band"),
-        (100, 150, "accept_offer", "within seller band"),
-        (100, 180, "accept_offer", "within seller band"),
-        (100, 200, "accept_offer", "at seller upper bound"),
-
-        # Seller counters if reasonable but below 80%
-        (100, 75, "counter_offer", "below band but reasonable"),
-        (100, 70, "counter_offer", "below band but reasonable"),
-        (100, 60, "counter_offer", "below band but reasonable"),
-        (100, 50, "counter_offer", "at reasonable lower bound"),
-
-        # Seller exits far outside reasonable
-        (100, 40, "exit_negotiation", "far below 50%"),
-        (100, 49, "exit_negotiation", "below reasonable"),
-        (100, 250, "exit_negotiation", "far above 200%"),
+    @pytest.mark.parametrize("our_price,their_price,expected_action", [
+        # Maximizer: accept if their_price >= our_price
+        (100, 100, "accept_offer"),   # At floor - accept
+        (100, 120, "accept_offer"),   # Above floor - accept
+        (100, 200, "accept_offer"),   # Well above - accept
+        (100, 1000, "accept_offer"),  # Extreme - accept
+        # Maximizer: counter if 0.67x <= their_price < our_price (where 0.67 ≈ 1/1.5)
+        (100, 90, "counter_offer"),   # Below floor, reasonable
+        (100, 70, "counter_offer"),   # Below floor, still reasonable
+        (100, 67, "counter_offer"),   # At 1/1.5 boundary - counter
+        # Maximizer: exit if < 0.67x
+        (100, 66, "exit_negotiation"),  # Beyond boundary - exit
+        (100, 50, "exit_negotiation"),  # Way below - exit
+        (100, 0, "exit_negotiation"),   # Zero - exit
     ])
-    async def test_seller_price_aware_decision(self, policy_store, our_price, their_price, expected_action, reason):
-        """Test seller negotiation policy at various price points."""
+    async def test_maximizer_decisions(self, policy_store, our_price, their_price, expected_action):
+        """Test maximizer strategy at various price points."""
         event = NegotiationEvent.create(
-            event_id=f"evt_test_seller_{our_price}_{their_price}",
-            negotiation_id=f"test_seller_{our_price}_{their_price}",
+            event_id=f"evt_test_maximizer_{our_price}_{their_price}",
+            negotiation_id=f"test_maximizer_{our_price}_{their_price}",
             message_type="counter_proposal",
             sender="other_agent",
             data={
@@ -197,7 +225,7 @@ class TestSellerNegotiation:
                 "their_price": their_price,
                 "our_order_id": "order_our",
                 "their_order_id": "order_their",
-                "role": "seller",
+                "strategy": "maximize",
             }
         )
 
@@ -209,21 +237,19 @@ class TestSellerNegotiation:
         )
 
         func = policy_store._registry.get("negotiation.action.price_interval_concession")
-        assert func is not None, "Policy not registered"
-
         ce = CallableEvaluator(func)
         result = await ce.evaluate(context)
 
-        assert result is not None, f"Policy returned None for: our={our_price}, their={their_price}, reason={reason}"
+        assert result is not None, f"Policy returned None for: our={our_price}, their={their_price}"
         assert result.action_type.value == expected_action, \
-            f"Expected {expected_action}, got {result.action_type.value} for: our={our_price}, their={their_price}, reason={reason}"
+            f"Expected {expected_action}, got {result.action_type.value} for: our={our_price}, their={their_price}"
 
     @pytest.mark.asyncio
-    async def test_seller_counter_calculation(self, policy_store):
-        """Test seller counter-offer price calculation."""
+    async def test_maximizer_counter_calculation(self, policy_store):
+        """Test maximizer counter-offer price calculation (midpoint)."""
         event = NegotiationEvent.create(
-            event_id="evt_test_seller_counter",
-            negotiation_id="test_seller_counter",
+            event_id="evt_test_maximizer_counter",
+            negotiation_id="test_maximizer_counter",
             message_type="counter_proposal",
             sender="other_agent",
             data={
@@ -231,7 +257,7 @@ class TestSellerNegotiation:
                 "their_price": 70,
                 "our_order_id": "order_our",
                 "their_order_id": "order_their",
-                "role": "seller",
+                "strategy": "maximize",
             }
         )
 
@@ -256,11 +282,11 @@ class TestNegotiationScenarios:
     """Test realistic negotiation scenarios."""
 
     @pytest.mark.asyncio
-    async def test_no_role_passes_to_next_policy(self, policy_store):
-        """Test that policy passes to next policy when no role is specified."""
+    async def test_no_strategy_passes_to_next_policy(self, policy_store):
+        """Test that policy passes to next policy when no strategy is specified."""
         event = NegotiationEvent.create(
-            event_id="evt_test_no_role",
-            negotiation_id="test_no_role",
+            event_id="evt_test_no_strategy",
+            negotiation_id="test_no_strategy",
             message_type="counter_proposal",
             sender="other_agent",
             data={
@@ -268,7 +294,7 @@ class TestNegotiationScenarios:
                 "their_price": 110,
                 "our_order_id": "order_our",
                 "their_order_id": "order_their",
-                # No role specified
+                # No strategy specified
             }
         )
 
@@ -283,115 +309,115 @@ class TestNegotiationScenarios:
         ce = CallableEvaluator(func)
         result = await ce.evaluate(context)
 
-        # Should return None (pass to next policy) when no role specified
-        assert result is None, "Policy should pass to next policy when no role is specified"
+        # Should return None (pass to next policy) when no strategy specified
+        assert result is None, "Policy should pass to next policy when no strategy is specified"
 
     @pytest.mark.asyncio
-    async def test_buyer_seller_equilibrium(self, policy_store):
-        """Test that buyer and seller reach equilibrium at same price.
+    async def test_minimizer_maximizer_equilibrium(self, policy_store):
+        """Test that minimizer and maximizer reach equilibrium at same price.
 
-        Buyer at 100 (max) receives offer at 110 → accepts
-        Seller at 100 (min) receives offer at 110 → accepts
-        Equilibrium reached!
+        Minimizer at 100 (ceiling) receives offer at 110 → counters (110 > 100)
+        Maximizer at 100 (floor) receives offer at 110 → accepts (110 >= 100)
         """
-        # Buyer perspective
-        buyer_event = NegotiationEvent.create(
-            event_id="evt_test_buyer_eq",
+        # Minimizer perspective (ceiling=100, sees 110)
+        minimizer_event = NegotiationEvent.create(
+            event_id="evt_test_min_eq",
             negotiation_id="test_eq",
             message_type="counter_proposal",
-            sender="seller_agent",
-            data={"our_price": 100, "their_price": 110, "role": "buyer",
-                   "our_order_id": "order_buyer", "their_order_id": "order_seller"}
+            sender="maximizer_agent",
+            data={"our_price": 100, "their_price": 110, "strategy": "minimize",
+                   "our_order_id": "order_min", "their_order_id": "order_max"}
         )
 
-        buyer_context = DecisionContext(
-            event=buyer_event,
-            agent_id="buyer_agent",
+        minimizer_context = DecisionContext(
+            event=minimizer_event,
+            agent_id="minimizer_agent",
             available_resources={},
             negotiation_history=[]
         )
 
         func = policy_store._registry.get("negotiation.action.price_interval_concession")
         ce = CallableEvaluator(func)
-        buyer_result = await ce.evaluate(buyer_context)
+        minimizer_result = await ce.evaluate(minimizer_context)
 
-        # Seller perspective
-        seller_event = NegotiationEvent.create(
-            event_id="evt_test_seller_eq",
+        # Maximizer perspective (floor=100, sees 110)
+        maximizer_event = NegotiationEvent.create(
+            event_id="evt_test_max_eq",
             negotiation_id="test_eq",
             message_type="counter_proposal",
-            sender="buyer_agent",
-            data={"our_price": 100, "their_price": 110, "role": "seller",
-                   "our_order_id": "order_seller", "their_order_id": "order_buyer"}
+            sender="minimizer_agent",
+            data={"our_price": 100, "their_price": 110, "strategy": "maximize",
+                   "our_order_id": "order_max", "their_order_id": "order_min"}
         )
 
-        seller_context = DecisionContext(
-            event=seller_event,
-            agent_id="seller_agent",
+        maximizer_context = DecisionContext(
+            event=maximizer_event,
+            agent_id="maximizer_agent",
             available_resources={},
             negotiation_history=[]
         )
 
-        seller_result = await ce.evaluate(seller_context)
+        maximizer_result = await ce.evaluate(maximizer_context)
 
-        # Both should accept at 110
-        assert buyer_result.action_type.value == "accept_offer"
-        assert seller_result.action_type.value == "accept_offer"
+        # Maximizer should accept at 110 (>= floor)
+        assert maximizer_result.action_type.value == "accept_offer"
+        # Minimizer should counter at 110 (above ceiling but <= 1.5x)
+        assert minimizer_result.action_type.value == "counter_offer"
 
     @pytest.mark.asyncio
-    async def test_buyer_seller_counter_convergence(self, policy_store):
-        """Test that buyer and seller counter-offers converge toward equilibrium.
+    async def test_minimizer_maximizer_counter_convergence(self, policy_store):
+        """Test that minimizer and maximizer counter-offers converge toward equilibrium.
 
-        Initial: Buyer at 100, Seller at 100
-        Offer: 150 (too high for buyer, good for seller)
-        Expected: Buyer counters to 125
+        Initial: Minimizer at 100, Maximizer at 100
+        Offer: 140 (above minimizer's ceiling)
+        Expected: Minimizer counters to 120, Maximizer accepts (120 >= 100)
         """
-        # Buyer sees 150 → counters to 125
-        buyer_event = NegotiationEvent.create(
-            event_id="evt_test_buyer_conv",
+        # Minimizer sees 140 → counters to 120
+        minimizer_event = NegotiationEvent.create(
+            event_id="evt_test_min_conv",
             negotiation_id="test_conv",
             message_type="counter_proposal",
-            sender="seller_agent",
-            data={"our_price": 100, "their_price": 150, "role": "buyer",
-                   "our_order_id": "order_buyer", "their_order_id": "order_seller"}
+            sender="maximizer_agent",
+            data={"our_price": 100, "their_price": 140, "strategy": "minimize",
+                   "our_order_id": "order_min", "their_order_id": "order_max"}
         )
 
-        buyer_context = DecisionContext(
-            event=buyer_event,
-            agent_id="buyer_agent",
+        minimizer_context = DecisionContext(
+            event=minimizer_event,
+            agent_id="minimizer_agent",
             available_resources={},
             negotiation_history=[]
         )
 
         func = policy_store._registry.get("negotiation.action.price_interval_concession")
         ce = CallableEvaluator(func)
-        buyer_result = await ce.evaluate(buyer_context)
+        minimizer_result = await ce.evaluate(minimizer_context)
 
-        # Buyer should counter
-        assert buyer_result.action_type.value == "counter_offer"
-        assert buyer_result.parameters.get("proposed_price") == 125
+        # Minimizer should counter to 120
+        assert minimizer_result.action_type.value == "counter_offer"
+        assert minimizer_result.parameters.get("proposed_price") == 120
 
-        # Seller sees 125 (from buyer counter) → should accept (>= 80% of min)
-        seller_event = NegotiationEvent.create(
-            event_id="evt_test_seller_conv",
+        # Maximizer sees 120 (from minimizer counter) → should accept (>= floor)
+        maximizer_event = NegotiationEvent.create(
+            event_id="evt_test_max_conv",
             negotiation_id="test_conv",
             message_type="counter_proposal",
-            sender="buyer_agent",
-            data={"our_price": 100, "their_price": 125, "role": "seller",
-                   "our_order_id": "order_seller", "their_order_id": "order_buyer"}
+            sender="minimizer_agent",
+            data={"our_price": 100, "their_price": 120, "strategy": "maximize",
+                   "our_order_id": "order_max", "their_order_id": "order_min"}
         )
 
-        seller_context = DecisionContext(
-            event=seller_event,
-            agent_id="seller_agent",
+        maximizer_context = DecisionContext(
+            event=maximizer_event,
+            agent_id="maximizer_agent",
             available_resources={},
             negotiation_history=[]
         )
 
-        seller_result = await ce.evaluate(seller_context)
+        maximizer_result = await ce.evaluate(maximizer_context)
 
-        # Seller should accept at 125
-        assert seller_result.action_type.value == "accept_offer"
+        # Maximizer should accept at 120 (>= floor of 100)
+        assert maximizer_result.action_type.value == "accept_offer"
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("our_price,their_price,expected_reason", [
@@ -483,13 +509,13 @@ class TestMultipleBilateralNegotiations:
         return NegotiationThreadStore(sqlite_client=sqlite_client)
 
     @pytest.mark.asyncio
-    async def test_buyer_negotiates_with_multiple_sellers(self, policy_store, thread_store):
-        """Agent A (buyer) negotiates with Agents B and C (sellers) independently.
+    async def test_minimizer_negotiates_with_multiple_maximizers(self, policy_store, thread_store):
+        """Agent A (minimizer) negotiates with Agents B and C (maximizers) independently.
 
         Scenario:
-        - Agent A is a buyer with order_A (max price 100)
-        - Agent B is a seller with order_B (asking 150)
-        - Agent C is a seller with order_C (asking 130)
+        - Agent A is a minimizer with order_A (ceiling=100)
+        - Agent B is a maximizer with order_B (asking 150)
+        - Agent C is a maximizer with order_C (asking 130)
         - A should counter both B and C independently
         """
         func = policy_store._registry.get("negotiation.action.price_interval_concession")
@@ -522,7 +548,7 @@ class TestMultipleBilateralNegotiations:
                 "their_price": 150,
                 "our_order_id": "order_A",
                 "their_order_id": "order_B",
-                "role": "buyer",
+                "strategy": "minimize",
             }
         )
         context_B = DecisionContext(
@@ -543,7 +569,7 @@ class TestMultipleBilateralNegotiations:
                 "their_price": 130,
                 "our_order_id": "order_A",
                 "their_order_id": "order_C",
-                "role": "buyer",
+                "strategy": "minimize",
             }
         )
         context_C = DecisionContext(
@@ -600,7 +626,7 @@ class TestMultipleBilateralNegotiations:
 
         Scenario:
         - Agent A has active negotiations with B and C for order_A
-        - B counters with price 110 (acceptable for buyer A)
+        - B counters with price 100 (acceptable for minimizer A - at ceiling)
         - A accepts B's offer
         - Negotiation A↔C should be canceled
         """
@@ -643,7 +669,7 @@ class TestMultipleBilateralNegotiations:
             message_type="initial_proposal",
         )
 
-        # Agent B counters with 110 (within buyer's band)
+        # Agent B counters with 100 (acceptable for minimizer A - at ceiling)
         event_accept = NegotiationEvent.create(
             event_id="evt_A_accept_B",
             negotiation_id="order_A_order_B",
@@ -651,10 +677,10 @@ class TestMultipleBilateralNegotiations:
             sender="agent_B",
             data={
                 "our_price": 100,
-                "their_price": 110,
+                "their_price": 100,
                 "our_order_id": "order_A",
                 "their_order_id": "order_B",
-                "role": "buyer",
+                "strategy": "minimize",
             }
         )
         context = DecisionContext(
@@ -801,13 +827,13 @@ class TestMultipleBilateralNegotiations:
         assert non_existing is None
 
     @pytest.mark.asyncio
-    async def test_multi_round_convergence_with_multiple_sellers(self, policy_store, thread_store):
-        """Test multi-round negotiation where buyer converges with one seller.
+    async def test_multi_round_convergence_with_multiple_maximizers(self, policy_store, thread_store):
+        """Test multi-round negotiation where minimizer converges with one maximizer.
 
         Scenario:
-        - Round 1: A counters B (150→125) and C (130→115)
-        - Round 2: B counters 120, C counters 125
-        - A accepts B's 120 (within band), cancels C
+        - Round 1: Minimizer A counters Maximizers B (150→125) and C (130→115)
+        - Round 2: Both B and C accept (125 >= 100 and 115 >= 100, both acceptable for maximizers)
+        - A accepts whichever completes first, cancels the other
         """
         func = policy_store._registry.get("negotiation.action.price_interval_concession")
         ce = CallableEvaluator(func)
@@ -828,7 +854,7 @@ class TestMultipleBilateralNegotiations:
             their_agent_id="agent_C",
         )
 
-        # Round 1: Both sellers offer high prices
+        # Round 1: Both maximizers offer high prices
         # A counters both
         for neg_id, their_price, expected_counter in [
             ("A_B", 150, 125),
@@ -844,64 +870,58 @@ class TestMultipleBilateralNegotiations:
                 message_type="counter_proposal",
             )
 
-        # Round 2: B counters with 120 (acceptable), C counters with 125 (also needs counter)
-        # First check B's counter of 120
+        # Round 2: B accepts A's counter of 125 (>= floor of 100), C accepts A's counter of 115 (>= floor)
+        # Check B's acceptance of 125
         event_B_round2 = NegotiationEvent.create(
             event_id="evt_B_r2",
             negotiation_id="A_B",
             message_type="counter_proposal",
             sender="agent_B",
             data={
-                "our_price": 100,
-                "their_price": 120,
-                "our_order_id": "order_A",
-                "their_order_id": "order_B",
-                "role": "buyer",
+                "our_price": 100,  # B's floor (maximizer offering compute)
+                "their_price": 125,  # A's counter
+                "our_order_id": "order_B",
+                "their_order_id": "order_A",
+                "strategy": "maximize",
             }
         )
 
-        # Use negotiation history to simulate prior round
         context_B_r2 = DecisionContext(
             event=event_B_round2,
-            agent_id="agent_A",
+            agent_id="agent_B",
             available_resources={},
-            negotiation_history=[
-                {"sender": "agent_A", "proposed_price": 125, "action_taken": "COUNTER_OFFER"}
-            ]
+            negotiation_history=[]
         )
 
         result_B = await ce.evaluate(context_B_r2)
-        # 120 is at boundary (120% of 100), should accept
+        # 125 >= 100 (floor), maximizer should accept
         assert result_B.action_type.value == "accept_offer"
 
-        # Check C's counter of 125 (above 120%, needs counter)
+        # Check C's acceptance of 115
         event_C_round2 = NegotiationEvent.create(
             event_id="evt_C_r2",
             negotiation_id="A_C",
             message_type="counter_proposal",
             sender="agent_C",
             data={
-                "our_price": 100,
-                "their_price": 125,
-                "our_order_id": "order_A",
-                "their_order_id": "order_C",
-                "role": "buyer",
+                "our_price": 100,  # C's floor (maximizer offering compute)
+                "their_price": 115,  # A's counter
+                "our_order_id": "order_C",
+                "their_order_id": "order_A",
+                "strategy": "maximize",
             }
         )
 
         context_C_r2 = DecisionContext(
             event=event_C_round2,
-            agent_id="agent_A",
+            agent_id="agent_C",
             available_resources={},
-            negotiation_history=[
-                {"sender": "agent_A", "proposed_price": 115, "action_taken": "COUNTER_OFFER"}
-            ]
+            negotiation_history=[]
         )
 
         result_C = await ce.evaluate(context_C_r2)
-        # 125 is above 120%, should counter with midpoint of (115 + 125) // 2 = 120
-        assert result_C.action_type.value == "counter_offer"
-        assert result_C.parameters.get("proposed_price") == 120
+        # 115 >= 100 (floor), maximizer should accept
+        assert result_C.action_type.value == "accept_offer"
 
         # Now A accepts B, which should cancel C
         canceled = await thread_store._sqlite.cancel_negotiations_for_order(
@@ -912,21 +932,21 @@ class TestMultipleBilateralNegotiations:
         assert "A_C" in canceled
 
     @pytest.mark.asyncio
-    async def test_seller_negotiates_with_multiple_buyers(self, policy_store, thread_store):
-        """Agent A (seller) negotiates with Agents B and C (buyers) independently.
+    async def test_maximizer_negotiates_with_multiple_minimizers(self, policy_store, thread_store):
+        """Agent A (maximizer) negotiates with Agents B and C (minimizers) independently.
 
         Scenario:
-        - Agent A is a seller with order_A (min price 100)
-        - Agent B is a buyer with order_B (offering 70)
-        - Agent C is a buyer with order_C (offering 90)
-        - A should counter B (below 80%) and accept C (at 90% >= 80%)
+        - Agent A is a maximizer with order_A (floor=100)
+        - Agent B is a minimizer with order_B (offering 70)
+        - Agent C is a minimizer with order_C (offering 90)
+        - A should counter both B and C (both offers below floor but >= 0.67x)
         """
         func = policy_store._registry.get("negotiation.action.price_interval_concession")
         ce = CallableEvaluator(func)
 
-        # Agent A (seller) receives offer from Agent B (price 70)
+        # Agent A (maximizer) receives offer from Agent B (price 70)
         event_from_B = NegotiationEvent.create(
-            event_id="evt_A_from_B_seller",
+            event_id="evt_A_from_B_max",
             negotiation_id="order_A_order_B",
             message_type="initial_proposal",
             sender="agent_B",
@@ -935,7 +955,7 @@ class TestMultipleBilateralNegotiations:
                 "their_price": 70,
                 "our_order_id": "order_A",
                 "their_order_id": "order_B",
-                "role": "seller",
+                "strategy": "maximize",
             }
         )
         context_B = DecisionContext(
@@ -945,9 +965,9 @@ class TestMultipleBilateralNegotiations:
             negotiation_history=[]
         )
 
-        # Agent A (seller) receives offer from Agent C (price 90)
+        # Agent A (maximizer) receives offer from Agent C (price 90)
         event_from_C = NegotiationEvent.create(
-            event_id="evt_A_from_C_seller",
+            event_id="evt_A_from_C_max",
             negotiation_id="order_A_order_C",
             message_type="initial_proposal",
             sender="agent_C",
@@ -956,7 +976,7 @@ class TestMultipleBilateralNegotiations:
                 "their_price": 90,
                 "our_order_id": "order_A",
                 "their_order_id": "order_C",
-                "role": "seller",
+                "strategy": "maximize",
             }
         )
         context_C = DecisionContext(
@@ -969,9 +989,10 @@ class TestMultipleBilateralNegotiations:
         result_B = await ce.evaluate(context_B)
         result_C = await ce.evaluate(context_C)
 
-        # B's offer of 70 is below 80% (80), so seller should counter
+        # B's offer of 70 is below floor (100), but >= 0.67x (67), so maximizer should counter
         assert result_B.action_type.value == "counter_offer"
         assert result_B.parameters.get("proposed_price") == 85  # (100 + 70) // 2
 
-        # C's offer of 90 is >= 80% (80), so seller should accept
-        assert result_C.action_type.value == "accept_offer"
+        # C's offer of 90 is below floor (100), but >= 0.67x (67), so maximizer should counter
+        # Wait, 90 < 100, so maximizer should counter (not accept)
+        assert result_C.action_type.value == "counter_offer"

--- a/agents/a2a-agent-trader/tests/unit/test_price_negotiation.py
+++ b/agents/a2a-agent-trader/tests/unit/test_price_negotiation.py
@@ -94,8 +94,6 @@ def create_test_context(
         sender="other_agent",
         data={
             "proposed_price": their_price,  # What they're proposing
-            "sender_order_id": their_order_id,
-            "target_order_id": our_order_id,
         }
     )
     
@@ -393,8 +391,6 @@ class TestNegotiationScenarios:
             sender="other_agent",
             data={
                 "proposed_price": their_price,
-                "sender_order_id": "order_their",
-                "target_order_id": "order_our",
             }
         )
 
@@ -427,10 +423,7 @@ class TestNegotiationScenarios:
             negotiation_id="test_missing_data",
             message_type="counter_proposal",
             sender="other_agent",
-            data={
-                "sender_order_id": "order_their",
-                "target_order_id": "order_our",
-            }
+            data={}
         )
 
         context = DecisionContext(

--- a/agents/a2a-agent-trader/tests/unit/test_price_negotiation.py
+++ b/agents/a2a-agent-trader/tests/unit/test_price_negotiation.py
@@ -66,6 +66,53 @@ def policy_store(temp_db):
     CALLABLE_REGISTRY.clear()
 
 
+def create_test_context(
+    *,
+    our_price: int | None,
+    their_price: int | None,  # This is what they propose (transmitted as proposed_price)
+    strategy: str | None,
+    negotiation_id: str = "test_negotiation",
+    event_id: str = "evt_test",
+    agent_id: str = "test_agent",
+    our_order_id: str = "order_our",
+    their_order_id: str = "order_their",
+    negotiation_history: list | None = None,
+) -> DecisionContext:
+    """Create a test context with POV-neutral structure.
+    
+    This helper properly separates:
+    - transmitted data: proposed_price (what they're offering)
+    - local POV data: our_initial_price, our_strategy (stored locally, never transmitted)
+    
+    The policy looks up our_initial_price and our_strategy from market_state.thread_info,
+    and interprets proposed_price as their_price.
+    """
+    event = NegotiationEvent.create(
+        event_id=event_id,
+        negotiation_id=negotiation_id,
+        message_type="counter_proposal",
+        sender="other_agent",
+        data={
+            "proposed_price": their_price,  # What they're proposing
+            "sender_order_id": their_order_id,
+            "target_order_id": our_order_id,
+        }
+    )
+    
+    return DecisionContext(
+        event=event,
+        agent_id=agent_id,
+        available_resources={},
+        market_state={
+            "thread_info": {
+                "our_initial_price": our_price,
+                "our_strategy": strategy,
+            }
+        },
+        negotiation_history=negotiation_history or []
+    )
+
+
 class TestMinimizerStrategy:
     """Test minimizer strategy (demanding compute, offering tokens)."""
 
@@ -83,25 +130,12 @@ class TestMinimizerStrategy:
     ])
     async def test_minimizer_decisions(self, policy_store, our_price, their_price, expected_action, reason):
         """Test minimizer strategy at various price points."""
-        event = NegotiationEvent.create(
-            event_id=f"evt_test_minimizer_{our_price}_{their_price}",
+        context = create_test_context(
+            our_price=our_price,
+            their_price=their_price,
+            strategy="minimize",
             negotiation_id=f"test_minimizer_{our_price}_{their_price}",
-            message_type="counter_proposal",
-            sender="other_agent",
-            data={
-                "our_price": our_price,
-                "their_price": their_price,
-                "our_order_id": "order_our",
-                "their_order_id": "order_their",
-                "strategy": "minimize",
-            }
-        )
-
-        context = DecisionContext(
-            event=event,
-            agent_id="test_agent",
-            available_resources={},
-            negotiation_history=[]
+            event_id=f"evt_test_minimizer_{our_price}_{their_price}",
         )
 
         func = policy_store._registry.get("negotiation.action.price_interval_concession")
@@ -132,25 +166,12 @@ class TestMinimizerStrategy:
     ])
     async def test_minimizer_complete_coverage(self, policy_store, our_price, their_price, expected_action):
         """Test minimizer strategy with complete coverage of all cases."""
-        event = NegotiationEvent.create(
-            event_id=f"evt_test_min_{our_price}_{their_price}",
+        context = create_test_context(
+            our_price=our_price,
+            their_price=their_price,
+            strategy="minimize",
             negotiation_id=f"test_min_{our_price}_{their_price}",
-            message_type="counter_proposal",
-            sender="other_agent",
-            data={
-                "our_price": our_price,
-                "their_price": their_price,
-                "our_order_id": "order_our",
-                "their_order_id": "order_their",
-                "strategy": "minimize",
-            }
-        )
-
-        context = DecisionContext(
-            event=event,
-            agent_id="test_agent",
-            available_resources={},
-            negotiation_history=[]
+            event_id=f"evt_test_min_{our_price}_{their_price}",
         )
 
         func = policy_store._registry.get("negotiation.action.price_interval_concession")
@@ -163,25 +184,12 @@ class TestMinimizerStrategy:
     @pytest.mark.asyncio
     async def test_minimizer_counter_calculation(self, policy_store):
         """Test minimizer counter-offer price calculation (midpoint)."""
-        event = NegotiationEvent.create(
-            event_id="evt_test_minimizer_counter",
+        context = create_test_context(
+            our_price=100,
+            their_price=140,
+            strategy="minimize",
             negotiation_id="test_minimizer_counter",
-            message_type="counter_proposal",
-            sender="other_agent",
-            data={
-                "our_price": 100,
-                "their_price": 140,
-                "our_order_id": "order_our",
-                "their_order_id": "order_their",
-                "strategy": "minimize",
-            }
-        )
-
-        context = DecisionContext(
-            event=event,
-            agent_id="test_agent",
-            available_resources={},
-            negotiation_history=[]
+            event_id="evt_test_minimizer_counter",
         )
 
         func = policy_store._registry.get("negotiation.action.price_interval_concession")
@@ -215,25 +223,12 @@ class TestMaximizerStrategy:
     ])
     async def test_maximizer_decisions(self, policy_store, our_price, their_price, expected_action):
         """Test maximizer strategy at various price points."""
-        event = NegotiationEvent.create(
-            event_id=f"evt_test_maximizer_{our_price}_{their_price}",
+        context = create_test_context(
+            our_price=our_price,
+            their_price=their_price,
+            strategy="maximize",
             negotiation_id=f"test_maximizer_{our_price}_{their_price}",
-            message_type="counter_proposal",
-            sender="other_agent",
-            data={
-                "our_price": our_price,
-                "their_price": their_price,
-                "our_order_id": "order_our",
-                "their_order_id": "order_their",
-                "strategy": "maximize",
-            }
-        )
-
-        context = DecisionContext(
-            event=event,
-            agent_id="test_agent",
-            available_resources={},
-            negotiation_history=[]
+            event_id=f"evt_test_maximizer_{our_price}_{their_price}",
         )
 
         func = policy_store._registry.get("negotiation.action.price_interval_concession")
@@ -247,25 +242,12 @@ class TestMaximizerStrategy:
     @pytest.mark.asyncio
     async def test_maximizer_counter_calculation(self, policy_store):
         """Test maximizer counter-offer price calculation (midpoint)."""
-        event = NegotiationEvent.create(
-            event_id="evt_test_maximizer_counter",
+        context = create_test_context(
+            our_price=100,
+            their_price=70,
+            strategy="maximize",
             negotiation_id="test_maximizer_counter",
-            message_type="counter_proposal",
-            sender="other_agent",
-            data={
-                "our_price": 100,
-                "their_price": 70,
-                "our_order_id": "order_our",
-                "their_order_id": "order_their",
-                "strategy": "maximize",
-            }
-        )
-
-        context = DecisionContext(
-            event=event,
-            agent_id="test_agent",
-            available_resources={},
-            negotiation_history=[]
+            event_id="evt_test_maximizer_counter",
         )
 
         func = policy_store._registry.get("negotiation.action.price_interval_concession")
@@ -320,20 +302,13 @@ class TestNegotiationScenarios:
         Maximizer at 100 (floor) receives offer at 110 → accepts (110 >= 100)
         """
         # Minimizer perspective (ceiling=100, sees 110)
-        minimizer_event = NegotiationEvent.create(
-            event_id="evt_test_min_eq",
-            negotiation_id="test_eq",
-            message_type="counter_proposal",
-            sender="maximizer_agent",
-            data={"our_price": 100, "their_price": 110, "strategy": "minimize",
-                   "our_order_id": "order_min", "their_order_id": "order_max"}
-        )
-
-        minimizer_context = DecisionContext(
-            event=minimizer_event,
+        minimizer_context = create_test_context(
+            our_price=100,
+            their_price=110,
+            strategy="minimize",
             agent_id="minimizer_agent",
-            available_resources={},
-            negotiation_history=[]
+            negotiation_id="test_eq",
+            event_id="evt_test_min_eq",
         )
 
         func = policy_store._registry.get("negotiation.action.price_interval_concession")
@@ -341,20 +316,13 @@ class TestNegotiationScenarios:
         minimizer_result = await ce.evaluate(minimizer_context)
 
         # Maximizer perspective (floor=100, sees 110)
-        maximizer_event = NegotiationEvent.create(
-            event_id="evt_test_max_eq",
-            negotiation_id="test_eq",
-            message_type="counter_proposal",
-            sender="minimizer_agent",
-            data={"our_price": 100, "their_price": 110, "strategy": "maximize",
-                   "our_order_id": "order_max", "their_order_id": "order_min"}
-        )
-
-        maximizer_context = DecisionContext(
-            event=maximizer_event,
+        maximizer_context = create_test_context(
+            our_price=100,
+            their_price=110,
+            strategy="maximize",
             agent_id="maximizer_agent",
-            available_resources={},
-            negotiation_history=[]
+            negotiation_id="test_eq",
+            event_id="evt_test_max_eq",
         )
 
         maximizer_result = await ce.evaluate(maximizer_context)
@@ -373,20 +341,13 @@ class TestNegotiationScenarios:
         Expected: Minimizer counters to 120, Maximizer accepts (120 >= 100)
         """
         # Minimizer sees 140 → counters to 120
-        minimizer_event = NegotiationEvent.create(
-            event_id="evt_test_min_conv",
-            negotiation_id="test_conv",
-            message_type="counter_proposal",
-            sender="maximizer_agent",
-            data={"our_price": 100, "their_price": 140, "strategy": "minimize",
-                   "our_order_id": "order_min", "their_order_id": "order_max"}
-        )
-
-        minimizer_context = DecisionContext(
-            event=minimizer_event,
+        minimizer_context = create_test_context(
+            our_price=100,
+            their_price=140,
+            strategy="minimize",
             agent_id="minimizer_agent",
-            available_resources={},
-            negotiation_history=[]
+            negotiation_id="test_conv",
+            event_id="evt_test_min_conv",
         )
 
         func = policy_store._registry.get("negotiation.action.price_interval_concession")
@@ -398,20 +359,13 @@ class TestNegotiationScenarios:
         assert minimizer_result.parameters.get("proposed_price") == 120
 
         # Maximizer sees 120 (from minimizer counter) → should accept (>= floor)
-        maximizer_event = NegotiationEvent.create(
-            event_id="evt_test_max_conv",
-            negotiation_id="test_conv",
-            message_type="counter_proposal",
-            sender="minimizer_agent",
-            data={"our_price": 100, "their_price": 120, "strategy": "maximize",
-                   "our_order_id": "order_max", "their_order_id": "order_min"}
-        )
-
-        maximizer_context = DecisionContext(
-            event=maximizer_event,
+        maximizer_context = create_test_context(
+            our_price=100,
+            their_price=120,
+            strategy="maximize",
             agent_id="maximizer_agent",
-            available_resources={},
-            negotiation_history=[]
+            negotiation_id="test_conv",
+            event_id="evt_test_max_conv",
         )
 
         maximizer_result = await ce.evaluate(maximizer_context)
@@ -438,10 +392,9 @@ class TestNegotiationScenarios:
             message_type="counter_proposal",
             sender="other_agent",
             data={
-                "our_price": our_price,
-                "their_price": their_price,
-                "our_order_id": "order_our",
-                "their_order_id": "order_their",
+                "proposed_price": their_price,
+                "sender_order_id": "order_their",
+                "target_order_id": "order_our",
             }
         )
 
@@ -449,6 +402,12 @@ class TestNegotiationScenarios:
             event=event,
             agent_id="test_agent",
             available_resources={},
+            market_state={
+                "thread_info": {
+                    "our_initial_price": our_price,
+                    "our_strategy": "minimize"
+                }
+            },
             negotiation_history=[]
         )
 
@@ -456,7 +415,6 @@ class TestNegotiationScenarios:
         ce = CallableEvaluator(func)
         result = await ce.evaluate(context)
 
-        # Should reject for safety
         assert result is not None, "Safe default should always return an action"
         assert result.action_type.value == "reject_offer"
         assert result.parameters.get("reason") == expected_reason
@@ -470,9 +428,8 @@ class TestNegotiationScenarios:
             message_type="counter_proposal",
             sender="other_agent",
             data={
-                # Missing our_price and their_price
-                "our_order_id": "order_our",
-                "their_order_id": "order_their",
+                "sender_order_id": "order_their",
+                "target_order_id": "order_our",
             }
         )
 
@@ -480,6 +437,10 @@ class TestNegotiationScenarios:
             event=event,
             agent_id="test_agent",
             available_resources={},
+            market_state={
+                 # Missing thread_info
+                 "thread_info": {}
+            },
             negotiation_history=[]
         )
 
@@ -521,13 +482,16 @@ class TestMultipleBilateralNegotiations:
         func = policy_store._registry.get("negotiation.action.price_interval_concession")
         ce = CallableEvaluator(func)
 
-        # Create negotiation threads for A↔B and A↔C
+        # Create negotiation threads for A↔B and A↔C with our_initial_price and our_strategy
         await thread_store.create_thread(
             negotiation_id="order_A_order_B",
             our_order_id="order_A",
             their_order_id="order_B",
             our_agent_id="agent_A",
             their_agent_id="agent_B",
+            owner_id="agent_A",
+            our_initial_price=100,
+            our_strategy="minimize",
         )
         await thread_store.create_thread(
             negotiation_id="order_A_order_C",
@@ -535,48 +499,29 @@ class TestMultipleBilateralNegotiations:
             their_order_id="order_C",
             our_agent_id="agent_A",
             their_agent_id="agent_C",
+            owner_id="agent_A",
+            our_initial_price=100,
+            our_strategy="minimize",
         )
 
         # Agent A receives offer from Agent B (price 150)
-        event_from_B = NegotiationEvent.create(
-            event_id="evt_A_from_B",
-            negotiation_id="order_A_order_B",
-            message_type="initial_proposal",
-            sender="agent_B",
-            data={
-                "our_price": 100,
-                "their_price": 150,
-                "our_order_id": "order_A",
-                "their_order_id": "order_B",
-                "strategy": "minimize",
-            }
-        )
-        context_B = DecisionContext(
-            event=event_from_B,
+        context_B = create_test_context(
+            our_price=100,
+            their_price=150,
+            strategy="minimize",
             agent_id="agent_A",
-            available_resources={},
-            negotiation_history=[]
+            negotiation_id="order_A_order_B",
+            event_id="evt_A_from_B",
         )
 
         # Agent A receives offer from Agent C (price 130)
-        event_from_C = NegotiationEvent.create(
-            event_id="evt_A_from_C",
-            negotiation_id="order_A_order_C",
-            message_type="initial_proposal",
-            sender="agent_C",
-            data={
-                "our_price": 100,
-                "their_price": 130,
-                "our_order_id": "order_A",
-                "their_order_id": "order_C",
-                "strategy": "minimize",
-            }
-        )
-        context_C = DecisionContext(
-            event=event_from_C,
+        context_C = create_test_context(
+            our_price=100,
+            their_price=130,
+            strategy="minimize",
             agent_id="agent_A",
-            available_resources={},
-            negotiation_history=[]
+            negotiation_id="order_A_order_C",
+            event_id="evt_A_from_C",
         )
 
         # Evaluate both negotiations
@@ -633,13 +578,16 @@ class TestMultipleBilateralNegotiations:
         func = policy_store._registry.get("negotiation.action.price_interval_concession")
         ce = CallableEvaluator(func)
 
-        # Create both negotiation threads
+        # Create both negotiation threads with our_initial_price and our_strategy
         await thread_store.create_thread(
             negotiation_id="order_A_order_B",
             our_order_id="order_A",
             their_order_id="order_B",
             our_agent_id="agent_A",
             their_agent_id="agent_B",
+            our_initial_price=100,
+            our_strategy="minimize",
+            owner_id="agent_A",
         )
         await thread_store.create_thread(
             negotiation_id="order_A_order_C",
@@ -647,6 +595,9 @@ class TestMultipleBilateralNegotiations:
             their_order_id="order_C",
             our_agent_id="agent_A",
             their_agent_id="agent_C",
+            our_initial_price=100,
+            our_strategy="minimize",
+            owner_id="agent_A",
         )
 
         # Add some history to both threads
@@ -670,24 +621,13 @@ class TestMultipleBilateralNegotiations:
         )
 
         # Agent B counters with 100 (acceptable for minimizer A - at ceiling)
-        event_accept = NegotiationEvent.create(
-            event_id="evt_A_accept_B",
-            negotiation_id="order_A_order_B",
-            message_type="counter_proposal",
-            sender="agent_B",
-            data={
-                "our_price": 100,
-                "their_price": 100,
-                "our_order_id": "order_A",
-                "their_order_id": "order_B",
-                "strategy": "minimize",
-            }
-        )
-        context = DecisionContext(
-            event=event_accept,
+        context = create_test_context(
+            our_price=100,
+            their_price=100,
+            strategy="minimize",
             agent_id="agent_A",
-            available_resources={},
-            negotiation_history=[]
+            negotiation_id="order_A_order_B",
+            event_id="evt_A_accept_B",
         )
 
         result = await ce.evaluate(context)
@@ -729,6 +669,7 @@ class TestMultipleBilateralNegotiations:
             their_order_id="order_B",
             our_agent_id="agent_A",
             their_agent_id="agent_B",
+            owner_id="agent_A",
         )
         await thread_store.create_thread(
             negotiation_id="neg_2",
@@ -736,6 +677,7 @@ class TestMultipleBilateralNegotiations:
             their_order_id="order_C",
             our_agent_id="agent_A",
             their_agent_id="agent_C",
+            owner_id="agent_A",
         )
 
         # Add 3 messages to neg_1
@@ -799,6 +741,7 @@ class TestMultipleBilateralNegotiations:
             their_order_id="order_B",
             our_agent_id="agent_A",
             their_agent_id="agent_B",
+            owner_id="agent_A",
         )
 
         # Check for existing negotiation (same order pair)
@@ -845,6 +788,9 @@ class TestMultipleBilateralNegotiations:
             their_order_id="order_B",
             our_agent_id="agent_A",
             their_agent_id="agent_B",
+            owner_id="agent_A",
+            our_initial_price=100,
+            our_strategy="minimize",
         )
         await thread_store.create_thread(
             negotiation_id="A_C",
@@ -852,6 +798,9 @@ class TestMultipleBilateralNegotiations:
             their_order_id="order_C",
             our_agent_id="agent_A",
             their_agent_id="agent_C",
+            owner_id="agent_A",
+            our_initial_price=100,
+            our_strategy="minimize",
         )
 
         # Round 1: Both maximizers offer high prices
@@ -872,25 +821,13 @@ class TestMultipleBilateralNegotiations:
 
         # Round 2: B accepts A's counter of 125 (>= floor of 100), C accepts A's counter of 115 (>= floor)
         # Check B's acceptance of 125
-        event_B_round2 = NegotiationEvent.create(
-            event_id="evt_B_r2",
-            negotiation_id="A_B",
-            message_type="counter_proposal",
-            sender="agent_B",
-            data={
-                "our_price": 100,  # B's floor (maximizer offering compute)
-                "their_price": 125,  # A's counter
-                "our_order_id": "order_B",
-                "their_order_id": "order_A",
-                "strategy": "maximize",
-            }
-        )
-
-        context_B_r2 = DecisionContext(
-            event=event_B_round2,
+        context_B_r2 = create_test_context(
+            our_price=100,  # B's floor (maximizer offering compute)
+            their_price=125,  # A's counter
+            strategy="maximize",
             agent_id="agent_B",
-            available_resources={},
-            negotiation_history=[]
+            negotiation_id="A_B",
+            event_id="evt_B_r2",
         )
 
         result_B = await ce.evaluate(context_B_r2)
@@ -898,25 +835,13 @@ class TestMultipleBilateralNegotiations:
         assert result_B.action_type.value == "accept_offer"
 
         # Check C's acceptance of 115
-        event_C_round2 = NegotiationEvent.create(
-            event_id="evt_C_r2",
-            negotiation_id="A_C",
-            message_type="counter_proposal",
-            sender="agent_C",
-            data={
-                "our_price": 100,  # C's floor (maximizer offering compute)
-                "their_price": 115,  # A's counter
-                "our_order_id": "order_C",
-                "their_order_id": "order_A",
-                "strategy": "maximize",
-            }
-        )
-
-        context_C_r2 = DecisionContext(
-            event=event_C_round2,
+        context_C_r2 = create_test_context(
+            our_price=100,  # C's floor (maximizer offering compute)
+            their_price=115,  # A's counter
+            strategy="maximize",
             agent_id="agent_C",
-            available_resources={},
-            negotiation_history=[]
+            negotiation_id="A_C",
+            event_id="evt_C_r2",
         )
 
         result_C = await ce.evaluate(context_C_r2)
@@ -945,45 +870,23 @@ class TestMultipleBilateralNegotiations:
         ce = CallableEvaluator(func)
 
         # Agent A (maximizer) receives offer from Agent B (price 70)
-        event_from_B = NegotiationEvent.create(
-            event_id="evt_A_from_B_max",
-            negotiation_id="order_A_order_B",
-            message_type="initial_proposal",
-            sender="agent_B",
-            data={
-                "our_price": 100,
-                "their_price": 70,
-                "our_order_id": "order_A",
-                "their_order_id": "order_B",
-                "strategy": "maximize",
-            }
-        )
-        context_B = DecisionContext(
-            event=event_from_B,
+        context_B = create_test_context(
+            our_price=100,
+            their_price=70,
+            strategy="maximize",
             agent_id="agent_A",
-            available_resources={},
-            negotiation_history=[]
+            negotiation_id="order_A_order_B",
+            event_id="evt_A_from_B_max",
         )
 
         # Agent A (maximizer) receives offer from Agent C (price 90)
-        event_from_C = NegotiationEvent.create(
-            event_id="evt_A_from_C_max",
-            negotiation_id="order_A_order_C",
-            message_type="initial_proposal",
-            sender="agent_C",
-            data={
-                "our_price": 100,
-                "their_price": 90,
-                "our_order_id": "order_A",
-                "their_order_id": "order_C",
-                "strategy": "maximize",
-            }
-        )
-        context_C = DecisionContext(
-            event=event_from_C,
+        context_C = create_test_context(
+            our_price=100,
+            their_price=90,
+            strategy="maximize",
             agent_id="agent_A",
-            available_resources={},
-            negotiation_history=[]
+            negotiation_id="order_A_order_C",
+            event_id="evt_A_from_C_max",
         )
 
         result_B = await ce.evaluate(context_B)

--- a/agents/a2a-agent-trader/tests/unit/test_price_negotiation.py
+++ b/agents/a2a-agent-trader/tests/unit/test_price_negotiation.py
@@ -1,0 +1,465 @@
+"""Parametrized price negotiation tests for role-aware smart policies.
+
+Tests the price_aware_decision (negotiation_action_price_interval_concession) policy.
+
+ROLE-AWARE POLICY BEHAVIOR:
+
+Buyer (demanding compute, our_price = max willing to pay):
+- Accepts if 50% <= their_price <= 120% of our_price (reasonable range)
+- Counters if 120% < their_price <= 200% of our_price (high but reasonable)
+- Exits if their_price < 50% or > 200% of our_price
+
+Seller (offering compute, our_price = min willing to accept):
+- Accepts if 80% <= their_price <= 200% of our_price (reasonable range)
+- Counters if 50% <= their_price < 80% of our_price (low but reasonable)
+- Exits if their_price < 50% or > 200% of our_price
+
+NOTE: Policy requires role to be specified. If no role, passes to next policy.
+"""
+
+import pytest
+from app.schema.pydantic_models import DecisionContext, NegotiationEvent
+from app.policies.store import PolicyStore
+from app.policies.sqlite_client import SQLiteClient
+from app.policies.evaluator import CallableEvaluator
+import tempfile
+import os
+
+
+@pytest.fixture
+def temp_db():
+    """Create a temporary database file for testing."""
+    fd, path = tempfile.mkstemp(suffix='.db')
+    os.close(fd)
+    yield path
+    if os.path.exists(path):
+        os.remove(path)
+
+
+@pytest.fixture
+def policy_store(temp_db):
+    """Create a PolicyStore with registered policies for testing."""
+    from app.policies.registry import CALLABLE_REGISTRY
+
+    # Clear registry to ensure clean state
+    CALLABLE_REGISTRY.clear()
+
+    # Import policies to register them via @policy_callable decorator
+    from app.policies.store import (
+        negotiation_action_price_interval_concession,
+        negotiation_action_safe_default_reject,
+    )
+
+    # Create policy store
+    sqlite_client = SQLiteClient(db_path=temp_db)
+    store = PolicyStore(sqlite_client=sqlite_client)
+
+    # Register callables from the module-level registry
+    store.register_callables({
+        "negotiation.action.price_interval_concession": negotiation_action_price_interval_concession,
+        "negotiation.action.safe_default_reject": negotiation_action_safe_default_reject,
+    })
+
+    yield store
+
+    # Cleanup
+    CALLABLE_REGISTRY.clear()
+
+
+class TestBuyerNegotiation:
+    """Test buyer role negotiation (demanding compute, offering tokens)."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("our_price,their_price,expected_action,reason", [
+        # Buyer accepts up to 120% of max (within band)
+        (100, 70, "accept_offer", "within buyer band"),
+        (100, 80, "accept_offer", "within buyer band"),
+        (100, 90, "accept_offer", "within buyer band"),
+        (100, 100, "accept_offer", "equal to max"),
+        (100, 110, "accept_offer", "within buyer band"),
+        (100, 120, "accept_offer", "at buyer max (120%)"),
+
+        # Buyer counters if reasonable but above 120%
+        (100, 125, "counter_offer", "above band but reasonable"),
+        (100, 130, "counter_offer", "above band but reasonable"),
+        (100, 150, "counter_offer", "above band but reasonable"),
+        (100, 180, "counter_offer", "above band but reasonable"),
+        (100, 200, "counter_offer", "at reasonable upper bound"),
+
+        # Buyer exits far outside reasonable
+        (100, 40, "exit_negotiation", "far below 50%"),
+        (100, 49, "exit_negotiation", "below reasonable"),
+        (100, 250, "exit_negotiation", "far above 200%"),
+    ])
+    async def test_buyer_price_aware_decision(self, policy_store, our_price, their_price, expected_action, reason):
+        """Test buyer negotiation policy at various price points."""
+        event = NegotiationEvent.create(
+            event_id=f"evt_test_buyer_{our_price}_{their_price}",
+            negotiation_id=f"test_buyer_{our_price}_{their_price}",
+            message_type="counter_proposal",
+            sender="other_agent",
+            data={
+                "our_price": our_price,
+                "their_price": their_price,
+                "our_order_id": "order_our",
+                "their_order_id": "order_their",
+                "role": "buyer",
+            }
+        )
+
+        context = DecisionContext(
+            event=event,
+            agent_id="test_agent",
+            available_resources={},
+            negotiation_history=[]
+        )
+
+        func = policy_store._registry.get("negotiation.action.price_interval_concession")
+        assert func is not None, "Policy not registered"
+
+        ce = CallableEvaluator(func)
+        result = await ce.evaluate(context)
+
+        assert result is not None, f"Policy returned None for: our={our_price}, their={their_price}, reason={reason}"
+        assert result.action_type.value == expected_action, \
+            f"Expected {expected_action}, got {result.action_type.value} for: our={our_price}, their={their_price}, reason={reason}"
+
+    @pytest.mark.asyncio
+    async def test_buyer_counter_calculation(self, policy_store):
+        """Test buyer counter-offer price calculation."""
+        event = NegotiationEvent.create(
+            event_id="evt_test_buyer_counter",
+            negotiation_id="test_buyer_counter",
+            message_type="counter_proposal",
+            sender="other_agent",
+            data={
+                "our_price": 100,
+                "their_price": 150,
+                "our_order_id": "order_our",
+                "their_order_id": "order_their",
+                "role": "buyer",
+            }
+        )
+
+        context = DecisionContext(
+            event=event,
+            agent_id="test_agent",
+            available_resources={},
+            negotiation_history=[]
+        )
+
+        func = policy_store._registry.get("negotiation.action.price_interval_concession")
+        ce = CallableEvaluator(func)
+        result = await ce.evaluate(context)
+
+        # Should counter with midpoint: (100 + 150) // 2 = 125
+        assert result is not None
+        assert result.action_type.value == "counter_offer"
+        assert result.parameters.get("proposed_price") == 125
+
+
+class TestSellerNegotiation:
+    """Test seller role negotiation (offering compute, demanding tokens)."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("our_price,their_price,expected_action,reason", [
+        # Seller accepts at least 80% of min (within band)
+        (100, 80, "accept_offer", "at seller min (80%)"),
+        (100, 85, "accept_offer", "within seller band"),
+        (100, 90, "accept_offer", "within seller band"),
+        (100, 100, "accept_offer", "equal to min"),
+        (100, 110, "accept_offer", "within seller band"),
+        (100, 120, "accept_offer", "within seller band"),
+        (100, 150, "accept_offer", "within seller band"),
+        (100, 180, "accept_offer", "within seller band"),
+        (100, 200, "accept_offer", "at seller upper bound"),
+
+        # Seller counters if reasonable but below 80%
+        (100, 75, "counter_offer", "below band but reasonable"),
+        (100, 70, "counter_offer", "below band but reasonable"),
+        (100, 60, "counter_offer", "below band but reasonable"),
+        (100, 50, "counter_offer", "at reasonable lower bound"),
+
+        # Seller exits far outside reasonable
+        (100, 40, "exit_negotiation", "far below 50%"),
+        (100, 49, "exit_negotiation", "below reasonable"),
+        (100, 250, "exit_negotiation", "far above 200%"),
+    ])
+    async def test_seller_price_aware_decision(self, policy_store, our_price, their_price, expected_action, reason):
+        """Test seller negotiation policy at various price points."""
+        event = NegotiationEvent.create(
+            event_id=f"evt_test_seller_{our_price}_{their_price}",
+            negotiation_id=f"test_seller_{our_price}_{their_price}",
+            message_type="counter_proposal",
+            sender="other_agent",
+            data={
+                "our_price": our_price,
+                "their_price": their_price,
+                "our_order_id": "order_our",
+                "their_order_id": "order_their",
+                "role": "seller",
+            }
+        )
+
+        context = DecisionContext(
+            event=event,
+            agent_id="test_agent",
+            available_resources={},
+            negotiation_history=[]
+        )
+
+        func = policy_store._registry.get("negotiation.action.price_interval_concession")
+        assert func is not None, "Policy not registered"
+
+        ce = CallableEvaluator(func)
+        result = await ce.evaluate(context)
+
+        assert result is not None, f"Policy returned None for: our={our_price}, their={their_price}, reason={reason}"
+        assert result.action_type.value == expected_action, \
+            f"Expected {expected_action}, got {result.action_type.value} for: our={our_price}, their={their_price}, reason={reason}"
+
+    @pytest.mark.asyncio
+    async def test_seller_counter_calculation(self, policy_store):
+        """Test seller counter-offer price calculation."""
+        event = NegotiationEvent.create(
+            event_id="evt_test_seller_counter",
+            negotiation_id="test_seller_counter",
+            message_type="counter_proposal",
+            sender="other_agent",
+            data={
+                "our_price": 100,
+                "their_price": 70,
+                "our_order_id": "order_our",
+                "their_order_id": "order_their",
+                "role": "seller",
+            }
+        )
+
+        context = DecisionContext(
+            event=event,
+            agent_id="test_agent",
+            available_resources={},
+            negotiation_history=[]
+        )
+
+        func = policy_store._registry.get("negotiation.action.price_interval_concession")
+        ce = CallableEvaluator(func)
+        result = await ce.evaluate(context)
+
+        # Should counter with midpoint: (100 + 70) // 2 = 85
+        assert result is not None
+        assert result.action_type.value == "counter_offer"
+        assert result.parameters.get("proposed_price") == 85
+
+
+class TestNegotiationScenarios:
+    """Test realistic negotiation scenarios."""
+
+    @pytest.mark.asyncio
+    async def test_no_role_passes_to_next_policy(self, policy_store):
+        """Test that policy passes to next policy when no role is specified."""
+        event = NegotiationEvent.create(
+            event_id="evt_test_no_role",
+            negotiation_id="test_no_role",
+            message_type="counter_proposal",
+            sender="other_agent",
+            data={
+                "our_price": 100,
+                "their_price": 110,
+                "our_order_id": "order_our",
+                "their_order_id": "order_their",
+                # No role specified
+            }
+        )
+
+        context = DecisionContext(
+            event=event,
+            agent_id="test_agent",
+            available_resources={},
+            negotiation_history=[]
+        )
+
+        func = policy_store._registry.get("negotiation.action.price_interval_concession")
+        ce = CallableEvaluator(func)
+        result = await ce.evaluate(context)
+
+        # Should return None (pass to next policy) when no role specified
+        assert result is None, "Policy should pass to next policy when no role is specified"
+
+    @pytest.mark.asyncio
+    async def test_buyer_seller_equilibrium(self, policy_store):
+        """Test that buyer and seller reach equilibrium at same price.
+
+        Buyer at 100 (max) receives offer at 110 → accepts
+        Seller at 100 (min) receives offer at 110 → accepts
+        Equilibrium reached!
+        """
+        # Buyer perspective
+        buyer_event = NegotiationEvent.create(
+            event_id="evt_test_buyer_eq",
+            negotiation_id="test_eq",
+            message_type="counter_proposal",
+            sender="seller_agent",
+            data={"our_price": 100, "their_price": 110, "role": "buyer",
+                   "our_order_id": "order_buyer", "their_order_id": "order_seller"}
+        )
+
+        buyer_context = DecisionContext(
+            event=buyer_event,
+            agent_id="buyer_agent",
+            available_resources={},
+            negotiation_history=[]
+        )
+
+        func = policy_store._registry.get("negotiation.action.price_interval_concession")
+        ce = CallableEvaluator(func)
+        buyer_result = await ce.evaluate(buyer_context)
+
+        # Seller perspective
+        seller_event = NegotiationEvent.create(
+            event_id="evt_test_seller_eq",
+            negotiation_id="test_eq",
+            message_type="counter_proposal",
+            sender="buyer_agent",
+            data={"our_price": 100, "their_price": 110, "role": "seller",
+                   "our_order_id": "order_seller", "their_order_id": "order_buyer"}
+        )
+
+        seller_context = DecisionContext(
+            event=seller_event,
+            agent_id="seller_agent",
+            available_resources={},
+            negotiation_history=[]
+        )
+
+        seller_result = await ce.evaluate(seller_context)
+
+        # Both should accept at 110
+        assert buyer_result.action_type.value == "accept_offer"
+        assert seller_result.action_type.value == "accept_offer"
+
+    @pytest.mark.asyncio
+    async def test_buyer_seller_counter_convergence(self, policy_store):
+        """Test that buyer and seller counter-offers converge toward equilibrium.
+
+        Initial: Buyer at 100, Seller at 100
+        Offer: 150 (too high for buyer, good for seller)
+        Expected: Buyer counters to 125
+        """
+        # Buyer sees 150 → counters to 125
+        buyer_event = NegotiationEvent.create(
+            event_id="evt_test_buyer_conv",
+            negotiation_id="test_conv",
+            message_type="counter_proposal",
+            sender="seller_agent",
+            data={"our_price": 100, "their_price": 150, "role": "buyer",
+                   "our_order_id": "order_buyer", "their_order_id": "order_seller"}
+        )
+
+        buyer_context = DecisionContext(
+            event=buyer_event,
+            agent_id="buyer_agent",
+            available_resources={},
+            negotiation_history=[]
+        )
+
+        func = policy_store._registry.get("negotiation.action.price_interval_concession")
+        ce = CallableEvaluator(func)
+        buyer_result = await ce.evaluate(buyer_context)
+
+        # Buyer should counter
+        assert buyer_result.action_type.value == "counter_offer"
+        assert buyer_result.parameters.get("proposed_price") == 125
+
+        # Seller sees 125 (from buyer counter) → should accept (>= 80% of min)
+        seller_event = NegotiationEvent.create(
+            event_id="evt_test_seller_conv",
+            negotiation_id="test_conv",
+            message_type="counter_proposal",
+            sender="buyer_agent",
+            data={"our_price": 100, "their_price": 125, "role": "seller",
+                   "our_order_id": "order_seller", "their_order_id": "order_buyer"}
+        )
+
+        seller_context = DecisionContext(
+            event=seller_event,
+            agent_id="seller_agent",
+            available_resources={},
+            negotiation_history=[]
+        )
+
+        seller_result = await ce.evaluate(seller_context)
+
+        # Seller should accept at 125
+        assert seller_result.action_type.value == "accept_offer"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("our_price,their_price,expected_reason", [
+        (None, 100, "missing_price_data"),
+        (100, None, "missing_price_data"),
+        (100, "invalid", "invalid_price_types"),
+        ("invalid", 100, "invalid_price_types"),
+        (0, 100, "non_positive_prices"),
+        (100, 0, "non_positive_prices"),
+        (-50, 100, "non_positive_prices"),
+        (100, -50, "non_positive_prices"),
+    ])
+    async def test_safe_default_reject(self, policy_store, our_price, their_price, expected_reason):
+        """Test safe default policy rejects on invalid price data."""
+        event = NegotiationEvent.create(
+            event_id=f"evt_test_invalid_{our_price}_{their_price}",
+            negotiation_id=f"test_invalid_{our_price}_{their_price}",
+            message_type="counter_proposal",
+            sender="other_agent",
+            data={
+                "our_price": our_price,
+                "their_price": their_price,
+                "our_order_id": "order_our",
+                "their_order_id": "order_their",
+            }
+        )
+
+        context = DecisionContext(
+            event=event,
+            agent_id="test_agent",
+            available_resources={},
+            negotiation_history=[]
+        )
+
+        func = policy_store._registry.get("negotiation.action.safe_default_reject")
+        ce = CallableEvaluator(func)
+        result = await ce.evaluate(context)
+
+        # Should reject for safety
+        assert result is not None, "Safe default should always return an action"
+        assert result.action_type.value == "reject_offer"
+        assert result.parameters.get("reason") == expected_reason
+
+    @pytest.mark.asyncio
+    async def test_passes_to_next_policy_on_missing_data(self, policy_store):
+        """Test that policy passes to next policy when price data is missing."""
+        event = NegotiationEvent.create(
+            event_id="evt_test_missing_data",
+            negotiation_id="test_missing_data",
+            message_type="counter_proposal",
+            sender="other_agent",
+            data={
+                # Missing our_price and their_price
+                "our_order_id": "order_our",
+                "their_order_id": "order_their",
+            }
+        )
+
+        context = DecisionContext(
+            event=event,
+            agent_id="test_agent",
+            available_resources={},
+            negotiation_history=[]
+        )
+
+        func = policy_store._registry.get("negotiation.action.price_interval_concession")
+        ce = CallableEvaluator(func)
+        result = await ce.evaluate(context)
+
+        # Should return None (pass to next policy) when price data missing
+        assert result is None, "Policy should pass to next policy when price data missing"

--- a/agents/a2a-agent-trader/tests/unit/test_price_negotiation.py
+++ b/agents/a2a-agent-trader/tests/unit/test_price_negotiation.py
@@ -463,3 +463,515 @@ class TestNegotiationScenarios:
 
         # Should return None (pass to next policy) when price data missing
         assert result is None, "Policy should pass to next policy when price data missing"
+
+
+class TestMultipleBilateralNegotiations:
+    """Test scenarios with one agent negotiating with multiple counterparties.
+
+    These tests verify that:
+    1. An agent can maintain separate negotiations with different counterparties
+    2. Each negotiation has isolated state (thread, round counter)
+    3. Accepting one negotiation cancels competing negotiations
+    4. Duplicate negotiations are prevented
+    """
+
+    @pytest.fixture
+    def thread_store(self, temp_db):
+        """Create a NegotiationThreadStore for multi-party tests."""
+        from app.policies.negotiation_thread import NegotiationThreadStore
+        sqlite_client = SQLiteClient(db_path=temp_db)
+        return NegotiationThreadStore(sqlite_client=sqlite_client)
+
+    @pytest.mark.asyncio
+    async def test_buyer_negotiates_with_multiple_sellers(self, policy_store, thread_store):
+        """Agent A (buyer) negotiates with Agents B and C (sellers) independently.
+
+        Scenario:
+        - Agent A is a buyer with order_A (max price 100)
+        - Agent B is a seller with order_B (asking 150)
+        - Agent C is a seller with order_C (asking 130)
+        - A should counter both B and C independently
+        """
+        func = policy_store._registry.get("negotiation.action.price_interval_concession")
+        ce = CallableEvaluator(func)
+
+        # Create negotiation threads for A↔B and A↔C
+        await thread_store.create_thread(
+            negotiation_id="order_A_order_B",
+            our_order_id="order_A",
+            their_order_id="order_B",
+            our_agent_id="agent_A",
+            their_agent_id="agent_B",
+        )
+        await thread_store.create_thread(
+            negotiation_id="order_A_order_C",
+            our_order_id="order_A",
+            their_order_id="order_C",
+            our_agent_id="agent_A",
+            their_agent_id="agent_C",
+        )
+
+        # Agent A receives offer from Agent B (price 150)
+        event_from_B = NegotiationEvent.create(
+            event_id="evt_A_from_B",
+            negotiation_id="order_A_order_B",
+            message_type="initial_proposal",
+            sender="agent_B",
+            data={
+                "our_price": 100,
+                "their_price": 150,
+                "our_order_id": "order_A",
+                "their_order_id": "order_B",
+                "role": "buyer",
+            }
+        )
+        context_B = DecisionContext(
+            event=event_from_B,
+            agent_id="agent_A",
+            available_resources={},
+            negotiation_history=[]
+        )
+
+        # Agent A receives offer from Agent C (price 130)
+        event_from_C = NegotiationEvent.create(
+            event_id="evt_A_from_C",
+            negotiation_id="order_A_order_C",
+            message_type="initial_proposal",
+            sender="agent_C",
+            data={
+                "our_price": 100,
+                "their_price": 130,
+                "our_order_id": "order_A",
+                "their_order_id": "order_C",
+                "role": "buyer",
+            }
+        )
+        context_C = DecisionContext(
+            event=event_from_C,
+            agent_id="agent_A",
+            available_resources={},
+            negotiation_history=[]
+        )
+
+        # Evaluate both negotiations
+        result_B = await ce.evaluate(context_B)
+        result_C = await ce.evaluate(context_C)
+
+        # Both should counter (150 and 130 are above 120% of 100)
+        assert result_B.action_type.value == "counter_offer"
+        assert result_C.action_type.value == "counter_offer"
+
+        # Counter prices should be different (midpoints)
+        assert result_B.parameters.get("proposed_price") == 125  # (100 + 150) // 2
+        assert result_C.parameters.get("proposed_price") == 115  # (100 + 130) // 2
+
+        # Record messages to threads
+        await thread_store.add_message(
+            negotiation_id="order_A_order_B",
+            sender="agent_A",
+            our_price=100,
+            their_price=150,
+            proposed_price=125,
+            action_taken="COUNTER_OFFER",
+            message_type="counter_proposal",
+        )
+        await thread_store.add_message(
+            negotiation_id="order_A_order_C",
+            sender="agent_A",
+            our_price=100,
+            their_price=130,
+            proposed_price=115,
+            action_taken="COUNTER_OFFER",
+            message_type="counter_proposal",
+        )
+
+        # Verify threads are independent
+        thread_B = await thread_store.get_thread("order_A_order_B")
+        thread_C = await thread_store.get_thread("order_A_order_C")
+
+        assert len(thread_B) == 1
+        assert len(thread_C) == 1
+        assert thread_B[0]["proposed_price"] == 125
+        assert thread_C[0]["proposed_price"] == 115
+
+    @pytest.mark.asyncio
+    async def test_accept_cancels_competing_negotiations(self, policy_store, thread_store):
+        """When A accepts B's offer, A's negotiation with C should be canceled.
+
+        Scenario:
+        - Agent A has active negotiations with B and C for order_A
+        - B counters with price 110 (acceptable for buyer A)
+        - A accepts B's offer
+        - Negotiation A↔C should be canceled
+        """
+        func = policy_store._registry.get("negotiation.action.price_interval_concession")
+        ce = CallableEvaluator(func)
+
+        # Create both negotiation threads
+        await thread_store.create_thread(
+            negotiation_id="order_A_order_B",
+            our_order_id="order_A",
+            their_order_id="order_B",
+            our_agent_id="agent_A",
+            their_agent_id="agent_B",
+        )
+        await thread_store.create_thread(
+            negotiation_id="order_A_order_C",
+            our_order_id="order_A",
+            their_order_id="order_C",
+            our_agent_id="agent_A",
+            their_agent_id="agent_C",
+        )
+
+        # Add some history to both threads
+        await thread_store.add_message(
+            negotiation_id="order_A_order_B",
+            sender="agent_B",
+            our_price=100,
+            their_price=150,
+            proposed_price=150,
+            action_taken="COUNTER_OFFER",
+            message_type="initial_proposal",
+        )
+        await thread_store.add_message(
+            negotiation_id="order_A_order_C",
+            sender="agent_C",
+            our_price=100,
+            their_price=140,
+            proposed_price=140,
+            action_taken="COUNTER_OFFER",
+            message_type="initial_proposal",
+        )
+
+        # Agent B counters with 110 (within buyer's band)
+        event_accept = NegotiationEvent.create(
+            event_id="evt_A_accept_B",
+            negotiation_id="order_A_order_B",
+            message_type="counter_proposal",
+            sender="agent_B",
+            data={
+                "our_price": 100,
+                "their_price": 110,
+                "our_order_id": "order_A",
+                "their_order_id": "order_B",
+                "role": "buyer",
+            }
+        )
+        context = DecisionContext(
+            event=event_accept,
+            agent_id="agent_A",
+            available_resources={},
+            negotiation_history=[]
+        )
+
+        result = await ce.evaluate(context)
+        assert result.action_type.value == "accept_offer"
+
+        # Simulate accept_offer action: cancel competing negotiations
+        canceled = await thread_store._sqlite.cancel_negotiations_for_order(
+            order_id="order_A",
+            except_negotiation_id="order_A_order_B",
+        )
+
+        # Verify A↔C was canceled
+        assert "order_A_order_C" in canceled
+
+        # Verify A↔B is still active (not canceled)
+        thread_B = await thread_store.get_thread("order_A_order_B")
+        assert len(thread_B) == 1  # Still has messages
+
+        # Verify canceled thread is marked
+        active_negs = await thread_store._sqlite.get_active_negotiations_for_order(
+            order_id="order_A"
+        )
+        active_neg_ids = [n["negotiation_id"] for n in active_negs]
+
+        # Only A↔B should be active (if not yet marked terminal)
+        # A↔C should be canceled
+        assert "order_A_order_C" not in active_neg_ids
+
+    @pytest.mark.asyncio
+    async def test_independent_thread_tracking(self, thread_store):
+        """Each negotiation has its own thread with isolated round counters.
+
+        Verifies that round numbers increment independently per negotiation.
+        """
+        # Create two threads
+        await thread_store.create_thread(
+            negotiation_id="neg_1",
+            our_order_id="order_A",
+            their_order_id="order_B",
+            our_agent_id="agent_A",
+            their_agent_id="agent_B",
+        )
+        await thread_store.create_thread(
+            negotiation_id="neg_2",
+            our_order_id="order_A",
+            their_order_id="order_C",
+            our_agent_id="agent_A",
+            their_agent_id="agent_C",
+        )
+
+        # Add 3 messages to neg_1
+        for i in range(3):
+            round_num = await thread_store.add_message(
+                negotiation_id="neg_1",
+                sender=f"agent_{'A' if i % 2 == 0 else 'B'}",
+                our_price=100,
+                their_price=120,
+                proposed_price=110,
+                action_taken="COUNTER_OFFER",
+                message_type="counter_proposal",
+            )
+            assert round_num == i, f"neg_1 round should be {i}, got {round_num}"
+
+        # Add 1 message to neg_2
+        round_num = await thread_store.add_message(
+            negotiation_id="neg_2",
+            sender="agent_C",
+            our_price=100,
+            their_price=130,
+            proposed_price=130,
+            action_taken="COUNTER_OFFER",
+            message_type="initial_proposal",
+        )
+        assert round_num == 0, "neg_2 should start at round 0"
+
+        # Add another message to neg_2
+        round_num = await thread_store.add_message(
+            negotiation_id="neg_2",
+            sender="agent_A",
+            our_price=100,
+            their_price=130,
+            proposed_price=115,
+            action_taken="COUNTER_OFFER",
+            message_type="counter_proposal",
+        )
+        assert round_num == 1, "neg_2 should be at round 1"
+
+        # Verify thread lengths are independent
+        thread_1 = await thread_store.get_thread("neg_1")
+        thread_2 = await thread_store.get_thread("neg_2")
+
+        assert len(thread_1) == 3
+        assert len(thread_2) == 2
+
+        # Verify round numbers
+        assert [m["round"] for m in thread_1] == [0, 1, 2]
+        assert [m["round"] for m in thread_2] == [0, 1]
+
+    @pytest.mark.asyncio
+    async def test_duplicate_negotiation_prevention(self, thread_store):
+        """Duplicate negotiations between same order pair should be detected.
+
+        Verifies check_existing_negotiation() prevents creating duplicates.
+        """
+        # Create first negotiation
+        await thread_store.create_thread(
+            negotiation_id="order_A_order_B",
+            our_order_id="order_A",
+            their_order_id="order_B",
+            our_agent_id="agent_A",
+            their_agent_id="agent_B",
+        )
+
+        # Check for existing negotiation (same order pair)
+        existing = await thread_store._sqlite.check_existing_negotiation(
+            our_order_id="order_A",
+            their_order_id="order_B",
+        )
+
+        assert existing is not None
+        assert existing["negotiation_id"] == "order_A_order_B"
+
+        # Check reverse direction (should also find it)
+        existing_reverse = await thread_store._sqlite.check_existing_negotiation(
+            our_order_id="order_B",
+            their_order_id="order_A",
+        )
+
+        # Should find the same negotiation (bidirectional check)
+        assert existing_reverse is not None
+
+        # Check non-existing pair
+        non_existing = await thread_store._sqlite.check_existing_negotiation(
+            our_order_id="order_A",
+            their_order_id="order_D",
+        )
+        assert non_existing is None
+
+    @pytest.mark.asyncio
+    async def test_multi_round_convergence_with_multiple_sellers(self, policy_store, thread_store):
+        """Test multi-round negotiation where buyer converges with one seller.
+
+        Scenario:
+        - Round 1: A counters B (150→125) and C (130→115)
+        - Round 2: B counters 120, C counters 125
+        - A accepts B's 120 (within band), cancels C
+        """
+        func = policy_store._registry.get("negotiation.action.price_interval_concession")
+        ce = CallableEvaluator(func)
+
+        # Setup threads
+        await thread_store.create_thread(
+            negotiation_id="A_B",
+            our_order_id="order_A",
+            their_order_id="order_B",
+            our_agent_id="agent_A",
+            their_agent_id="agent_B",
+        )
+        await thread_store.create_thread(
+            negotiation_id="A_C",
+            our_order_id="order_A",
+            their_order_id="order_C",
+            our_agent_id="agent_A",
+            their_agent_id="agent_C",
+        )
+
+        # Round 1: Both sellers offer high prices
+        # A counters both
+        for neg_id, their_price, expected_counter in [
+            ("A_B", 150, 125),
+            ("A_C", 130, 115),
+        ]:
+            await thread_store.add_message(
+                negotiation_id=neg_id,
+                sender="agent_A",
+                our_price=100,
+                their_price=their_price,
+                proposed_price=expected_counter,
+                action_taken="COUNTER_OFFER",
+                message_type="counter_proposal",
+            )
+
+        # Round 2: B counters with 120 (acceptable), C counters with 125 (also needs counter)
+        # First check B's counter of 120
+        event_B_round2 = NegotiationEvent.create(
+            event_id="evt_B_r2",
+            negotiation_id="A_B",
+            message_type="counter_proposal",
+            sender="agent_B",
+            data={
+                "our_price": 100,
+                "their_price": 120,
+                "our_order_id": "order_A",
+                "their_order_id": "order_B",
+                "role": "buyer",
+            }
+        )
+
+        # Use negotiation history to simulate prior round
+        context_B_r2 = DecisionContext(
+            event=event_B_round2,
+            agent_id="agent_A",
+            available_resources={},
+            negotiation_history=[
+                {"sender": "agent_A", "proposed_price": 125, "action_taken": "COUNTER_OFFER"}
+            ]
+        )
+
+        result_B = await ce.evaluate(context_B_r2)
+        # 120 is at boundary (120% of 100), should accept
+        assert result_B.action_type.value == "accept_offer"
+
+        # Check C's counter of 125 (above 120%, needs counter)
+        event_C_round2 = NegotiationEvent.create(
+            event_id="evt_C_r2",
+            negotiation_id="A_C",
+            message_type="counter_proposal",
+            sender="agent_C",
+            data={
+                "our_price": 100,
+                "their_price": 125,
+                "our_order_id": "order_A",
+                "their_order_id": "order_C",
+                "role": "buyer",
+            }
+        )
+
+        context_C_r2 = DecisionContext(
+            event=event_C_round2,
+            agent_id="agent_A",
+            available_resources={},
+            negotiation_history=[
+                {"sender": "agent_A", "proposed_price": 115, "action_taken": "COUNTER_OFFER"}
+            ]
+        )
+
+        result_C = await ce.evaluate(context_C_r2)
+        # 125 is above 120%, should counter with midpoint of (115 + 125) // 2 = 120
+        assert result_C.action_type.value == "counter_offer"
+        assert result_C.parameters.get("proposed_price") == 120
+
+        # Now A accepts B, which should cancel C
+        canceled = await thread_store._sqlite.cancel_negotiations_for_order(
+            order_id="order_A",
+            except_negotiation_id="A_B",
+        )
+
+        assert "A_C" in canceled
+
+    @pytest.mark.asyncio
+    async def test_seller_negotiates_with_multiple_buyers(self, policy_store, thread_store):
+        """Agent A (seller) negotiates with Agents B and C (buyers) independently.
+
+        Scenario:
+        - Agent A is a seller with order_A (min price 100)
+        - Agent B is a buyer with order_B (offering 70)
+        - Agent C is a buyer with order_C (offering 90)
+        - A should counter B (below 80%) and accept C (at 90% >= 80%)
+        """
+        func = policy_store._registry.get("negotiation.action.price_interval_concession")
+        ce = CallableEvaluator(func)
+
+        # Agent A (seller) receives offer from Agent B (price 70)
+        event_from_B = NegotiationEvent.create(
+            event_id="evt_A_from_B_seller",
+            negotiation_id="order_A_order_B",
+            message_type="initial_proposal",
+            sender="agent_B",
+            data={
+                "our_price": 100,
+                "their_price": 70,
+                "our_order_id": "order_A",
+                "their_order_id": "order_B",
+                "role": "seller",
+            }
+        )
+        context_B = DecisionContext(
+            event=event_from_B,
+            agent_id="agent_A",
+            available_resources={},
+            negotiation_history=[]
+        )
+
+        # Agent A (seller) receives offer from Agent C (price 90)
+        event_from_C = NegotiationEvent.create(
+            event_id="evt_A_from_C_seller",
+            negotiation_id="order_A_order_C",
+            message_type="initial_proposal",
+            sender="agent_C",
+            data={
+                "our_price": 100,
+                "their_price": 90,
+                "our_order_id": "order_A",
+                "their_order_id": "order_C",
+                "role": "seller",
+            }
+        )
+        context_C = DecisionContext(
+            event=event_from_C,
+            agent_id="agent_A",
+            available_resources={},
+            negotiation_history=[]
+        )
+
+        result_B = await ce.evaluate(context_B)
+        result_C = await ce.evaluate(context_C)
+
+        # B's offer of 70 is below 80% (80), so seller should counter
+        assert result_B.action_type.value == "counter_offer"
+        assert result_B.parameters.get("proposed_price") == 85  # (100 + 70) // 2
+
+        # C's offer of 90 is >= 80% (80), so seller should accept
+        assert result_C.action_type.value == "accept_offer"


### PR DESCRIPTION
## Changes Made
- Role-aware negotiation policy with price bands for buyer and seller (buyer accepts 50-120%, seller accepts 80-200%)
- Refactored action construction for negotiation and negotiation ID generation
- Added duplicate negotiation prevention with pre-send thread creation
- Added determine role from order and resources
- Mark accepted negotiations as terminal to prevent reprocessing
- Added unit tests covering:
   - Buyer acceptance/counter/exit scenarios
   - Seller acceptance/counter/exit scenarios
   - Rejections on invalid data
   - Convergence scenarios
   - Multiple bilateral negotiations

## Testing                                                                                                                                                                             
From agent directory, run the unit tests:
```
cd agents/a2a-agent-trader
uv run pytest tests/unit/test_price_negotiation.py -v
```

Or run all unit tests:
```
cd agents/a2a-agent-trader
uv run pytest tests/unit/ -v
```