### PR TITLE
Feature: Update Zerotier Scripts and Env to Handle External Self-Hosted Controllers 

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,10 +161,11 @@ The `make` targets above wrap the following scripts in `infra/zerotier/`. You ca
 
 #### `create_ztnetwork.sh`
 
-Creates a new private ZeroTier network, joins the controller node, and writes the generated network ID back to `infra/zerotier/.env`.
+Creates a new private ZeroTier network and writes the generated network ID back to `infra/zerotier/.env`. Pass `--join` to also join the network and authorize the local node.
 
 ```bash
-./infra/zerotier/create_ztnetwork.sh
+./infra/zerotier/create_ztnetwork.sh          # create only
+./infra/zerotier/create_ztnetwork.sh --join    # create network then join and authorize local node
 ```
 
 Required env vars in `infra/zerotier/.env`: `NETWORK_NAME`, `IP_RANGE_START`, `IP_RANGE_END`, `NETWORK_CIDR`, `CONTROLLER_URL`, `CONTROLLER_PORT`. Optionally set `CONTROLLER_AUTH_TOKEN` (falls back to reading the local auth token file). Requires `sudo`.

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Creates a new private ZeroTier network and writes the generated network ID back 
 ./infra/zerotier/create_ztnetwork.sh --join    # create network then join and authorize local node
 ```
 
-Required env vars in `infra/zerotier/.env`: `NETWORK_NAME`, `IP_RANGE_START`, `IP_RANGE_END`, `NETWORK_CIDR`, `CONTROLLER_URL`, `CONTROLLER_PORT`. Optionally set `CONTROLLER_AUTH_TOKEN` (falls back to reading the local auth token file). Requires `sudo`.
+Required env vars in `infra/zerotier/.env`: `NETWORK_NAME`, `IP_RANGE_START`, `IP_RANGE_END`, `NETWORK_CIDR`, `CONTROLLER_URL`. Optionally set `CONTROLLER_AUTH_TOKEN` (falls back to reading the local auth token file). Requires `sudo`.
 
 #### `authorize_zt_member.sh`
 
@@ -182,7 +182,7 @@ Authorizes a pending member on an existing network. The member must have already
 ./infra/zerotier/authorize_zt_member.sh <NETWORK_ID> <MEMBER_ID>
 ```
 
-Required env vars in `infra/zerotier/.env`: `CONTROLLER_URL`, `CONTROLLER_PORT`, `ZEROTIER_NETWORK`. Requires `sudo`.
+Required env vars in `infra/zerotier/.env`: `CONTROLLER_URL`, `ZEROTIER_NETWORK`. Requires `sudo`.
 
 ## Useful Commands
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,34 @@ Both registry and agent will auto-join ZeroTier when started if `ZEROTIER_NETWOR
    ./infra/zerotier/authorize_approved_members.sh --max-entries 10
    ```
 
+### Direct Script Usage
+
+The `make` targets above wrap the following scripts in `infra/zerotier/`. You can run them directly if needed.
+
+#### `create_ztnetwork.sh`
+
+Creates a new private ZeroTier network, joins the controller node, and writes the generated network ID back to `infra/zerotier/.env`.
+
+```bash
+./infra/zerotier/create_ztnetwork.sh
+```
+
+Required env vars in `infra/zerotier/.env`: `NETWORK_NAME`, `IP_RANGE_START`, `IP_RANGE_END`, `NETWORK_CIDR`, `CONTROLLER_URL`, `CONTROLLER_PORT`. Optionally set `CONTROLLER_AUTH_TOKEN` (falls back to reading the local auth token file). Requires `sudo`.
+
+#### `authorize_zt_member.sh`
+
+Authorizes a pending member on an existing network. The member must have already run `zerotier-cli join <NETWORK_ID>`.
+
+```bash
+# Uses ZEROTIER_NETWORK from .env as the network ID
+./infra/zerotier/authorize_zt_member.sh <MEMBER_ID>
+
+# Explicit network ID
+./infra/zerotier/authorize_zt_member.sh <NETWORK_ID> <MEMBER_ID>
+```
+
+Required env vars in `infra/zerotier/.env`: `CONTROLLER_URL`, `CONTROLLER_PORT`, `ZEROTIER_NETWORK`. Requires `sudo`.
+
 ## Useful Commands
 
 - Agent playground: `make playground` in `agent`

--- a/infra/zerotier/.env.sample
+++ b/infra/zerotier/.env.sample
@@ -10,7 +10,7 @@ ZEROTIER_NETWORK=5170efff3f3bf6ba
 # Fill this up with the self-hosted controller info
 CONTROLLER_URL="http://localhost"
 CONTROLLER_PORT=9993
-# Optional - only needed if connecting to an external controller, otherwise will retrieve this from the local controller
+# Optional - only needed if connecting to an external controller. If empty, will automatically use the local controller's auth token instead
 CONTROLLER_AUTH_TOKEN=
 
 # Airtable API Key for processing waitlist data 

--- a/infra/zerotier/.env.sample
+++ b/infra/zerotier/.env.sample
@@ -9,7 +9,6 @@ ZEROTIER_NETWORK=5170efff3f3bf6ba
 
 # Fill this up with the self-hosted controller info
 CONTROLLER_URL="http://localhost:9993"
-CONTROLLER_PORT=9993
 # Optional - only needed if connecting to an external controller. If empty, will automatically use the local controller's auth token instead
 CONTROLLER_AUTH_TOKEN=
 

--- a/infra/zerotier/.env.sample
+++ b/infra/zerotier/.env.sample
@@ -7,6 +7,12 @@ NETWORK_CIDR="10.10.10.0/24"
 # Fill this up after generating the network
 ZEROTIER_NETWORK=5170efff3f3bf6ba
 
+# Fill this up with the self-hosted controller info
+CONTROLLER_URL="http://localhost"
+CONTROLLER_PORT=9993
+# Optional - only needed if connecting to an external controller, otherwise will retrieve this from the local controller
+CONTROLLER_AUTH_TOKEN=
+
 # Airtable API Key for processing waitlist data 
 AIRTABLE_API_KEY=<your_airtable_api_key_here>
 AIRTABLE_BASE_ID=<your_airtable_base_id_here>

--- a/infra/zerotier/.env.sample
+++ b/infra/zerotier/.env.sample
@@ -8,7 +8,7 @@ NETWORK_CIDR="10.10.10.0/24"
 ZEROTIER_NETWORK=5170efff3f3bf6ba
 
 # Fill this up with the self-hosted controller info
-CONTROLLER_URL="http://localhost"
+CONTROLLER_URL="http://localhost:9993"
 CONTROLLER_PORT=9993
 # Optional - only needed if connecting to an external controller. If empty, will automatically use the local controller's auth token instead
 CONTROLLER_AUTH_TOKEN=

--- a/infra/zerotier/authorize_approved_members.sh
+++ b/infra/zerotier/authorize_approved_members.sh
@@ -108,6 +108,7 @@ while IFS= read -r record; do
   echo "Processing: Email=$EMAIL, Node ID=$NODE_ID, Record ID=$RECORD_ID"
   
   # Authorize the member and capture output
+  AUTH_ERROR=0
   AUTH_OUTPUT=$("${SCRIPT_DIR}/authorize_zt_member.sh" "$ZEROTIER_NETWORK" "$NODE_ID" 2>&1) || AUTH_ERROR=$?
 
 

--- a/infra/zerotier/authorize_approved_members.sh
+++ b/infra/zerotier/authorize_approved_members.sh
@@ -119,7 +119,7 @@ while IFS= read -r record; do
     # Update Airtable status to "authorized"
     echo "Updating Airtable status to 'authorized'..."
     UPDATE_RESPONSE=$(curl -sf -X PATCH \
-      "https://api.airtable.com/v0/appY1WZgCrnD5QW1q/Waitlist%20Responses/$RECORD_ID" \
+      "https://api.airtable.com/v0/${AIRTABLE_BASE_ID}/${AIRTABLE_TABLE_NAME}/$RECORD_ID" \
       -H "Authorization: Bearer $AIRTABLE_API_KEY" \
       -H "Content-Type: application/json" \
       -d "{\"fields\": {\"Status\": \"authorized\", \"Error Message\": \"\"}}" 2>&1) || {
@@ -141,7 +141,7 @@ while IFS= read -r record; do
     # Update Airtable status to "error" with error message
     echo "Updating Airtable status to 'error'..."
     UPDATE_RESPONSE=$(curl -sf -X PATCH \
-      "https://api.airtable.com/v0/appY1WZgCrnD5QW1q/Waitlist%20Responses/$RECORD_ID" \
+      "https://api.airtable.com/v0/${AIRTABLE_BASE_ID}/${AIRTABLE_TABLE_NAME}/$RECORD_ID" \
       -H "Authorization: Bearer $AIRTABLE_API_KEY" \
       -H "Content-Type: application/json" \
       -d "{\"fields\": {\"Status\": \"error\", \"Error Message\": $ERROR_MSG}}" 2>&1) || {

--- a/infra/zerotier/authorize_zt_member.sh
+++ b/infra/zerotier/authorize_zt_member.sh
@@ -35,8 +35,8 @@ if [[ -z "$NETWORK_ID" ]] || [[ -z "$MEMBER_ID" ]]; then
 fi
 # Check if ZeroTier controller API is accessible
 echo "Checking ZeroTier controller API..."
-if ! curl -s --max-time 2 $CONTROLLER_URL:$CONTROLLER_PORT/status &> /dev/null; then
-  echo "Error: ZeroTier controller API is not accessible at $CONTROLLER_URL:$CONTROLLER_PORT" >&2
+if ! curl -s --max-time 2 $CONTROLLER_URL/status &> /dev/null; then
+  echo "Error: ZeroTier controller API is not accessible at $CONTROLLER_URL" >&2
   echo "" >&2
   echo "The ZeroTier controller service needs to be running to authorize members." >&2
   exit 1
@@ -82,7 +82,7 @@ fi
 echo "Authorizing member $MEMBER_ID on network $NETWORK_ID..."
 
 set +e
-RESPONSE=$(curl -s --max-time 10 -X POST $CONTROLLER_URL:$CONTROLLER_PORT/controller/network/${NETWORK_ID}/member/${MEMBER_ID} \
+RESPONSE=$(curl -s --max-time 10 -X POST $CONTROLLER_URL/controller/network/${NETWORK_ID}/member/${MEMBER_ID} \
   -H "X-ZT1-Auth: $CONTROLLER_AUTH_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"authorized": true}' \
@@ -98,7 +98,7 @@ if [[ $CURL_EXIT -ne 0 ]]; then
   if [[ -n "$BODY" ]]; then
     echo "Response: $BODY" >&2
   fi
-  echo "Check that ZeroTier controller is reachable at $CONTROLLER_URL:$CONTROLLER_PORT" >&2
+  echo "Check that ZeroTier controller is reachable at $CONTROLLER_URL" >&2
   exit 1
 fi
 

--- a/infra/zerotier/authorize_zt_member.sh
+++ b/infra/zerotier/authorize_zt_member.sh
@@ -3,11 +3,34 @@
 
 set -euo pipefail
 
-NETWORK_ID="${1:-}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="${SCRIPT_DIR}/.env"
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "Env file not found at $ENV_FILE"
+  echo "Copy infra/zerotier/.env.sample to $ENV_FILE and set values."
+  exit 1
+fi
+
+# Load network configuration from .env
+set -a
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+set +a
+
+for var in CONTROLLER_URL CONTROLLER_PORT ZEROTIER_NETWORK; do
+  if [[ -z "${!var:-}" ]]; then
+    echo "Missing required env var: $var in $ENV_FILE" >&2
+    exit 1
+  fi
+done
+
+NETWORK_ID="${1:-$ZEROTIER_NETWORK}"
 MEMBER_ID="${2:-}"
 
 if [[ -z "$NETWORK_ID" ]] || [[ -z "$MEMBER_ID" ]]; then
-  echo "Usage: $0 NETWORK_ID MEMBER_ID" >&2
+  echo "Usage: $0 [NETWORK_ID] MEMBER_ID" >&2
+  echo "  NETWORK_ID defaults to ZEROTIER_NETWORK from .env ($ZEROTIER_NETWORK)" >&2
   exit 1
 fi
 
@@ -17,38 +40,100 @@ if ! command -v zerotier-cli &> /dev/null; then
   exit 1
 fi
 
-# Determine auth token file location based on OS
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  # macOS
-  AUTH_TOKEN_FILE="/Library/Application Support/ZeroTier/One/authtoken.secret"
-else
-  # Linux
-  AUTH_TOKEN_FILE="/var/lib/zerotier-one/authtoken.secret"
-fi
-
-if [[ ! -f "$AUTH_TOKEN_FILE" ]]; then
-  echo "Error: ZeroTier auth token not found at $AUTH_TOKEN_FILE" >&2
-  echo "Make sure ZeroTier is installed and running." >&2
+# Check if ZeroTier controller API is accessible
+echo "Checking ZeroTier controller API..."
+if ! curl -s --max-time 2 $CONTROLLER_URL:$CONTROLLER_PORT/status &> /dev/null; then
+  echo "Error: ZeroTier controller API is not accessible at $CONTROLLER_URL:$CONTROLLER_PORT" >&2
+  echo "" >&2
+  echo "The ZeroTier controller service needs to be running to authorize members." >&2
+  echo "" >&2
   if [[ "$OSTYPE" == "darwin"* ]]; then
-    echo "On macOS, start ZeroTier from System Settings or run: sudo launchctl load /Library/LaunchDaemons/com.zerotier.one.plist" >&2
+    echo "On macOS:" >&2
+    echo "  1. Open ZeroTier from Applications or System Preferences" >&2
+    echo "  2. Make sure ZeroTier is running (check the menu bar icon)" >&2
+    echo "  3. Or start it with: sudo launchctl load /Library/LaunchDaemons/com.zerotier.one.plist" >&2
+    echo "" >&2
+    echo "Note: On macOS, ZeroTier runs as a regular app, not a system service." >&2
+    echo "The controller API may only be available when ZeroTier is actively running." >&2
   else
-    echo "On Linux, start with: sudo systemctl start zerotier-one" >&2
+    echo "On Linux:" >&2
+    echo "  Start it with: sudo systemctl start zerotier-one" >&2
+    echo "  Enable it with: sudo systemctl enable zerotier-one" >&2
   fi
   exit 1
 fi
+echo "ZeroTier controller API is accessible"
 
-AUTH_TOKEN=$(sudo cat "$AUTH_TOKEN_FILE" 2>/dev/null)
-if [[ -z "$AUTH_TOKEN" ]]; then
-  echo "Error: Failed to read auth token from $AUTH_TOKEN_FILE" >&2
-  echo "This script requires sudo access. Please run it interactively." >&2
-  exit 1
+# Resolve auth token: prefer CONTROLLER_AUTH_TOKEN from env, fall back to auth token file
+if [[ -n "${CONTROLLER_AUTH_TOKEN:-}" ]]; then
+  echo "Using CONTROLLER_AUTH_TOKEN from environment" >&2
+  AUTH_TOKEN="$CONTROLLER_AUTH_TOKEN"
+else
+  echo "CONTROLLER_AUTH_TOKEN not set, reading from auth token file..." >&2
+
+  # Determine auth token file location based on OS
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    AUTH_TOKEN_FILE="/Library/Application Support/ZeroTier/One/authtoken.secret"
+  else
+    AUTH_TOKEN_FILE="/var/lib/zerotier-one/authtoken.secret"
+  fi
+
+  # Check if auth token file exists
+  if [[ ! -f "$AUTH_TOKEN_FILE" ]]; then
+    echo "Error: ZeroTier auth token not found at $AUTH_TOKEN_FILE" >&2
+    echo "Make sure ZeroTier is installed and running, or set CONTROLLER_AUTH_TOKEN in your .env file." >&2
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+      echo "On macOS, start ZeroTier from System Preferences or run: sudo launchctl load /Library/LaunchDaemons/com.zerotier.one.plist" >&2
+    else
+      echo "On Linux, start with: sudo systemctl start zerotier-one" >&2
+    fi
+    exit 1
+  fi
+
+  AUTH_TOKEN=$(sudo cat "$AUTH_TOKEN_FILE" 2>/dev/null)
+  if [[ -z "$AUTH_TOKEN" ]]; then
+    echo "Error: Failed to read auth token from $AUTH_TOKEN_FILE" >&2
+    echo "This script requires sudo access. Please run it interactively." >&2
+    exit 1
+  fi
+
+  CONTROLLER_AUTH_TOKEN="$AUTH_TOKEN"
 fi
 
 echo "Authorizing member $MEMBER_ID on network $NETWORK_ID..."
 
-curl -X POST http://localhost:9993/controller/network/${NETWORK_ID}/member/${MEMBER_ID} \
-  -H "X-ZT1-Auth: $AUTH_TOKEN" \
+set +e
+RESPONSE=$(curl -s --max-time 10 -X POST $CONTROLLER_URL:$CONTROLLER_PORT/controller/network/${NETWORK_ID}/member/${MEMBER_ID} \
+  -H "X-ZT1-Auth: $CONTROLLER_AUTH_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"authorized": true}'
+  -d '{"authorized": true}' \
+  -w "\n%{http_code}" 2>&1)
+CURL_EXIT=$?
+set -e
 
+HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+BODY=$(echo "$RESPONSE" | sed '$d')
+
+if [[ $CURL_EXIT -ne 0 ]]; then
+  echo "Error: Failed to authorize member (curl exit code: $CURL_EXIT)" >&2
+  if [[ -n "$BODY" ]]; then
+    echo "Response: $BODY" >&2
+  fi
+  echo "Check that ZeroTier controller is reachable at $CONTROLLER_URL:$CONTROLLER_PORT" >&2
+  exit 1
+fi
+
+if [[ "$HTTP_CODE" != "200" ]]; then
+  echo "Error: Failed to authorize member (HTTP $HTTP_CODE)" >&2
+  if [[ -n "$BODY" ]]; then
+    echo "Response: $BODY" >&2
+  fi
+  exit 1
+fi
+
+echo "Member $MEMBER_ID authorized successfully!"
+
+# Verify by listing peers
+echo -e "\nVerifying network peers..."
+sudo zerotier-cli -D${CONTROLLER_URL} -p${CONTROLLER_PORT} -T${CONTROLLER_AUTH_TOKEN} listpeers
 echo -e "\nDone!"

--- a/infra/zerotier/authorize_zt_member.sh
+++ b/infra/zerotier/authorize_zt_member.sh
@@ -33,33 +33,12 @@ if [[ -z "$NETWORK_ID" ]] || [[ -z "$MEMBER_ID" ]]; then
   echo "  NETWORK_ID defaults to ZEROTIER_NETWORK from .env ($ZEROTIER_NETWORK)" >&2
   exit 1
 fi
-
-# Check if ZeroTier is installed
-if ! command -v zerotier-cli &> /dev/null; then
-  echo "Error: ZeroTier CLI not found. Install with: cd infra && make install" >&2
-  exit 1
-fi
-
 # Check if ZeroTier controller API is accessible
 echo "Checking ZeroTier controller API..."
 if ! curl -s --max-time 2 $CONTROLLER_URL:$CONTROLLER_PORT/status &> /dev/null; then
   echo "Error: ZeroTier controller API is not accessible at $CONTROLLER_URL:$CONTROLLER_PORT" >&2
   echo "" >&2
   echo "The ZeroTier controller service needs to be running to authorize members." >&2
-  echo "" >&2
-  if [[ "$OSTYPE" == "darwin"* ]]; then
-    echo "On macOS:" >&2
-    echo "  1. Open ZeroTier from Applications or System Preferences" >&2
-    echo "  2. Make sure ZeroTier is running (check the menu bar icon)" >&2
-    echo "  3. Or start it with: sudo launchctl load /Library/LaunchDaemons/com.zerotier.one.plist" >&2
-    echo "" >&2
-    echo "Note: On macOS, ZeroTier runs as a regular app, not a system service." >&2
-    echo "The controller API may only be available when ZeroTier is actively running." >&2
-  else
-    echo "On Linux:" >&2
-    echo "  Start it with: sudo systemctl start zerotier-one" >&2
-    echo "  Enable it with: sudo systemctl enable zerotier-one" >&2
-  fi
   exit 1
 fi
 echo "ZeroTier controller API is accessible"
@@ -132,8 +111,3 @@ if [[ "$HTTP_CODE" != "200" ]]; then
 fi
 
 echo "Member $MEMBER_ID authorized successfully!"
-
-# Verify by listing peers
-echo -e "\nVerifying network peers..."
-sudo zerotier-cli -D${CONTROLLER_URL} -p${CONTROLLER_PORT} -T${CONTROLLER_AUTH_TOKEN} listpeers
-echo -e "\nDone!"

--- a/infra/zerotier/authorize_zt_member.sh
+++ b/infra/zerotier/authorize_zt_member.sh
@@ -18,7 +18,7 @@ set -a
 source "$ENV_FILE"
 set +a
 
-for var in CONTROLLER_URL CONTROLLER_PORT ZEROTIER_NETWORK; do
+for var in CONTROLLER_URL ZEROTIER_NETWORK; do
   if [[ -z "${!var:-}" ]]; then
     echo "Missing required env var: $var in $ENV_FILE" >&2
     exit 1

--- a/infra/zerotier/create_ztnetwork.sh
+++ b/infra/zerotier/create_ztnetwork.sh
@@ -3,6 +3,13 @@
 
 set -euo pipefail
 
+JOIN=false
+for arg in "$@"; do
+  case "$arg" in
+    --join) JOIN=true ;;
+  esac
+done
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ENV_FILE="${SCRIPT_DIR}/.env"
 
@@ -26,35 +33,37 @@ for var in NETWORK_NAME IP_RANGE_START IP_RANGE_END NETWORK_CIDR; do
 done
 
 # Get node ID and auth token
-# Check if ZeroTier is installed
-if ! command -v zerotier-cli &> /dev/null; then
-  echo "Error: ZeroTier CLI not found. Install with: make install" >&2
-  exit 1
-fi
-
-# Check if ZeroTier controller API is accessible
-echo "Checking ZeroTier controller API..."
-if ! curl -s --max-time 2 $CONTROLLER_URL:$CONTROLLER_PORT/status &> /dev/null; then
-  echo "Error: ZeroTier controller API is not accessible at $CONTROLLER_URL:$CONTROLLER_PORT" >&2
-  echo "" >&2
-  echo "The ZeroTier controller service needs to be running to create networks." >&2
-  echo "" >&2
-  if [[ "$OSTYPE" == "darwin"* ]]; then
-    echo "On macOS:" >&2
-    echo "  1. Open ZeroTier from Applications or System Preferences" >&2
-    echo "  2. Make sure ZeroTier is running (check the menu bar icon)" >&2
-    echo "  3. Or start it with: sudo launchctl load /Library/LaunchDaemons/com.zerotier.one.plist" >&2
-    echo "" >&2
-    echo "Note: On macOS, ZeroTier runs as a regular app, not a system service." >&2
-    echo "The controller API may only be available when ZeroTier is actively running." >&2
-  else
-    echo "On Linux:" >&2
-    echo "  Start it with: sudo systemctl start zerotier-one" >&2
-    echo "  Enable it with: sudo systemctl enable zerotier-one" >&2
+if [[ "$JOIN" == true ]]; then
+  # Check if ZeroTier is installed
+  if ! command -v zerotier-cli &> /dev/null; then
+    echo "Error: ZeroTier CLI not found. Install with: make install" >&2
+    exit 1
   fi
-  exit 1
+
+  # Check if ZeroTier service is running
+  echo "Checking ZeroTier service status..."
+  if ! zerotier-cli info &> /dev/null; then
+    echo "Error: ZeroTier service is not running." >&2
+    echo "" >&2
+    echo "The ZeroTier service needs to be running to create networks." >&2
+    echo "" >&2
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+      echo "On macOS:" >&2
+      echo "  1. Open ZeroTier from Applications or System Preferences" >&2
+      echo "  2. Make sure ZeroTier is running (check the menu bar icon)" >&2
+      echo "  3. Or start it with: sudo launchctl load /Library/LaunchDaemons/com.zerotier.one.plist" >&2
+      echo "" >&2
+      echo "Note: On macOS, ZeroTier runs as a regular app, not a system service." >&2
+      echo "The controller API may only be available when ZeroTier is actively running." >&2
+    else
+      echo "On Linux:" >&2
+      echo "  Start it with: sudo systemctl start zerotier-one" >&2
+      echo "  Enable it with: sudo systemctl enable zerotier-one" >&2
+    fi
+    exit 1
+  fi
+  echo "ZeroTier service is running"
 fi
-echo "ZeroTier controller API is accessible"
 
 # Resolve auth token: prefer CONTROLLER_AUTH_TOKEN from env, fall back to auth token file
 if [[ -n "${CONTROLLER_AUTH_TOKEN:-}" ]]; then
@@ -92,27 +101,25 @@ else
   CONTROLLER_AUTH_TOKEN="$AUTH_TOKEN"
 fi
 
-echo "Retrieving node ID..." >&2
+echo "Retrieving node ID from controller status..." >&2
 set +e
-ZT_INFO_OUTPUT=$(sudo zerotier-cli -D${CONTROLLER_URL} -p${CONTROLLER_PORT} -T${CONTROLLER_AUTH_TOKEN} info 2>&1)
-ZT_INFO_EXIT=$?
+STATUS_RESPONSE=$(curl -s --max-time 5 -H "X-ZT1-Auth: $CONTROLLER_AUTH_TOKEN" $CONTROLLER_URL:$CONTROLLER_PORT/status 2>&1)
+STATUS_EXIT=$?
 set -e
 
-if [[ $ZT_INFO_EXIT -ne 0 ]]; then
-  echo "Error: zerotier-cli info command failed (exit code: $ZT_INFO_EXIT)" >&2
-  echo "Command output: $ZT_INFO_OUTPUT" >&2
-  echo "Check that ZeroTier is running and the controller is reachable at $CONTROLLER_URL:$CONTROLLER_PORT" >&2
+if [[ $STATUS_EXIT -ne 0 ]]; then
+  echo "Error: Failed to fetch controller status (curl exit code: $STATUS_EXIT)" >&2
+  echo "Response: $STATUS_RESPONSE" >&2
+  echo "Check that the controller is reachable at $CONTROLLER_URL:$CONTROLLER_PORT" >&2
   exit 1
 fi
 
-NODE_ID=$(echo "$ZT_INFO_OUTPUT" | awk '{print $3}')
+NODE_ID=$(echo "$STATUS_RESPONSE" | grep -o '"address":"[^"]*"' | head -1 | cut -d'"' -f4)
 
 if [[ -z "$NODE_ID" ]] || [[ ${#NODE_ID} -ne 10 ]]; then
-  echo "Error: Failed to parse ZeroTier node ID from output." >&2
-  echo "Expected a 10-character node ID, got: '${NODE_ID:-<empty>}'" >&2
-  echo "Full zerotier-cli info output: $ZT_INFO_OUTPUT" >&2
-  echo "This script requires sudo access. Please run it interactively." >&2
-  echo "You can get your node ID manually with: sudo zerotier-cli info" >&2
+  echo "Error: Failed to parse node address from /status response." >&2
+  echo "Expected a 10-character address, got: '${NODE_ID:-<empty>}'" >&2
+  echo "Full /status response: $STATUS_RESPONSE" >&2
   exit 1
 fi
 
@@ -181,54 +188,75 @@ fi
 
 echo "   Network created successfully!"
 
-# Join the network
-echo -e "\n\n2. Joining network..."
-sudo zerotier-cli -D${CONTROLLER_URL} -p${CONTROLLER_PORT} -T${CONTROLLER_AUTH_TOKEN} join ${NETWORK_ID}
-
-# Authorize ourselves
-echo -e "\n3. Authorizing controller node..."
-sleep 2
-# Use set +e to allow curl to fail without exiting the script
+# Verify
+echo -e "\n\n2. Verifying network..."
+sleep 3
 set +e
-RESPONSE=$(curl -s -X POST $CONTROLLER_URL:$CONTROLLER_PORT/controller/network/${NETWORK_ID}/member/${NODE_ID} \
-  -H "X-ZT1-Auth: $CONTROLLER_AUTH_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"authorized": true}' \
-  -w "\n%{http_code}" 2>&1)
-CURL_EXIT=$?
+NETWORK_LIST=$(curl -s --max-time 5 -H "X-ZT1-Auth: $CONTROLLER_AUTH_TOKEN" $CONTROLLER_URL:$CONTROLLER_PORT/controller/network 2>&1)
+VERIFY_EXIT=$?
 set -e
 
-HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
-BODY=$(echo "$RESPONSE" | sed '$d')
-
-if [[ $CURL_EXIT -ne 0 ]] || [[ "$HTTP_CODE" != "200" ]]; then
-  echo "Warning: Failed to authorize controller node" >&2
-  if [[ $CURL_EXIT -ne 0 ]]; then
-    echo "Curl exit code: $CURL_EXIT" >&2
-  fi
-  if [[ -n "$HTTP_CODE" ]] && [[ "$HTTP_CODE" != "200" ]]; then
-    echo "HTTP status: $HTTP_CODE" >&2
-  fi
-  if [[ -n "$BODY" ]]; then
-    echo "Response: $BODY" >&2
-  fi
-  echo "You may need to authorize manually or the node may already be authorized." >&2
-  echo "Try running: make add-node NODE_ID=$NODE_ID" >&2
-  # Don't exit here as network creation succeeded
+if [[ $VERIFY_EXIT -ne 0 ]]; then
+  echo "Warning: Failed to fetch network list for verification (curl exit code: $VERIFY_EXIT)" >&2
+  echo "Response: $NETWORK_LIST" >&2
+elif echo "$NETWORK_LIST" | grep -q "$NETWORK_ID"; then
+  echo "   Verified: Network $NETWORK_ID found in controller network list."
 else
-  echo "Controller node authorized successfully!"
+  echo "Warning: Network $NETWORK_ID not found in controller network list." >&2
+  echo "Response: $NETWORK_LIST" >&2
 fi
-
-
-# Verify
-echo -e "\n\n4. Verifying network..."
-sleep 3
-sudo zerotier-cli -D${CONTROLLER_URL} -p${CONTROLLER_PORT} -T${CONTROLLER_AUTH_TOKEN} listnetworks
 
 echo -e "\n\nNetwork created successfully!"
 echo "Network ID: $NETWORK_ID"
 echo "Share this ID with others to join your network"
 echo ""
+
+if [[ "$JOIN" == true ]]; then
+  # Join the network
+  echo -e "\n3. Joining network..."
+  sudo zerotier-cli join ${NETWORK_ID}
+
+  # Authorize ourselves
+  echo -e "\n4. Authorizing local node..."
+  LOCAL_NODE_ID=$(zerotier-cli info | awk '{print $3}')
+  if [[ -z "$LOCAL_NODE_ID" ]] || [[ ${#LOCAL_NODE_ID} -ne 10 ]]; then
+    echo "Error: Failed to get local node ID from zerotier-cli info" >&2
+    echo "Got: '${LOCAL_NODE_ID:-<empty>}'" >&2
+    exit 1
+  fi
+  echo "   Local Node ID: $LOCAL_NODE_ID"
+  sleep 2
+  # Use set +e to allow curl to fail without exiting the script
+  set +e
+  RESPONSE=$(curl -s -X POST $CONTROLLER_URL:$CONTROLLER_PORT/controller/network/${NETWORK_ID}/member/${LOCAL_NODE_ID} \
+    -H "X-ZT1-Auth: $CONTROLLER_AUTH_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{"authorized": true}' \
+    -w "\n%{http_code}" 2>&1)
+  CURL_EXIT=$?
+  set -e
+
+  HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+  BODY=$(echo "$RESPONSE" | sed '$d')
+
+  if [[ $CURL_EXIT -ne 0 ]] || [[ "$HTTP_CODE" != "200" ]]; then
+    echo "Warning: Failed to authorize local node" >&2
+    if [[ $CURL_EXIT -ne 0 ]]; then
+      echo "Curl exit code: $CURL_EXIT" >&2
+    fi
+    if [[ -n "$HTTP_CODE" ]] && [[ "$HTTP_CODE" != "200" ]]; then
+      echo "HTTP status: $HTTP_CODE" >&2
+    fi
+    if [[ -n "$BODY" ]]; then
+      echo "Response: $BODY" >&2
+    fi
+    echo "You may need to authorize manually or the node may already be authorized." >&2
+    echo "Try running: make add-node NODE_ID=$LOCAL_NODE_ID" >&2
+    # Don't exit here as network creation succeeded
+  else
+    echo "Local node authorized successfully!"
+  fi
+fi
 
 # Try to update .env file with the network ID
 ENV_FILE="${SCRIPT_DIR}/.env"

--- a/infra/zerotier/create_ztnetwork.sh
+++ b/infra/zerotier/create_ztnetwork.sh
@@ -103,14 +103,14 @@ fi
 
 echo "Retrieving node ID from controller status..." >&2
 set +e
-STATUS_RESPONSE=$(curl -s --max-time 5 -H "X-ZT1-Auth: $CONTROLLER_AUTH_TOKEN" $CONTROLLER_URL:$CONTROLLER_PORT/status 2>&1)
+STATUS_RESPONSE=$(curl -s --max-time 5 -H "X-ZT1-Auth: $CONTROLLER_AUTH_TOKEN" $CONTROLLER_URL/status 2>&1)
 STATUS_EXIT=$?
 set -e
 
 if [[ $STATUS_EXIT -ne 0 ]]; then
   echo "Error: Failed to fetch controller status (curl exit code: $STATUS_EXIT)" >&2
   echo "Response: $STATUS_RESPONSE" >&2
-  echo "Check that the controller is reachable at $CONTROLLER_URL:$CONTROLLER_PORT" >&2
+  echo "Check that the controller is reachable at $CONTROLLER_URL" >&2
   exit 1
 fi
 
@@ -139,7 +139,7 @@ echo "   This may take a few seconds..."
 
 # Use timeout and better error handling
 set +e
-RESPONSE=$(curl -s --max-time 10 -X POST $CONTROLLER_URL:$CONTROLLER_PORT/controller/network/${NETWORK_ID} \
+RESPONSE=$(curl -s --max-time 10 -X POST $CONTROLLER_URL/controller/network/${NETWORK_ID} \
   -H "X-ZT1-Auth: $CONTROLLER_AUTH_TOKEN" \
   -H "Content-Type: application/json" \
   -d "{
@@ -169,7 +169,7 @@ if [[ $CURL_EXIT -ne 0 ]]; then
     echo "Response: $BODY" >&2
   fi
   echo "This might mean:" >&2
-  echo "  - ZeroTier controller API is not accessible at $CONTROLLER_URL:$CONTROLLER_PORT" >&2
+  echo "  - ZeroTier controller API is not accessible at $CONTROLLER_URL" >&2
   echo "  - Network already exists (try a different network ID)" >&2
   echo "  - ZeroTier service needs to be restarted" >&2
   exit 1
@@ -192,7 +192,7 @@ echo "   Network created successfully!"
 echo -e "\n\n2. Verifying network..."
 sleep 3
 set +e
-NETWORK_LIST=$(curl -s --max-time 5 -H "X-ZT1-Auth: $CONTROLLER_AUTH_TOKEN" $CONTROLLER_URL:$CONTROLLER_PORT/controller/network 2>&1)
+NETWORK_LIST=$(curl -s --max-time 5 -H "X-ZT1-Auth: $CONTROLLER_AUTH_TOKEN" $CONTROLLER_URL/controller/network 2>&1)
 VERIFY_EXIT=$?
 set -e
 
@@ -228,7 +228,7 @@ if [[ "$JOIN" == true ]]; then
   sleep 2
   # Use set +e to allow curl to fail without exiting the script
   set +e
-  RESPONSE=$(curl -s -X POST $CONTROLLER_URL:$CONTROLLER_PORT/controller/network/${NETWORK_ID}/member/${LOCAL_NODE_ID} \
+  RESPONSE=$(curl -s -X POST $CONTROLLER_URL/controller/network/${NETWORK_ID}/member/${LOCAL_NODE_ID} \
     -H "X-ZT1-Auth: $CONTROLLER_AUTH_TOKEN" \
     -H "Content-Type: application/json" \
     -d '{"authorized": true}' \
@@ -284,6 +284,6 @@ echo "To authorize new members:"
 echo "  make add-node NODE_ID=<member-id>"
 echo ""
 echo "Or manually:"
-echo "  curl -X POST $CONTROLLER_URL:$CONTROLLER_PORT/controller/network/${NETWORK_ID}/member/MEMBER_ID \\"
+echo "  curl -X POST $CONTROLLER_URL/controller/network/${NETWORK_ID}/member/MEMBER_ID \\"
 echo "    -H \"X-ZT1-Auth: $CONTROLLER_AUTH_TOKEN\" \\"
 echo "    -d '{\"authorized\": true}'"

--- a/infra/zerotier/create_ztnetwork.sh
+++ b/infra/zerotier/create_ztnetwork.sh
@@ -34,8 +34,8 @@ fi
 
 # Check if ZeroTier controller API is accessible
 echo "Checking ZeroTier controller API..."
-if ! curl -s --max-time 2 http://localhost:9993/status &> /dev/null; then
-  echo "Error: ZeroTier controller API is not accessible at http://localhost:9993" >&2
+if ! curl -s --max-time 2 $CONTROLLER_URL:$CONTROLLER_PORT/status &> /dev/null; then
+  echo "Error: ZeroTier controller API is not accessible at $CONTROLLER_URL:$CONTROLLER_PORT" >&2
   echo "" >&2
   echo "The ZeroTier controller service needs to be running to create networks." >&2
   echo "" >&2
@@ -56,60 +56,65 @@ if ! curl -s --max-time 2 http://localhost:9993/status &> /dev/null; then
 fi
 echo "ZeroTier controller API is accessible"
 
-# Determine auth token file location based on OS
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  # macOS
-  AUTH_TOKEN_FILE="/Library/Application Support/ZeroTier/One/authtoken.secret"
+# Resolve auth token: prefer CONTROLLER_AUTH_TOKEN from env, fall back to auth token file
+if [[ -n "${CONTROLLER_AUTH_TOKEN:-}" ]]; then
+  echo "Using CONTROLLER_AUTH_TOKEN from environment" >&2
+  AUTH_TOKEN="$CONTROLLER_AUTH_TOKEN"
 else
-  # Linux
-  AUTH_TOKEN_FILE="/var/lib/zerotier-one/authtoken.secret"
-fi
+  echo "CONTROLLER_AUTH_TOKEN not set, reading from auth token file..." >&2
 
-# Check if auth token file exists
-if [[ ! -f "$AUTH_TOKEN_FILE" ]]; then
-  echo "Error: ZeroTier auth token not found at $AUTH_TOKEN_FILE" >&2
-  echo "Make sure ZeroTier is installed and running." >&2
+  # Determine auth token file location based on OS
   if [[ "$OSTYPE" == "darwin"* ]]; then
-    echo "On macOS, start ZeroTier from System Preferences or run: sudo launchctl load /Library/LaunchDaemons/com.zerotier.one.plist" >&2
+    AUTH_TOKEN_FILE="/Library/Application Support/ZeroTier/One/authtoken.secret"
   else
-    echo "On Linux, start with: sudo systemctl start zerotier-one" >&2
+    AUTH_TOKEN_FILE="/var/lib/zerotier-one/authtoken.secret"
   fi
+
+  # Check if auth token file exists
+  if [[ ! -f "$AUTH_TOKEN_FILE" ]]; then
+    echo "Error: ZeroTier auth token not found at $AUTH_TOKEN_FILE" >&2
+    echo "Make sure ZeroTier is installed and running, or set CONTROLLER_AUTH_TOKEN in your .env file." >&2
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+      echo "On macOS, start ZeroTier from System Preferences or run: sudo launchctl load /Library/LaunchDaemons/com.zerotier.one.plist" >&2
+    else
+      echo "On Linux, start with: sudo systemctl start zerotier-one" >&2
+    fi
+    exit 1
+  fi
+
+  AUTH_TOKEN=$(sudo cat "$AUTH_TOKEN_FILE" 2>/dev/null)
+  if [[ -z "$AUTH_TOKEN" ]]; then
+    echo "Error: Failed to read auth token from $AUTH_TOKEN_FILE" >&2
+    echo "This script requires sudo access. Please run it interactively." >&2
+    exit 1
+  fi
+
+  CONTROLLER_AUTH_TOKEN="$AUTH_TOKEN"
+fi
+
+echo "Retrieving node ID..." >&2
+set +e
+ZT_INFO_OUTPUT=$(sudo zerotier-cli -D${CONTROLLER_URL} -p${CONTROLLER_PORT} -T${CONTROLLER_AUTH_TOKEN} info 2>&1)
+ZT_INFO_EXIT=$?
+set -e
+
+if [[ $ZT_INFO_EXIT -ne 0 ]]; then
+  echo "Error: zerotier-cli info command failed (exit code: $ZT_INFO_EXIT)" >&2
+  echo "Command output: $ZT_INFO_OUTPUT" >&2
+  echo "Check that ZeroTier is running and the controller is reachable at $CONTROLLER_URL:$CONTROLLER_PORT" >&2
   exit 1
 fi
 
-# Get node ID from identity file (requires sudo but avoids zerotier-cli password prompt)
-# The node ID is the first 10 characters of the identity.public file
-IDENTITY_FILE="${AUTH_TOKEN_FILE%/*}/identity.public"
-
-if [[ ! -f "$IDENTITY_FILE" ]]; then
-  echo "Error: ZeroTier identity file not found at $IDENTITY_FILE" >&2
-  echo "Make sure ZeroTier is installed and running." >&2
-  exit 1
-fi
-
-# Read node ID from identity file (first 10 chars)
-NODE_ID=$(sudo cat "$IDENTITY_FILE" 2>/dev/null | head -1 | cut -c 1-10)
-
-# If that failed, try zerotier-cli info as fallback
-if [[ -z "$NODE_ID" ]] || [[ ${#NODE_ID} -ne 10 ]]; then
-  echo "Trying alternative method to get node ID..." >&2
-  NODE_ID=$(sudo zerotier-cli info 2>/dev/null | awk '{print $3}')
-fi
+NODE_ID=$(echo "$ZT_INFO_OUTPUT" | awk '{print $3}')
 
 if [[ -z "$NODE_ID" ]] || [[ ${#NODE_ID} -ne 10 ]]; then
-  echo "Error: Failed to get ZeroTier node ID." >&2
+  echo "Error: Failed to parse ZeroTier node ID from output." >&2
+  echo "Expected a 10-character node ID, got: '${NODE_ID:-<empty>}'" >&2
+  echo "Full zerotier-cli info output: $ZT_INFO_OUTPUT" >&2
   echo "This script requires sudo access. Please run it interactively." >&2
   echo "You can get your node ID manually with: sudo zerotier-cli info" >&2
   exit 1
 fi
-
-AUTH_TOKEN=$(sudo cat "$AUTH_TOKEN_FILE" 2>/dev/null)
-if [[ -z "$AUTH_TOKEN" ]]; then
-  echo "Error: Failed to read auth token from $AUTH_TOKEN_FILE" >&2
-  echo "This script requires sudo access. Please run it interactively." >&2
-  exit 1
-fi
-
 
 # Generate network ID (node ID + random suffix)
 SUFFIX=$(openssl rand -hex 3)
@@ -127,8 +132,8 @@ echo "   This may take a few seconds..."
 
 # Use timeout and better error handling
 set +e
-RESPONSE=$(curl -s --max-time 10 -X POST http://localhost:9993/controller/network/${NETWORK_ID} \
-  -H "X-ZT1-Auth: $AUTH_TOKEN" \
+RESPONSE=$(curl -s --max-time 10 -X POST $CONTROLLER_URL:$CONTROLLER_PORT/controller/network/${NETWORK_ID} \
+  -H "X-ZT1-Auth: $CONTROLLER_AUTH_TOKEN" \
   -H "Content-Type: application/json" \
   -d "{
     \"name\": \"$NETWORK_NAME\",
@@ -157,7 +162,7 @@ if [[ $CURL_EXIT -ne 0 ]]; then
     echo "Response: $BODY" >&2
   fi
   echo "This might mean:" >&2
-  echo "  - ZeroTier controller API is not accessible at http://localhost:9993" >&2
+  echo "  - ZeroTier controller API is not accessible at $CONTROLLER_URL:$CONTROLLER_PORT" >&2
   echo "  - Network already exists (try a different network ID)" >&2
   echo "  - ZeroTier service needs to be restarted" >&2
   exit 1
@@ -178,15 +183,15 @@ echo "   Network created successfully!"
 
 # Join the network
 echo -e "\n\n2. Joining network..."
-sudo zerotier-cli join ${NETWORK_ID}
+sudo zerotier-cli -D${CONTROLLER_URL} -p${CONTROLLER_PORT} -T${CONTROLLER_AUTH_TOKEN} join ${NETWORK_ID}
 
 # Authorize ourselves
 echo -e "\n3. Authorizing controller node..."
 sleep 2
 # Use set +e to allow curl to fail without exiting the script
 set +e
-RESPONSE=$(curl -s -X POST http://localhost:9993/controller/network/${NETWORK_ID}/member/${NODE_ID} \
-  -H "X-ZT1-Auth: $AUTH_TOKEN" \
+RESPONSE=$(curl -s -X POST $CONTROLLER_URL:$CONTROLLER_PORT/controller/network/${NETWORK_ID}/member/${NODE_ID} \
+  -H "X-ZT1-Auth: $CONTROLLER_AUTH_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"authorized": true}' \
   -w "\n%{http_code}" 2>&1)
@@ -218,7 +223,7 @@ fi
 # Verify
 echo -e "\n\n4. Verifying network..."
 sleep 3
-sudo zerotier-cli listnetworks
+sudo zerotier-cli -D${CONTROLLER_URL} -p${CONTROLLER_PORT} -T${CONTROLLER_AUTH_TOKEN} listnetworks
 
 echo -e "\n\nNetwork created successfully!"
 echo "Network ID: $NETWORK_ID"
@@ -251,7 +256,6 @@ echo "To authorize new members:"
 echo "  make add-node NODE_ID=<member-id>"
 echo ""
 echo "Or manually:"
-echo "  curl -X POST http://localhost:9993/controller/network/${NETWORK_ID}/member/MEMBER_ID \\"
-echo "    -H \"X-ZT1-Auth: $AUTH_TOKEN\" \\"
+echo "  curl -X POST $CONTROLLER_URL:$CONTROLLER_PORT/controller/network/${NETWORK_ID}/member/MEMBER_ID \\"
+echo "    -H \"X-ZT1-Auth: $CONTROLLER_AUTH_TOKEN\" \\"
 echo "    -d '{\"authorized\": true}'"
-

--- a/infra/zerotier/get_peers.sh
+++ b/infra/zerotier/get_peers.sh
@@ -16,45 +16,30 @@ if ! command -v jq &> /dev/null; then
   exit 1
 fi
 
-# Check if ZeroTier is installed
-if ! command -v zerotier-cli &> /dev/null; then
-  echo "Error: ZeroTier CLI not found. Install with: cd infra && make install" >&2
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="${SCRIPT_DIR}/.env"
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "Env file not found at $ENV_FILE"
+  echo "Copy infra/zerotier/.env.sample to $ENV_FILE and set values."
   exit 1
 fi
 
-# Check if ZeroTier service is running (skip on macOS as it requires password prompt)
-if [[ "$OSTYPE" != "darwin"* ]]; then
-  if ! sudo zerotier-cli info &> /dev/null; then
-    echo "Error: ZeroTier service is not running." >&2
-    echo "Start it with: sudo systemctl start zerotier-one" >&2
-    exit 1
-  fi
-fi
+# Load configuration from .env
+set -a
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+set +a
 
-# Determine auth token file location based on OS
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  # macOS
-  AUTH_TOKEN_FILE="/Library/Application Support/ZeroTier/One/authtoken.secret"
-else
-  # Linux
-  AUTH_TOKEN_FILE="/var/lib/zerotier-one/authtoken.secret"
-fi
-
-# Check if auth token file exists
-if [[ ! -f "$AUTH_TOKEN_FILE" ]]; then
-  echo "Error: ZeroTier auth token not found at $AUTH_TOKEN_FILE" >&2
-  echo "Make sure ZeroTier is installed and running." >&2
-  if [[ "$OSTYPE" == "darwin"* ]]; then
-    echo "On macOS, start ZeroTier from System Preferences or run: sudo launchctl load /Library/LaunchDaemons/com.zerotier.one.plist" >&2
-  else
-    echo "On Linux, start with: sudo systemctl start zerotier-one" >&2
-  fi
+# Require CONTROLLER_AUTH_TOKEN from environment
+if [[ -z "${CONTROLLER_AUTH_TOKEN:-}" ]]; then
+  echo "Error: CONTROLLER_AUTH_TOKEN is not set." >&2
+  echo "Please set CONTROLLER_AUTH_TOKEN in your .env file." >&2
   exit 1
 fi
-# Where your ZeroTier state lives (default for most installs)
-TOKEN=$(sudo cat "$AUTH_TOKEN_FILE")
+TOKEN="$CONTROLLER_AUTH_TOKEN"
 
-API="http://127.0.0.1:9993"
+API="$CONTROLLER_URL:$CONTROLLER_PORT"
 
 echo "Using ZeroTier controller at: $API"
 echo "Network ID: $NWID"

--- a/infra/zerotier/get_peers.sh
+++ b/infra/zerotier/get_peers.sh
@@ -39,7 +39,7 @@ if [[ -z "${CONTROLLER_AUTH_TOKEN:-}" ]]; then
 fi
 TOKEN="$CONTROLLER_AUTH_TOKEN"
 
-API="$CONTROLLER_URL:$CONTROLLER_PORT"
+API="$CONTROLLER_URL"
 
 echo "Using ZeroTier controller at: $API"
 echo "Network ID: $NWID"


### PR DESCRIPTION
# ZeroTier Network Scripts

## Prerequisites

1. ZeroTier CLI installed (`zerotier-cli`)
2. A running ZeroTier controller (local or self-hosted)
3. Copy `.env.sample` to `.env` and fill in the required values

## Environment Variables

| Variable | Required By | Description |
|---|---|---|
| `NETWORK_NAME` | `create_ztnetwork.sh` | Name for the new network |
| `IP_RANGE_START` | `create_ztnetwork.sh` | Start of the IP assignment pool |
| `IP_RANGE_END` | `create_ztnetwork.sh` | End of the IP assignment pool |
| `NETWORK_CIDR` | `create_ztnetwork.sh` | Network CIDR route (e.g. `10.10.10.0/24`) |
| `CONTROLLER_URL` | Both | Controller API URL (e.g. `http://localhost`) |
| `CONTROLLER_PORT` | Both | Controller API port (default `9993`) |
| `CONTROLLER_AUTH_TOKEN` | Both | Optional. Falls back to reading the local auth token file if unset |
| `ZEROTIER_NETWORK` | `authorize_zt_member.sh` | Network ID (auto-populated by `create_ztnetwork.sh`) |

## Scripts

### `create_ztnetwork.sh`

Creates a new private ZeroTier network and joins the controller node to it.

```bash
./create_ztnetwork.sh
```

The script will:
1. Create a network using the IP range and CIDR from `.env`
2. Join the controller node to the new network
3. Authorize the controller node as a member
4. Write the generated `ZEROTIER_NETWORK` ID back to `.env`

Requires `sudo` (to read the local auth token and run `zerotier-cli`).

### `authorize_zt_member.sh`

Authorizes a member node on an existing ZeroTier network.

```bash
# Uses ZEROTIER_NETWORK from .env as the network ID
./authorize_zt_member.sh <MEMBER_ID>

# Explicit network ID
./authorize_zt_member.sh <NETWORK_ID> <MEMBER_ID>
```

The member must have already attempted to join the network (`zerotier-cli join <NETWORK_ID>`) so that it appears as a pending member on the controller.
