### PR TITLE
fix(puffer): patch pufferlib's eval loop

### DIFF
--- a/core/agent/Makefile
+++ b/core/agent/Makefile
@@ -171,8 +171,13 @@ train-arkhai:
 		--train.total-timesteps $$TOTAL_TIMESTEPS \
 		$$WANDB_FLAG $$TAG_FLAG $$ARGS
 
+# Patch pufferlib's eval loop to guard driver.render() with a render_mode check.
+# Re-run after every `uv sync`.
+patch-puffer-eval:
+	uv --project .. run python scripts/patch_puffer_eval.py
+
 # Evaluate Arkhai policy with upstream puffer CLI.
-# Usage: make eval-arkhai [MODEL=latest] [DEVICE=cpu] [ARGS="..."]
+# Usage: make eval-arkhai [MODEL=latest] [DEVICE=cpu] [ARGS="--render-mode None"]
 eval-arkhai:
 	@echo "Evaluating Arkhai model via puffer..."
 	@MODEL=$${MODEL:-latest}; \
@@ -181,13 +186,11 @@ eval-arkhai:
 	echo "Model: $$MODEL"; \
 	echo "Device: $$DEVICE"; \
 	[ -n "$$ARGS" ] && echo "Extra args: $$ARGS" || true; \
+	$(MAKE) patch-puffer-eval; \
 	uv --project .. run puffer eval puffer_arkhai \
 		--load-model-path $$MODEL \
 		--train.device $$DEVICE \
 		$$ARGS
-
-# Backward-compatible alias for previous target name.
-eval-arkhai-seller: eval-arkhai
 
 # Export model weights in puffer's native format.
 # Usage: make export-arkhai-weights [MODEL=latest]
@@ -196,9 +199,6 @@ export-arkhai-weights:
 	@MODEL=$${MODEL:-latest}; \
 	echo "Model: $$MODEL"; \
 	uv --project .. run puffer export puffer_arkhai --load-model-path $$MODEL
-
-# Backward-compatible alias for previous target name.
-export-arkhai-model: export-arkhai-weights
 
 # Test Arkhai environment integration
 # Usage: make test-arkhai-env

--- a/core/agent/scripts/patch_puffer_eval.py
+++ b/core/agent/scripts/patch_puffer_eval.py
@@ -1,0 +1,77 @@
+"""Patch pufferlib's eval loop with three fixes:
+
+1. Guard driver.render() so --render-mode None actually skips it.
+2. Replace `while True:` with a bounded episode loop (default 5 episodes,
+   override with --max-runs N).
+3. Unpack the full step tuple and print per-step reward/action output.
+
+Re-run after every `uv sync`:
+    uv run python scripts/patch_puffer_eval.py
+or:
+    make patch-puffer-eval
+"""
+import pathlib
+import sys
+
+PATCHES = [
+    (
+        "render guard",
+        "        render = driver.render()",
+        (
+            "        render = ("
+            "driver.render()"
+            " if getattr(driver, 'render_mode', 'auto') not in ('None', None)"
+            " else None"
+            ")"
+        ),
+    ),
+    (
+        "bounded episode loop",
+        "    frames = []\n    while True:",
+        "    frames = []\n    _ep, _step, _max_ep = 0, 0, args.get('max_runs', 5)\n    while _ep < _max_ep:",
+    ),
+    (
+        "step unpack + logging + episode reset",
+        "        ob = vecenv.step(action)[0]",
+        "\n".join([
+            "        ob, _rew, _done, _trunc, _ = vecenv.step(action)",
+            "        _step += 1",
+            "        print(",
+            "            f'[eval] ep {_ep+1}/{_max_ep}  step {_step:4d}"
+            "  rew {float(_rew[0]):+.4f}  act {action[0].tolist()}',"
+            "            flush=True,",
+            "        )",
+            "        if bool(_done[0]) or bool(_trunc[0]):",
+            "            _ep += 1",
+            "            if _ep < _max_ep:",
+            "                ob, _ = vecenv.reset()",
+            "                for _v in state.values():",
+            "                    _v.zero_()",
+            "            _step = 0",
+        ]),
+    ),
+]
+
+venv = pathlib.Path(".venv")
+matches = list(venv.rglob("pufferlib/pufferl.py"))
+if not matches:
+    print("ERROR: pufferlib not found in .venv — run `uv sync` first", file=sys.stderr)
+    sys.exit(1)
+
+target = matches[0]
+text = target.read_text()
+changed = False
+
+for desc, old, new in PATCHES:
+    if old not in text:
+        print(f"  skip  [{desc}] — already applied or pattern not found")
+        continue
+    text = text.replace(old, new)
+    print(f"  patch [{desc}]")
+    changed = True
+
+if changed:
+    target.write_text(text)
+    print(f"Written to {target}")
+else:
+    print("Nothing to do — all patches already applied.")


### PR DESCRIPTION
# Changes Made

- Added `scripts/patch_puffer_eval.py` to patch three upstream bugs in pufferlib's eval loop:
  - **Render guard**: `driver.render()` is called unconditionally even when `--render-mode None` is passed. Patch skips the call when render mode is `None`, enabling headless evaluation on servers without a display.
  - **Bounded episode loop**: The eval loop runs `while True:` with no exit condition. Patch replaces it with a bounded loop (default 5 episodes, configurable via `--max-runs N`).
  - **Step unpack + logging**: `vecenv.step()` return value was only partially unpacked (`ob = vecenv.step(action)[0]`). Patch unpacks the full tuple `(ob, rew, done, trunc, info)`, prints per-step reward/action output, and handles episode resets on done/truncated.
- Added `make patch-puffer-eval` target that runs the patch script.
- Updated `make eval-arkhai` to automatically run the patch before evaluation.
- Removed backward-compatible aliases (`eval-arkhai-seller`, `export-arkhai-model`) that are no longer referenced.

# Testing

## Patch application

- Run `cd agent && make patch-puffer-eval`.
- Verify the script prints `patch [render guard]`, `patch [bounded episode loop]`, and `patch [step unpack + logging + episode reset]`.
- Run `make patch-puffer-eval` again and verify it prints `skip` for all three patches (idempotent).

## Headless evaluation

- Train a model first: `make train-arkhai DEVICE=cpu TOTAL_TIMESTEPS=1000000`.
- Run `make eval-arkhai MODEL=experiments/puffer_arkhai_*/model_*.pt ARGS="--render-mode None"`.
- Verify:
  - No display/render errors on a headless server.
  - Per-step logs are printed: `[eval] ep 1/5  step    1  rew +0.0000  act [...]`.
  - Evaluation completes after 5 episodes and exits cleanly.

## Re-apply after uv sync

- Run `uv sync --dev` to reinstall pufferlib (resets the patched file).
- Run `make eval-arkhai MODEL=... ARGS="--render-mode None"` again.
- Verify the patch is re-applied automatically (eval-arkhai calls `make patch-puffer-eval` first).