### PR TITLE
Feature: ZeroTier Waitlist Authorization Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,21 @@ Both registry and agent will auto-join ZeroTier when started if `ZEROTIER_NETWOR
 
 **Note**: ZeroTier operations require `sudo`.
 
+5. **Authorize Approved Waitlist Members**:
+
+   Copy `infra/zerotier/.env.sample` to `infra/zerotier/.env` and set `AIRTABLE_API_KEY`, `AIRTABLE_BASE_ID`, `AIRTABLE_TABLE_NAME`, and `ZEROTIER_NETWORK`. Requires `jq`.
+
+   ```bash
+   # Authorize all approved waitlist entries
+   ./infra/zerotier/authorize_approved_members.sh
+
+   # Retry entries that previously failed
+   ./infra/zerotier/authorize_approved_members.sh --retry-errors
+
+   # Limit records processed
+   ./infra/zerotier/authorize_approved_members.sh --max-entries 10
+   ```
+
 ## Useful Commands
 
 - Agent playground: `make playground` in `agent`

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -20,6 +20,12 @@ add-node:
 	fi; \
 	bash zerotier/authorize_zt_member.sh $$ZEROTIER_NETWORK $(NODE_ID)
 
+authorize-approved:
+	@bash zerotier/authorize_approved_members.sh
+
+authorize-approved-retry:
+	@bash zerotier/authorize_approved_members.sh --retry-errors
+
 get-peers:
 	@. ./zerotier/.env; \
 	./zerotier/get_peers.sh $$ZEROTIER_NETWORK

--- a/infra/zerotier/.env.sample
+++ b/infra/zerotier/.env.sample
@@ -9,3 +9,5 @@ ZEROTIER_NETWORK=5170efff3f3bf6ba
 
 # Airtable API Key for processing waitlist data 
 AIRTABLE_API_KEY=<your_airtable_api_key_here>
+AIRTABLE_BASE_ID=<your_airtable_base_id_here>
+AIRTABLE_TABLE_NAME=<your_airtable_table_name_here>

--- a/infra/zerotier/.env.sample
+++ b/infra/zerotier/.env.sample
@@ -7,3 +7,5 @@ NETWORK_CIDR="10.10.10.0/24"
 # Fill this up after generating the network
 ZEROTIER_NETWORK=5170efff3f3bf6ba
 
+# Airtable API Key for processing waitlist data 
+AIR_TABLE_API_KEY=<your_airtable_api_key_here>

--- a/infra/zerotier/.env.sample
+++ b/infra/zerotier/.env.sample
@@ -8,4 +8,4 @@ NETWORK_CIDR="10.10.10.0/24"
 ZEROTIER_NETWORK=5170efff3f3bf6ba
 
 # Airtable API Key for processing waitlist data 
-AIR_TABLE_API_KEY=<your_airtable_api_key_here>
+AIRTABLE_API_KEY=<your_airtable_api_key_here>

--- a/infra/zerotier/authorize_approved_members.sh
+++ b/infra/zerotier/authorize_approved_members.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+# authorize_pending_members.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="${SCRIPT_DIR}/.env"
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "Env file not found at $ENV_FILE"
+  echo "Copy infra/zerotier/.env.sample to $ENV_FILE and set values."
+  exit 1
+fi
+
+set -a
+source "$ENV_FILE"
+set +a
+
+# Check required environment variables
+for var in AIR_TABLE_API_KEY ZEROTIER_NETWORK; do
+  if [[ -z "${!var:-}" ]]; then
+    echo "Missing required env var: $var in $ENV_FILE" >&2
+    exit 1
+  fi
+done
+
+# Check if jq is installed for JSON parsing
+if ! command -v jq &> /dev/null; then
+  echo "Error: jq is required but not installed." >&2
+  echo "Install with: brew install jq (macOS) or apt-get install jq (Linux)" >&2
+  exit 1
+fi
+
+# Parse arguments
+FILTER_STATUS="approved"
+MAX_ENTRIES=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --retry-errors)
+      FILTER_STATUS="error"
+      shift
+      ;;
+    --max-entries)
+      if [[ -z "${2:-}" || "$2" =~ ^- ]]; then
+        echo "Error: --max-entries requires a numeric value" >&2
+        exit 1
+      fi
+      MAX_ENTRIES="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      echo "Usage: $0 [--retry-errors] [--max-entries N]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "$FILTER_STATUS" == "error" ]]; then
+  echo "Retry mode: fetching records with status 'error'..."
+else
+  echo "Fetching approved records from Airtable..."
+fi
+
+# Build Airtable API URL
+AIRTABLE_URL="https://api.airtable.com/v0/appY1WZgCrnD5QW1q/Waitlist%20Responses?filterByFormula=%7BStatus%7D+%3D+%27${FILTER_STATUS}%27&sort%5B0%5D%5Bfield%5D=Created&sort%5B0%5D%5Bdirection%5D=asc"
+if [[ -n "$MAX_ENTRIES" ]]; then
+  AIRTABLE_URL="${AIRTABLE_URL}&maxRecords=${MAX_ENTRIES}"
+fi
+
+# Fetch records from Airtable with error handling
+RESPONSE=$(curl -sf "$AIRTABLE_URL" \
+  -H "Authorization: Bearer $AIR_TABLE_API_KEY" 2>&1) || {
+  echo "Error: Failed to fetch data from Airtable" >&2
+  echo "$RESPONSE" >&2
+  exit 1
+}
+
+# Validate JSON response
+if ! echo "$RESPONSE" | jq empty 2>/dev/null; then
+  echo "Error: Invalid JSON response from Airtable" >&2
+  echo "$RESPONSE" >&2
+  exit 1
+fi
+
+# Extract approved records
+APPROVED_RECORDS=$(echo "$RESPONSE" | jq -c ".records[] | select(.fields.Status == \"$FILTER_STATUS\")")
+
+if [[ -z "$APPROVED_RECORDS" ]]; then
+  echo "No records with status '$FILTER_STATUS' found."
+  exit 0
+fi
+
+echo "Found records with status '$FILTER_STATUS'. Processing..."
+
+# Track successes and failures
+SUCCESS_COUNT=0
+FAILURE_COUNT=0
+
+# Process each approved record
+while IFS= read -r record; do
+  RECORD_ID=$(echo "$record" | jq -r '.id')
+  NODE_ID=$(echo "$record" | jq -r '.fields["Node ID"]')
+  EMAIL=$(echo "$record" | jq -r '.fields.Email // "N/A"')
+  
+  echo ""
+  echo "Processing: Email=$EMAIL, Node ID=$NODE_ID, Record ID=$RECORD_ID"
+  
+  # Authorize the member and capture output
+  AUTH_OUTPUT=$("${SCRIPT_DIR}/authorize_zt_member.sh" "$ZEROTIER_NETWORK" "$NODE_ID" 2>&1) || AUTH_ERROR=$?
+
+
+  if [[ ${AUTH_ERROR:-0} -eq 0 ]]; then
+    # Authorization succeeded
+    echo "✓ Authorization succeeded"
+
+    # Update Airtable status to "authorized"
+    echo "Updating Airtable status to 'authorized'..."
+    UPDATE_RESPONSE=$(curl -sf -X PATCH \
+      "https://api.airtable.com/v0/appY1WZgCrnD5QW1q/Waitlist%20Responses/$RECORD_ID" \
+      -H "Authorization: Bearer $AIR_TABLE_API_KEY" \
+      -H "Content-Type: application/json" \
+      -d "{\"fields\": {\"Status\": \"authorized\", \"Error Message\": \"\"}}" 2>&1) || {
+      echo "✗ Failed to update Airtable record $RECORD_ID to authorized" >&2
+      echo "$UPDATE_RESPONSE" >&2
+      FAILURE_COUNT=$((FAILURE_COUNT + 1))
+      continue
+    }
+    
+    echo "✓ Successfully updated record $RECORD_ID to 'authorized'"
+    SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
+  else
+    # Authorization failed
+    echo "✗ Authorization failed with exit code $AUTH_ERROR"
+    
+    # Escape the error message for JSON (keep the quotes)
+    ERROR_MSG=$(echo "$AUTH_OUTPUT" | jq -Rs .)
+    
+    # Update Airtable status to "error" with error message
+    echo "Updating Airtable status to 'error'..."
+    UPDATE_RESPONSE=$(curl -sf -X PATCH \
+      "https://api.airtable.com/v0/appY1WZgCrnD5QW1q/Waitlist%20Responses/$RECORD_ID" \
+      -H "Authorization: Bearer $AIR_TABLE_API_KEY" \
+      -H "Content-Type: application/json" \
+      -d "{\"fields\": {\"Status\": \"error\", \"Error Message\": $ERROR_MSG}}" 2>&1) || {
+      echo "✗ Failed to update Airtable record $RECORD_ID to error status" >&2
+      echo "$UPDATE_RESPONSE" >&2
+      FAILURE_COUNT=$((FAILURE_COUNT + 1))
+      continue
+    }
+    
+    echo "✓ Updated record $RECORD_ID to 'error' status"
+    FAILURE_COUNT=$((FAILURE_COUNT + 1))
+  fi
+  
+done <<< "$APPROVED_RECORDS"
+
+echo ""
+echo "========================================"
+echo "Processing complete!"
+echo "Successfully processed: $SUCCESS_COUNT"
+echo "Failed: $FAILURE_COUNT"
+echo "========================================"
+
+if [[ $FAILURE_COUNT -gt 0 ]]; then
+  exit 1
+fi
+

--- a/infra/zerotier/authorize_approved_members.sh
+++ b/infra/zerotier/authorize_approved_members.sh
@@ -17,7 +17,7 @@ source "$ENV_FILE"
 set +a
 
 # Check required environment variables
-for var in AIRTABLE_API_KEY ZEROTIER_NETWORK; do
+for var in AIRTABLE_API_KEY AIRTABLE_BASE_ID AIRTABLE_TABLE_NAME ZEROTIER_NETWORK; do
   if [[ -z "${!var:-}" ]]; then
     echo "Missing required env var: $var in $ENV_FILE" >&2
     exit 1

--- a/infra/zerotier/authorize_approved_members.sh
+++ b/infra/zerotier/authorize_approved_members.sh
@@ -17,7 +17,7 @@ source "$ENV_FILE"
 set +a
 
 # Check required environment variables
-for var in AIR_TABLE_API_KEY ZEROTIER_NETWORK; do
+for var in AIRTABLE_API_KEY ZEROTIER_NETWORK; do
   if [[ -z "${!var:-}" ]]; then
     echo "Missing required env var: $var in $ENV_FILE" >&2
     exit 1
@@ -71,7 +71,7 @@ fi
 
 # Fetch records from Airtable with error handling
 RESPONSE=$(curl -sf "$AIRTABLE_URL" \
-  -H "Authorization: Bearer $AIR_TABLE_API_KEY" 2>&1) || {
+  -H "Authorization: Bearer $AIRTABLE_API_KEY" 2>&1) || {
   echo "Error: Failed to fetch data from Airtable" >&2
   echo "$RESPONSE" >&2
   exit 1
@@ -119,7 +119,7 @@ while IFS= read -r record; do
     echo "Updating Airtable status to 'authorized'..."
     UPDATE_RESPONSE=$(curl -sf -X PATCH \
       "https://api.airtable.com/v0/appY1WZgCrnD5QW1q/Waitlist%20Responses/$RECORD_ID" \
-      -H "Authorization: Bearer $AIR_TABLE_API_KEY" \
+      -H "Authorization: Bearer $AIRTABLE_API_KEY" \
       -H "Content-Type: application/json" \
       -d "{\"fields\": {\"Status\": \"authorized\", \"Error Message\": \"\"}}" 2>&1) || {
       echo "✗ Failed to update Airtable record $RECORD_ID to authorized" >&2
@@ -141,7 +141,7 @@ while IFS= read -r record; do
     echo "Updating Airtable status to 'error'..."
     UPDATE_RESPONSE=$(curl -sf -X PATCH \
       "https://api.airtable.com/v0/appY1WZgCrnD5QW1q/Waitlist%20Responses/$RECORD_ID" \
-      -H "Authorization: Bearer $AIR_TABLE_API_KEY" \
+      -H "Authorization: Bearer $AIRTABLE_API_KEY" \
       -H "Content-Type: application/json" \
       -d "{\"fields\": {\"Status\": \"error\", \"Error Message\": $ERROR_MSG}}" 2>&1) || {
       echo "✗ Failed to update Airtable record $RECORD_ID to error status" >&2

--- a/infra/zerotier/authorize_approved_members.sh
+++ b/infra/zerotier/authorize_approved_members.sh
@@ -64,7 +64,7 @@ else
 fi
 
 # Build Airtable API URL
-AIRTABLE_URL="https://api.airtable.com/v0/appY1WZgCrnD5QW1q/Waitlist%20Responses?filterByFormula=%7BStatus%7D+%3D+%27${FILTER_STATUS}%27&sort%5B0%5D%5Bfield%5D=Created&sort%5B0%5D%5Bdirection%5D=asc"
+AIRTABLE_URL="https://api.airtable.com/v0/${AIRTABLE_BASE_ID}/${AIRTABLE_TABLE_NAME}?filterByFormula=%7BStatus%7D+%3D+%27${FILTER_STATUS}%27&sort%5B0%5D%5Bfield%5D=Created&sort%5B0%5D%5Bdirection%5D=asc"
 if [[ -n "$MAX_ENTRIES" ]]; then
   AIRTABLE_URL="${AIRTABLE_URL}&maxRecords=${MAX_ENTRIES}"
 fi


### PR DESCRIPTION
# ZeroTier Waitlist Authorization

Fetches waitlist entries from Airtable, authorizes them on a ZeroTier network, and updates their status back in Airtable.

See detailed usage guide [here](https://coda.io/d/SUBMITTED-Arkhai-Autonomous-Agents_dkqlCHRTkuw/ZeroTier-Waitlisting_su5-JakA).

## Prerequisites

- [jq](https://jqlang.github.io/jq/) for JSON parsing
- A `.env` file in this directory (copy from `.env.sample`)

### Required environment variables

| Variable | Description |
|---|---|
| `AIR_TABLE_API_KEY` | Airtable API key for accessing the waitlist table |
| `ZEROTIER_NETWORK` | ZeroTier network ID to authorize members on |

## Usage

```bash
# Authorize all approved waitlist entries (oldest first)
./authorize_approved_members.sh

# Limit to the first N entries
./authorize_approved_members.sh --max-entries 10

# Retry entries that previously failed
./authorize_approved_members.sh --retry-errors

# Combine flags
./authorize_approved_members.sh --retry-errors --max-entries 5
```

### Flags

| Flag | Description |
|---|---|
| `--retry-errors` | Process entries with `error` status instead of `approved` |
| `--max-entries N` | Limit the number of entries fetched from Airtable |

## How it works

1. Fetches records from the Airtable "Waitlist Responses" table filtered by status (`approved` by default), sorted oldest first
2. For each record, calls `authorize_zt_member.sh` to authorize the node on the ZeroTier network
3. On success, updates the Airtable record status to `authorized`
4. On failure, updates the status to `error` and stores the error message

The script exits with code `1` if any records failed to process.