### PR TITLE
Feature: Puffer Training CI

### DIFF
--- a/.github/workflows/validate-model-release.yml
+++ b/.github/workflows/validate-model-release.yml
@@ -1,0 +1,115 @@
+name: Validate Model Release
+
+on:
+  push:
+    tags:
+      - 'model-v*.*.*'  # Triggers on version tags like model-v0.1.0
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Release tag to validate (e.g. model-v0.1.0)"
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ github.event.inputs.release_tag || github.ref_name }}
+    defaults:
+      run:
+        working-directory: agent
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "0.8.13"
+          enable-cache: true
+          cache-dependency-glob: ""
+
+      - name: Install validation dependencies
+        run: |
+          uv venv .venv
+          uv pip install "setuptools>=80"
+          uv pip install --extra-index-url https://download.pytorch.org/whl/cpu \
+            torch gymnasium numpy
+          uv pip install --no-build-isolation \
+            "pufferlib @ git+https://github.com/arkhai-io/ArkhaiPufferEnv@ef59f84c989ddc6a30d0590c807507c4e09b65c7"
+
+      - name: Download release assets
+        id: download
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p app/policies/models
+          gh release download "${{ env.RELEASE_TAG }}" \
+            --pattern "*.pt" \
+            --dir app/policies/models/ \
+            --clobber
+
+      - name: Validate models
+        if: steps.download.outcome == 'success'
+        run: |
+          .venv/bin/python -c "
+          import sys, torch
+          from pathlib import Path
+          import gymnasium as gym
+          import pufferlib.models
+
+          # Minimal env stub — mirrors PolicyEnvStub in arkhai_common.py
+          class EnvStub:
+              def __init__(self, obs_dim):
+                  self.single_observation_space = gym.spaces.Box(0.0, 1.0, (obs_dim,), 'float32')
+                  self.single_action_space = gym.spaces.MultiDiscrete([9, 2])
+                  self.observation_space = self.single_observation_space
+                  self.action_space = self.single_action_space
+
+          NODE_TYPES = 3
+          OBS_DIM = 12 + 3 * NODE_TYPES  # upstream layout: 1+2N+5+N+5 = 21
+          print(f'Config: node_types={NODE_TYPES}, obs_dim={OBS_DIM}')
+
+          models_dir = Path('app/policies/models')
+          pt_files = list(models_dir.glob('*.pt'))
+          if not pt_files:
+              print('ERROR: No .pt files found in release')
+              sys.exit(1)
+
+          for pt_file in pt_files:
+              print(f'Validating {pt_file.name}...')
+
+              model = pufferlib.models.Default(EnvStub(OBS_DIM), hidden_size=128)
+              raw = torch.load(str(pt_file), map_location='cpu', weights_only=True)
+              sd = raw.get('policy_state_dict', raw) if isinstance(raw, dict) else raw
+              if any(k.startswith('policy.') for k in sd):
+                  sd = {k.removeprefix('policy.'): v for k, v in sd.items() if k.startswith('policy.')}
+              model.load_state_dict(sd, strict=False)
+              model.eval()
+
+              obs = torch.zeros(1, OBS_DIM)
+              with torch.no_grad():
+                  output = model(obs)
+
+              assert isinstance(output, tuple) and len(output) == 2, f'{pt_file.name}: unexpected output shape'
+              print(f'  OK: {pt_file.name} loaded and forward pass succeeded')
+
+          print('All models validated successfully.')
+          "
+
+      - name: Comment on release
+        if: steps.download.outcome == 'success'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release edit "${{ env.RELEASE_TAG }}" \
+            --notes-file <(cat <<EOF
+          $(gh release view "${{ env.RELEASE_TAG }}" --json body -q .body)
+
+          ---
+          **Validation:** All model artifacts passed smoke tests (checkpoint load + forward pass).
+          EOF
+          )

--- a/agent/.cloudbuild/staging.yaml
+++ b/agent/.cloudbuild/staging.yaml
@@ -13,6 +13,22 @@
 # limitations under the License.
 
 steps:
+  # Download trained model artifacts from GitHub Release
+  - name: "gcr.io/cloud-builders/git"
+    id: download-models
+    entrypoint: /bin/bash
+    args:
+      - "-c"
+      - |
+        apt-get update && apt-get install -y gh
+        mkdir -p agent/app/policies/models
+        gh release download "${_MODEL_VERSION}" \
+          --repo "${_GITHUB_REPO}" \
+          --pattern "*.pt" \
+          --dir agent/app/policies/models/ \
+          --clobber || echo "WARNING: Model download failed, continuing without models"
+    secretEnv: ['GITHUB_TOKEN']
+
   # Build and Push
   - name: "gcr.io/cloud-builders/docker"
     args:
@@ -129,6 +145,8 @@ steps:
 substitutions:
   _STAGING_PROJECT_ID: YOUR_STAGING_PROJECT_ID
   _REGION: asia-southeast1
+  _MODEL_VERSION: "latest"
+  _GITHUB_REPO: "arkhai-io/simple-market-service"
 
 logsBucket: gs://${PROJECT_ID}-a2a-agent-logs/build-logs
 options:

--- a/agent/.gitignore
+++ b/agent/.gitignore
@@ -195,3 +195,9 @@ my_env.tfvars
 .saved_chats
 .env
 .requirements.txt
+
+# Trained model checkpoints (distributed via GitHub Releases)
+app/policies/models/*.pt
+
+# Puffer training experiments
+experiments/

--- a/agent/app/arkhai_training/README.md
+++ b/agent/app/arkhai_training/README.md
@@ -1,29 +1,73 @@
 # Arkhai Training (Library-First)
 
-This project uses `ArkhaiPufferEnv` via `pufferlib` directly.
+This project uses `ArkhaiPufferEnv` via `pufferlib` directly. Training produces `.pt` checkpoint files that are released as GitHub Release assets and downloaded at deployment time.
 
 ## Source of Truth
 
 - Environment and training contracts come from upstream `pufferlib`.
 - Local scripts in this folder are intentionally minimal.
-- Training and evaluation should run through `puffer` CLI commands.
+- Training and evaluation run through `puffer` CLI commands via Makefile targets.
+- Training configs live in `agent/app/arkhai_training/config/`.
+- Sweep-tuned PPO hyperparameters are from upstream ArkhaiPufferEnv (100M timesteps).
 
-## Recommended Commands
+## Prerequisites
+
+**Hardware:** GPU recommended. Training runs at ~300K SPS on RTX A5000 (~5 min for 100M steps).
+
+**WandB setup** (optional, for tracking training metrics):
+
+```bash
+# Install is automatic (transitive dep from pufferlib)
+# Login with your API key from https://wandb.ai/authorize
+cd agent
+uv run wandb login
+```
+
+## Training Commands
 
 Run from `/agent`:
 
 ```bash
-# Train with defaults
-make train-arkhai
+# ──────────────────────────────────────────────
+# Seller training
+# ──────────────────────────────────────────────
 
-# Train with explicit controls
-make train-arkhai DEVICE=cpu TOTAL_TIMESTEPS=1000000 ARGS="--vec.num-envs 1 --env.num-envs 64 --train.batch-size 16384 --train.minibatch-size 2048"
+# Smoke test (CPU, quick validation)
+make train-arkhai DEVICE=cpu TOTAL_TIMESTEPS=1000000
 
+# Production seller (GPU, 100M steps, WandB logging)
+make train-arkhai DEVICE=cuda TOTAL_TIMESTEPS=100000000 WANDB=true TAG=seller_prod_v1
+
+# With explicit overrides
+make train-arkhai DEVICE=cuda TOTAL_TIMESTEPS=100000000 WANDB=true TAG=seller_v1 \
+  ARGS="--vec.num-envs 1 --env.num-envs 64 --train.batch-size 16384 --train.minibatch-size 2048"
+
+# ──────────────────────────────────────────────
+# Buyer training
+# ──────────────────────────────────────────────
+
+# Production buyer (GPU, 100M steps, WandB logging)
+make train-arkhai-buyer DEVICE=cuda TOTAL_TIMESTEPS=100000000 WANDB=true TAG=buyer_prod_v1
+
+# ──────────────────────────────────────────────
+# Bilateral training (experimental)
+# ──────────────────────────────────────────────
+
+# Both AI seller and AI buyer train simultaneously
+make train-arkhai-bilateral DEVICE=cuda TOTAL_TIMESTEPS=100000000 WANDB=true TAG=bilateral_v1
+```
+
+## Evaluation
+
+```bash
 # Evaluate latest checkpoint
 make eval-arkhai
 
 # Evaluate specific checkpoint
 make eval-arkhai MODEL=experiments/puffer_arkhai_*/model_puffer_arkhai_000001.pt
+
+# Evaluate buyer
+make eval-arkhai-buyer MODEL=experiments/puffer_arkhai_*/model_puffer_arkhai_000001.pt
 
 # Export puffer-native weights binary
 make export-arkhai-weights MODEL=latest
@@ -32,12 +76,92 @@ make export-arkhai-weights MODEL=latest
 make test-arkhai-env
 ```
 
+## Release and Deploy
+
+After training, copy the checkpoint and release it as a GitHub asset:
+
+```bash
+# 1. Copy checkpoint to model directory
+cp experiments/puffer_arkhai_<run_id>.pt app/policies/models/arkhai_seller.pt
+cp experiments/puffer_arkhai_<run_id>.pt app/policies/models/arkhai_buyer.pt
+
+# 2. Release to GitHub (requires gh CLI authenticated)
+make release-models VERSION=model-v0.1.0
+
+# 3. Download models (on other machines or in CI)
+make download-models VERSION=model-v0.1.0
+make download-models  # downloads latest
+```
+
+The `.pt` files are **not committed to git** (listed in `.gitignore`). They travel through GitHub Releases as binary assets. Cloud Build downloads them before building the Docker image.
+
+## Training Configs
+
+| Config | File | Description |
+|--------|------|-------------|
+| Seller | `config/single_agent_seller.ini` | 1 AI seller vs 3 scripted buyers |
+| Buyer | `config/single_agent_buyer.ini` | 1 AI buyer vs 3 scripted sellers |
+| Bilateral | `config/bilateral.ini` | Both AI seller and buyer (experimental) |
+
+All configs use sweep-tuned PPO hyperparameters from upstream ArkhaiPufferEnv. If training is unstable, alternate hyperparameters are commented in the config files.
+
+## GPU Node Type Configuration
+
+The RL environment models a compute marketplace with configurable GPU node types. Each node type occupies a **slot** in the observation vector, contributing 3 dimensions: cluster total nodes, cluster free nodes, and request nodes.
+
+```
+obs_dim = 12 + 3 * ARKHAI_NODE_TYPES
+```
+
+### Default slot mapping (3 node types, obs_dim=21)
+
+| Slot | GPU Model | Env Value |
+|------|-----------|-----------|
+| 0 | H200 | `H200` |
+| 1 | Tesla V100 | `Tesla V100` |
+| 2 | RTX 5080 | `RTX 5080` |
+
+### Customizing the slot map
+
+Set these environment variables (or add to `.env`):
+
+```bash
+# Number of GPU node types
+ARKHAI_NODE_TYPES=4
+
+# Comma-separated GPU_NAME:SLOT pairs
+ARKHAI_GPU_SLOT_MAP="H200:0, Tesla V100:1, RTX 5080:2, A100:3"
+
+# Per-slot job GPU node counts (comma-separated, one per slot)
+ARKHAI_JOB_GPU_NODES="10,10,10,10"
+
+# Or set individually per slot
+ARKHAI_JOB_GPU_0_NODES=10
+ARKHAI_JOB_GPU_1_NODES=10
+ARKHAI_JOB_GPU_2_NODES=10
+ARKHAI_JOB_GPU_3_NODES=10
+```
+
+GPU names in `ARKHAI_GPU_SLOT_MAP` must match the `GPUModel` enum values in `app/schema/pydantic_models.py`. Slot indices must be in `[0, ARKHAI_NODE_TYPES)`. When the env var is unset, the default 3-slot mapping above is used.
+
+Training configs in `config/` set per-slot cluster capacities (`cluster_gpu_N_capacity`) and job sizes (`job_gpu_N_nodes`). These must be consistent with the slot map.
+
+See `agent/.env.sample` for a complete reference of all configurable variables.
+
+## Policy Integration
+
+The trained models are loaded by the policy adapters at runtime:
+
+- `app/policies/torch_arkhai_seller.py` loads `arkhai_seller.pt`
+- `app/policies/torch_arkhai_buyer.py` loads `arkhai_buyer.pt`
+- Override paths via env vars: `ARKHAI_SELLER_MODEL_PATH`, `ARKHAI_BUYER_MODEL_PATH`
+
+The policy manager chains: RL seller -> RL buyer -> rule-based accept. Each RL policy returns `None` when its `.pt` file is absent, falling through gracefully.
+
 ## Notes
 
 1. If training fails with `batch_size`/`minibatch_size` errors, pass compatible values in `ARGS`.
-2. Keep dependency pinning immutable in `pyproject.toml` and sync `uv.lock`.
-3. If upstream env keys change, update local Makefile/test config to match upstream key names.
-
-## Deprecated Local Workflow
-
-The previous custom scripts `eval.py` and `export_model.py` were removed in favor of library-native `puffer eval` and `puffer export`.
+2. If `total_timesteps` is too small relative to batch size, training may fail with a division error. Use at least 1M steps.
+3. Keep dependency pinning immutable in `pyproject.toml` and sync `uv.lock`.
+4. If upstream env keys change, update local Makefile/test config to match upstream key names.
+5. `pyproject.toml` uses `pytorch-cu128` on Linux and `pytorch-cpu` on macOS.

--- a/agent/app/arkhai_training/config/bilateral.ini
+++ b/agent/app/arkhai_training/config/bilateral.ini
@@ -5,17 +5,23 @@ policy_name = Policy
 rnn_name = Recurrent
 
 [vec]
-backend = multiprocessing
-num_envs = 4
+# Serial backend required: Multiprocessing hangs with bilateral (2 AI agents per env).
+# Compensate by using more envs per worker.
+backend = Serial
+num_envs = 1
 
 [env]
 num_envs = 1024
 node_types = 3
 
+# Bilateral training: both AI buyer and AI seller learn simultaneously.
+# This produces co-adapted models but is harder to train (non-stationary opponents).
+# Verified by upstream C tests in arkhai.c (bilateral agent negotiation test).
+# Experimental -- prefer single-agent configs for initial production models.
 ai_sellers = 1
-ai_buyers = 0
+ai_buyers = 1
 scripted_sellers = 0
-scripted_buyers = 3
+scripted_buyers = 0
 
 episode_length = 100
 request_timeout = 5
@@ -76,7 +82,6 @@ cluster_kw_generation_dr = 0.2
 
 [train]
 # Sweep-tuned PPO hyperparameters from upstream ArkhaiPufferEnv.
-# vf_clip_coef is aggressively low but the rest are reasonable.
 total_timesteps = 100_000_000
 learning_rate = 0.019070502993686896
 gamma = 0.9947092311365654
@@ -89,27 +94,8 @@ max_grad_norm = 1.9130472971582053
 adam_beta1 = 0.9223446120784968
 adam_beta2 = 0.9418904801775516
 adam_eps = 4.1808405477736747e-11
-minibatch_size = 8192
+minibatch_size = 1024
 prio_alpha = 0.99
 prio_beta0 = 0.7552965379192393
 vtrace_c_clip = 2.6939928387562437
 vtrace_rho_clip = 0.6513603468577192
-
-# Alternate stable settings if the above gets unstable
-#total_timesteps = 100_000_000
-#learning_rate = 0.014061052765541085
-#gamma = 0.9924188400188361
-#gae_lambda = 0.99364902402328
-#clip_coef = 0.1674137340268662
-#ent_coef = 0.001402322657505479
-#vf_coef = 1.0765600879902826
-#vf_clip_coef = 0.9671558938774713
-#max_grad_norm = 0.2898020872357432
-#adam_beta1 = 0.9109764991734199
-#adam_beta2 = 0.9985139194195674
-#adam_eps = 2.487083956093364e-9
-#minibatch_size = 16384
-#prio_alpha = 0.9877184059538485
-#prio_beta0 = 0.09999999999999998
-#vtrace_c_clip = 3.1287697179359437
-#vtrace_rho_clip = 0.6256051857893086

--- a/agent/app/arkhai_training/config/single_agent_buyer.ini
+++ b/agent/app/arkhai_training/config/single_agent_buyer.ini
@@ -12,10 +12,15 @@ num_envs = 4
 num_envs = 1024
 node_types = 3
 
-ai_sellers = 1
-ai_buyers = 0
-scripted_sellers = 0
-scripted_buyers = 3
+# Buyer training: 1 AI buyer learns against 3 scripted sellers.
+# Buyer clusters are initialized as empty ({0} ClusterSpec) -- the buyer has
+# no infrastructure. Cluster observation features will be zero; the model
+# learns from request features, price dynamics, and negotiation outcomes.
+# Buyer reward = (base_price - negotiated_price) * duration (profit margin).
+ai_sellers = 0
+ai_buyers = 1
+scripted_sellers = 3
+scripted_buyers = 0
 
 episode_length = 100
 request_timeout = 5

--- a/agent/app/policies/arkhai_common.py
+++ b/agent/app/policies/arkhai_common.py
@@ -1,0 +1,497 @@
+"""Shared infrastructure for Arkhai policy adapters (seller and buyer).
+
+Observation layout, model creation, checkpoint loading, and action extraction
+are identical for both sides. Role-specific logic (accept/counter/reject
+thresholds, model path, env var) lives in the role-specific modules.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+import gymnasium as gym
+
+from app.schema.pydantic_models import (
+    Action as DomainAction,
+    ActionType,
+    ComputeResource,
+    ComputeResourcePortfolio,
+    DecisionContext,
+    GPUModel,
+    TokenResource,
+)
+
+try:  # Torch is optional at runtime; fail gracefully if unavailable.
+    torch: Any = importlib.import_module("torch")
+except Exception:  # pragma: no cover - environment-dependent
+    torch = None
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Environment stub for puffer model creation
+# ---------------------------------------------------------------------------
+
+class PolicyEnvStub:
+    """Minimal env shape/action stub for puffer Default policy."""
+
+    def __init__(self, obs_dim: int) -> None:
+        self.single_observation_space = gym.spaces.Box(
+            low=0.0,
+            high=1.0,
+            shape=(obs_dim,),
+            dtype="float32",
+        )
+        self.single_action_space = gym.spaces.MultiDiscrete([9, 2])
+        # Aliases required by pufferlib.models.Default dict-obs detection fallback
+        self.observation_space = self.single_observation_space
+        self.action_space = self.single_action_space
+
+
+# ---------------------------------------------------------------------------
+# Config parsing helpers
+# ---------------------------------------------------------------------------
+
+def parse_node_types() -> int:
+    try:
+        return max(1, int(os.getenv("ARKHAI_NODE_TYPES", "3")))
+    except ValueError:
+        return 3
+
+
+def parse_job_nodes(node_types: int) -> list[float]:
+    raw = os.getenv("ARKHAI_JOB_GPU_NODES", "")
+    if not raw.strip():
+        values: list[float] = []
+        for slot in range(node_types):
+            slot_raw = os.getenv(f"ARKHAI_JOB_GPU_{slot}_NODES", "").strip()
+            if not slot_raw:
+                values.append(10.0)
+                continue
+            try:
+                values.append(float(slot_raw))
+            except ValueError:
+                logger.warning(
+                    "[ARKHAI COMMON] Invalid ARKHAI_JOB_GPU_%s_NODES value '%s'; using default",
+                    slot,
+                    slot_raw,
+                )
+                values.append(10.0)
+        return values
+    values = []
+    for item in raw.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        try:
+            values.append(float(item))
+        except ValueError:
+            logger.warning(
+                "[ARKHAI COMMON] Invalid ARKHAI_JOB_GPU_NODES value '%s'; using defaults",
+                raw,
+            )
+            return [10.0] * node_types
+    if not values:
+        return [10.0] * node_types
+    if len(values) < node_types:
+        values.extend([values[-1]] * (node_types - len(values)))
+    return values[:node_types]
+
+
+def parse_gpu_slot_map(node_types: int) -> dict[str, int]:
+    mapping: dict[str, int] = {
+        GPUModel.H200.value: 0,
+        GPUModel.TESLA_V100.value: 1,
+        GPUModel.RTX_5080.value: 2,
+    }
+    raw = os.getenv("ARKHAI_GPU_SLOT_MAP", "").strip()
+    if not raw:
+        return {
+            key: slot
+            for key, slot in mapping.items()
+            if 0 <= slot < node_types
+        }
+
+    parsed: dict[str, int] = {}
+    for pair in raw.split(","):
+        pair = pair.strip()
+        if not pair or ":" not in pair:
+            continue
+        gpu_name, slot_str = pair.split(":", 1)
+        try:
+            slot = int(slot_str.strip())
+        except ValueError:
+            continue
+        if 0 <= slot < node_types:
+            parsed[gpu_name.strip()] = slot
+
+    if parsed:
+        return parsed
+    logger.warning(
+        "[ARKHAI COMMON] Invalid ARKHAI_GPU_SLOT_MAP='%s'; using defaults",
+        raw,
+    )
+    return {
+        key: slot
+        for key, slot in mapping.items()
+        if 0 <= slot < node_types
+    }
+
+
+def obs_dim(node_types: int) -> int:
+    # Upstream Arkhai layout:
+    # 1 (time) + 2*N (cluster nodes) + 5 (tb/energy) + N (request nodes) + 5 (request meta + prev_reward)
+    return 12 + 3 * node_types
+
+
+# ---------------------------------------------------------------------------
+# Model creation and checkpoint loading
+# ---------------------------------------------------------------------------
+
+def create_model(obs_dim: int) -> Optional[Any]:
+    if torch is None:
+        return None
+    try:
+        puffer_models = importlib.import_module("pufferlib.models")
+        env_stub = PolicyEnvStub(obs_dim)
+        return puffer_models.Default(env_stub, hidden_size=128)
+    except Exception as exc:
+        logger.error("[ARKHAI COMMON] Failed to create puffer model stub: %s", exc)
+        return None
+
+
+def load_state_dict(model_file: Path, obs_dim_val: int) -> Optional[Any]:
+    if torch is None:
+        return None
+
+    model = create_model(obs_dim_val)
+    if model is None:
+        return None
+
+    try:
+        raw_state = torch.load(str(model_file), map_location="cpu")
+    except Exception as exc:
+        logger.error("[ARKHAI COMMON] Failed reading model file %s: %s", model_file, exc)
+        return None
+
+    if not isinstance(raw_state, dict):
+        logger.error("[ARKHAI COMMON] Unsupported checkpoint format at %s", model_file)
+        return None
+
+    state_dict = raw_state.get("policy_state_dict", raw_state)
+    if not isinstance(state_dict, dict):
+        logger.error("[ARKHAI COMMON] Invalid state_dict in %s", model_file)
+        return None
+
+    # If checkpoint came from wrapped recurrent policy, extract base policy weights.
+    if any(k.startswith("policy.") for k in state_dict):
+        state_dict = {
+            k.removeprefix("policy."): v
+            for k, v in state_dict.items()
+            if k.startswith("policy.")
+        }
+
+    try:
+        model.load_state_dict(state_dict, strict=False)
+    except Exception as exc:
+        logger.error("[ARKHAI COMMON] Failed loading checkpoint into policy: %s", exc)
+        return None
+
+    model.eval()
+    logger.info("[ARKHAI COMMON] Loaded checkpoint model from %s", model_file)
+    return model
+
+
+def get_model(
+    env_var_name: str,
+    default_model_path: Path,
+    obs_dim_val: int,
+    *,
+    _cache: dict[str, Any] | None = None,
+) -> Optional[Any]:
+    """Lazily load an Arkhai model checkpoint.
+
+    Uses a module-level cache keyed by (env_var_name, obs_dim) to avoid
+    re-loading the same model.
+    """
+    if torch is None:
+        logger.warning("[ARKHAI COMMON] PyTorch not available; skipping model load")
+        return None
+
+    if _cache is None:
+        _cache = _MODEL_CACHE
+
+    cache_key = f"{env_var_name}:{obs_dim_val}"
+    if cache_key in _cache:
+        return _cache[cache_key]
+
+    env_path = os.getenv(env_var_name, "").strip()
+    model_file = Path(env_path) if env_path else default_model_path
+    if not model_file.exists():
+        logger.warning(
+            "[ARKHAI COMMON] Model checkpoint not found at %s. "
+            "Set %s to a puffer checkpoint path.",
+            model_file,
+            env_var_name,
+        )
+        return None
+
+    loaded = load_state_dict(model_file, obs_dim_val)
+    if loaded is None:
+        return None
+
+    _cache[cache_key] = loaded
+    return loaded
+
+
+_MODEL_CACHE: dict[str, Any] = {}
+
+
+# ---------------------------------------------------------------------------
+# Observation / portfolio helpers
+# ---------------------------------------------------------------------------
+
+def gpu_slot(resource: ComputeResource, gpu_slot_map: dict[str, int]) -> Optional[int]:
+    return gpu_slot_map.get(resource.gpu_model.value)
+
+
+def count_nodes_by_slot(
+    portfolio: ComputeResourcePortfolio,
+    node_types: int,
+    gpu_slot_map: dict[str, int],
+) -> tuple[list[float], list[float]]:
+    total = [0.0] * node_types
+    free = [0.0] * node_types
+    for resource in portfolio.resources:
+        if not isinstance(resource, ComputeResource):
+            continue
+        slot = gpu_slot(resource, gpu_slot_map)
+        if slot is None:
+            continue
+        total[slot] += float(resource.quantity)
+        # Local portfolio has no direct free-capacity metric; use conservative estimate.
+        free[slot] += float(resource.quantity) * 0.5
+    return total, free
+
+
+def extract_token_amount(offer_resource: Any, demand_resource: Any) -> float:
+    if isinstance(offer_resource, TokenResource):
+        return float(offer_resource.amount)
+    if isinstance(demand_resource, TokenResource):
+        return float(demand_resource.amount)
+    return 0.0
+
+
+def build_arkhai_observation(
+    context: DecisionContext,
+    offer_resource: Optional[Any] = None,
+    demand_resource: Optional[Any] = None,
+    order: Optional[Any] = None,
+) -> Optional[Any]:
+    """Build upstream-aligned Arkhai observation vector.
+
+    Layout follows upstream compute_observations:
+    [time] + [cluster nodes total/free * N] + [tb_usage, tb_capacity, kwh_storage, kwh_capacity, kw_generation]
+    + [request nodes * N] + [request tb, start, duration, negotiations, price, prev_reward]
+    """
+    if torch is None:
+        return None
+
+    node_types = parse_node_types()
+    obs = torch.zeros((1, obs_dim(node_types)), dtype=torch.float32)
+    job_nodes = parse_job_nodes(node_types)
+    gpu_slot_map = parse_gpu_slot_map(node_types)
+    idx = 0
+
+    try:
+        # Time of day
+        obs[0, idx] = (time.localtime().tm_hour % 24) / 24.0
+        idx += 1
+
+        # Portfolio extraction
+        totals = [0.0] * node_types
+        frees = [0.0] * node_types
+        portfolio_dict = context.available_resources
+        if portfolio_dict and "resources" in portfolio_dict:
+            try:
+                portfolio = ComputeResourcePortfolio.model_validate(portfolio_dict)
+                totals, frees = count_nodes_by_slot(portfolio, node_types, gpu_slot_map)
+            except Exception as exc:
+                logger.warning("[ARKHAI COMMON] Failed to validate portfolio: %s", exc)
+
+        # Cluster node totals and free amounts
+        for slot in range(node_types):
+            denom = job_nodes[slot] + 1.0
+            obs[0, idx] = min(1.0, totals[slot] / denom)
+            idx += 1
+            obs[0, idx] = min(1.0, frees[slot] / denom)
+            idx += 1
+
+        # TB and energy states (placeholders until local state tracking is added)
+        obs[0, idx] = 0.0  # tb_usage
+        idx += 1
+        obs[0, idx] = 0.5  # tb_capacity normalized
+        idx += 1
+        obs[0, idx] = 0.0  # kwh_storage normalized
+        idx += 1
+        obs[0, idx] = 0.5  # kwh_capacity normalized
+        idx += 1
+        obs[0, idx] = 0.1  # kw_generation normalized
+        idx += 1
+
+        # Request node quantities by slot
+        request_nodes = [0.0] * node_types
+        if isinstance(demand_resource, ComputeResource):
+            slot = gpu_slot(demand_resource, gpu_slot_map)
+            if slot is not None:
+                request_nodes[slot] = float(demand_resource.quantity)
+        for slot in range(node_types):
+            denom = job_nodes[slot] + 1.0
+            obs[0, idx] = min(1.0, request_nodes[slot] / denom)
+            idx += 1
+
+        # Request metadata
+        obs[0, idx] = 0.0  # request tb usage
+        idx += 1
+        obs[0, idx] = 0.0  # request start
+        idx += 1
+
+        duration_hours = float(getattr(order, "duration_hours", 0) or 0)
+        job_duration = float(os.getenv("ARKHAI_JOB_DURATION", "10") or 10)
+        obs[0, idx] = min(1.0, duration_hours / (job_duration + 1.0))
+        idx += 1
+
+        obs[0, idx] = 0.0  # negotiations/request timeout ratio
+        idx += 1
+
+        token_amount = extract_token_amount(offer_resource, demand_resource)
+        obs[0, idx] = token_amount / (token_amount + 1.0) if token_amount > 0 else 0.0
+        idx += 1
+
+        obs[0, idx] = 0.0  # previous reward
+        return obs
+    except Exception as exc:
+        logger.error("[ARKHAI COMMON] Failed to build observation: %s", exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Action extraction from model output
+# ---------------------------------------------------------------------------
+
+def extract_actions_from_logits(output: Any) -> tuple[int, int]:
+    """Extract (price_idx, sell_flag) from puffer policy outputs."""
+    if torch is None:
+        return 4, 0
+
+    try:
+        if not isinstance(output, tuple) or len(output) != 2:
+            logger.warning("[ARKHAI COMMON] Unexpected model output type: %s", type(output))
+            return 4, 0
+
+        logits = output[0]
+
+        # Native puffer MultiDiscrete output: tuple/list of tensors [(B,9), (B,2)]
+        if isinstance(logits, (tuple, list)) and len(logits) >= 2:
+            price_logits = logits[0][0] if len(logits[0].shape) > 1 else logits[0]
+            sell_logits = logits[1][0] if len(logits[1].shape) > 1 else logits[1]
+            return int(torch.argmax(price_logits).item()), int(torch.argmax(sell_logits).item())
+
+        # Optional concatenated fallback: tensor (B,11)
+        if isinstance(logits, torch.Tensor):
+            flat = logits[0] if len(logits.shape) > 1 else logits
+            if flat.shape[-1] >= 11:
+                return (
+                    int(torch.argmax(flat[:9]).item()),
+                    int(torch.argmax(flat[9:11]).item()),
+                )
+
+        logger.warning("[ARKHAI COMMON] Could not parse action logits; using defaults")
+        return 4, 0
+    except Exception as exc:
+        logger.error("[ARKHAI COMMON] Failed parsing actions: %s", exc)
+        return 4, 0
+
+
+# ---------------------------------------------------------------------------
+# Domain action parameter builder
+# ---------------------------------------------------------------------------
+
+def build_action_parameters(
+    order_id: str | None = None,
+    offer_resource: Any = None,
+    demand_resource: Any = None,
+    price_idx: int | None = None,
+    sell_flag: int | None = None,
+    order: Any = None,
+) -> dict[str, Any]:
+    parameters: dict[str, Any] = {}
+
+    if order is not None:
+        if hasattr(order, "model_dump"):
+            parameters["order"] = order.model_dump(mode="json")
+        elif isinstance(order, dict):
+            parameters["order"] = order
+
+    if order_id:
+        parameters["order_id"] = order_id
+    if offer_resource:
+        parameters["offer_resource"] = (
+            offer_resource.model_dump(mode="json")
+            if hasattr(offer_resource, "model_dump")
+            else offer_resource
+        )
+    if demand_resource:
+        parameters["demand_resource"] = (
+            demand_resource.model_dump(mode="json")
+            if hasattr(demand_resource, "model_dump")
+            else demand_resource
+        )
+
+    if price_idx is not None:
+        parameters["price_idx"] = price_idx
+        multipliers = [0.8, 0.85, 0.9, 0.95, 1.0, 1.05, 1.1, 1.15, 1.2]
+        if 0 <= price_idx < len(multipliers):
+            parameters["price_multiplier"] = multipliers[price_idx]
+    if sell_flag is not None:
+        parameters["sell_flag"] = sell_flag
+        parameters["energy_sell_action"] = "sell_50_percent" if sell_flag == 1 else "hold"
+
+    return parameters
+
+
+# ---------------------------------------------------------------------------
+# Role detection helper
+# ---------------------------------------------------------------------------
+
+def detect_agent_role(
+    offer_resource: Any,
+    demand_resource: Any,
+    order: Any,
+    current_url: str,
+) -> str:
+    """Determine if the current agent acts as 'seller' or 'buyer'."""
+    maker_offers_compute = isinstance(offer_resource, ComputeResource) and isinstance(
+        demand_resource, TokenResource
+    )
+    maker_offers_tokens = isinstance(offer_resource, TokenResource) and isinstance(
+        demand_resource, ComputeResource
+    )
+    maker_url = order.order_maker.rstrip("/")
+    current = current_url.rstrip("/")
+    is_maker = maker_url == current or maker_url.endswith(current) or current.endswith(maker_url)
+
+    if is_maker:
+        agent_role = "seller" if maker_offers_compute else "buyer"
+    else:
+        agent_role = "buyer" if maker_offers_compute else "seller"
+
+    if not maker_offers_compute and not maker_offers_tokens:
+        agent_role = "seller"
+
+    return agent_role

--- a/agent/app/policies/torch_arkhai_buyer.py
+++ b/agent/app/policies/torch_arkhai_buyer.py
@@ -1,9 +1,8 @@
-"""Arkhai seller policy adapter backed by upstream puffer checkpoints.
+"""Arkhai buyer policy adapter backed by upstream puffer checkpoints.
 
-This policy intentionally keeps local logic thin:
-- Observation layout follows upstream Arkhai ordering (via arkhai_common).
-- Model loading expects puffer `state_dict` checkpoints.
-- Action mapping remains local (domain-level accept/counter/reject).
+Mirror of the seller adapter with buyer-specific action thresholds.
+Buyers are more price-sensitive: their reward is profit margin
+(base_price - negotiated_price) * duration, so lower prices are preferred.
 """
 from __future__ import annotations
 
@@ -35,17 +34,17 @@ from app.utils.validation import extract_resources_from_make_offer_event
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_MODEL_PATH = Path(__file__).resolve().parent / "models" / "arkhai_seller.pt"
+_DEFAULT_MODEL_PATH = Path(__file__).resolve().parent / "models" / "arkhai_buyer.pt"
 
 
 def _get_model(obs_dim_val: int) -> Optional[Any]:
-    """Lazily load the Arkhai seller model checkpoint."""
-    return get_model("ARKHAI_SELLER_MODEL_PATH", _DEFAULT_MODEL_PATH, obs_dim_val)
+    """Lazily load the Arkhai buyer model checkpoint."""
+    return get_model("ARKHAI_BUYER_MODEL_PATH", _DEFAULT_MODEL_PATH, obs_dim_val)
 
 
-@policy_callable("mo.action.torch_arkhai_seller")
-async def mo_action_torch_arkhai_seller(context: DecisionContext) -> DomainAction | None:
-    """Model-based Arkhai seller policy for MakeOffer events."""
+@policy_callable("mo.action.torch_arkhai_buyer")
+async def mo_action_torch_arkhai_buyer(context: DecisionContext) -> DomainAction | None:
+    """Model-based Arkhai buyer policy for MakeOffer events."""
     if not isinstance(context.event, MakeOfferEvent):
         return None
 
@@ -69,24 +68,24 @@ async def mo_action_torch_arkhai_seller(context: DecisionContext) -> DomainActio
                         },
                     )
             except Exception as exc:
-                logger.warning("[ARKHAI SELLER POLICY] Failed to validate portfolio: %s", exc)
+                logger.warning("[ARKHAI BUYER POLICY] Failed to validate portfolio: %s", exc)
 
     node_types = parse_node_types()
     model = _get_model(obs_dim(node_types))
     if model is None or torch is None:
-        logger.warning("[ARKHAI SELLER POLICY] Model unavailable; returning None")
+        logger.warning("[ARKHAI BUYER POLICY] Model unavailable; returning None")
         return None
 
     observation = build_arkhai_observation(context, offer_resource, demand_resource, order)
     if observation is None:
-        logger.warning("[ARKHAI SELLER POLICY] Failed to build observation; returning None")
+        logger.warning("[ARKHAI BUYER POLICY] Failed to build observation; returning None")
         return None
 
     try:
         with torch.no_grad():
             output = model(observation)
     except Exception as exc:
-        logger.error("[ARKHAI SELLER POLICY] Inference failed: %s", exc)
+        logger.error("[ARKHAI BUYER POLICY] Inference failed: %s", exc)
         return None
 
     price_idx, sell_flag = extract_actions_from_logits(output)
@@ -95,21 +94,23 @@ async def mo_action_torch_arkhai_seller(context: DecisionContext) -> DomainActio
         offer_resource, demand_resource, order, CONFIG.base_url_override,
     )
 
-    # Seller thresholds: sellers are less price-sensitive (want to sell compute).
-    if agent_role == "seller":
+    # Buyer thresholds: buyers are more price-sensitive (want low prices).
+    # Lower price_idx = lower offered price = better for buyer.
+    if agent_role == "buyer":
+        action_type = (
+            ActionType.ACCEPT_OFFER
+            if price_idx <= 5
+            else ActionType.COUNTER_OFFER
+            if price_idx <= 7
+            else ActionType.REJECT_OFFER
+        )
+    else:
+        # When acting as seller (fallback), use seller-like thresholds.
         action_type = (
             ActionType.ACCEPT_OFFER
             if price_idx <= 7
             else ActionType.COUNTER_OFFER
             if price_idx == 8
-            else ActionType.REJECT_OFFER
-        )
-    else:
-        action_type = (
-            ActionType.ACCEPT_OFFER
-            if price_idx <= 6
-            else ActionType.COUNTER_OFFER
-            if price_idx == 7
             else ActionType.REJECT_OFFER
         )
 

--- a/agent/tests/conftest.py
+++ b/agent/tests/conftest.py
@@ -1,0 +1,23 @@
+"""Test configuration for agent tests.
+
+Pre-registers the ``app`` package so that imports like
+``from app.policies.arkhai_common import ...`` work without triggering
+``app/__init__.py`` (which pulls in ``core.agent.app.agent`` and its full
+dependency chain — incompatible with the agent venv's Python 3.10).
+"""
+import sys
+import types
+from pathlib import Path
+
+_REPO_ROOT = str(Path(__file__).resolve().parents[2])
+_AGENT_ROOT = str(Path(__file__).resolve().parents[1])
+
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+# Pre-register the 'app' package so sub-module imports bypass
+# app/__init__.py (avoids core.agent.app.agent import chain).
+if "app" not in sys.modules:
+    _app = types.ModuleType("app")
+    _app.__path__ = [str(Path(_AGENT_ROOT) / "app")]
+    sys.modules["app"] = _app

--- a/agent/tests/integration/test_arkhai.py
+++ b/agent/tests/integration/test_arkhai.py
@@ -51,7 +51,7 @@ def test_observation_builder_basic():
 def test_action_extraction_basic():
     """Test that action extraction works with mock model output."""
     import torch
-    from app.policies.torch_arkhai_seller import _extract_actions_from_logits
+    from app.policies.arkhai_common import extract_actions_from_logits as _extract_actions_from_logits
 
     # Create mock output (action_logits, values)
     action_logits = torch.randn(1, 11)  # 9 price + 2 sell
@@ -71,6 +71,10 @@ def test_action_extraction_basic():
 
 def test_model_path_environment_variable(monkeypatch):
     """Test that ARKHAI_SELLER_MODEL_PATH environment variable is respected."""
+    from app.policies.arkhai_common import _MODEL_CACHE
+    # Clear cache to ensure fresh load attempt
+    _MODEL_CACHE.clear()
+
     from app.policies.torch_arkhai_seller import _get_model
 
     # Set environment variable to a test path
@@ -78,7 +82,10 @@ def test_model_path_environment_variable(monkeypatch):
     monkeypatch.setenv("ARKHAI_SELLER_MODEL_PATH", test_path)
 
     # Model won't load (file doesn't exist), but we can check the path is read
-    model = _get_model(obs_dim=21)
+    model = _get_model(obs_dim_val=21)
 
     # Model should be None since file doesn't exist
     assert model is None, "Model should be None when file doesn't exist"
+
+    # Clean up cache
+    _MODEL_CACHE.clear()

--- a/agent/tests/integration/test_arkhai_buyer.py
+++ b/agent/tests/integration/test_arkhai_buyer.py
@@ -1,0 +1,91 @@
+"""Integration tests for Arkhai buyer policy adapter.
+
+Mirrors test_arkhai.py for the buyer-side policy.
+"""
+import pytest
+
+
+def test_torch_arkhai_buyer_import():
+    """Test that torch_arkhai_buyer module can be imported."""
+    try:
+        from app.policies import torch_arkhai_buyer
+        assert torch_arkhai_buyer is not None
+    except ImportError as e:
+        pytest.fail(f"Failed to import torch_arkhai_buyer: {e}")
+
+
+def test_arkhai_common_import():
+    """Test that arkhai_common shared module can be imported."""
+    try:
+        from app.policies import arkhai_common
+        assert arkhai_common is not None
+    except ImportError as e:
+        pytest.fail(f"Failed to import arkhai_common: {e}")
+
+
+def test_buyer_action_extraction():
+    """Test that action extraction works with mock model output."""
+    import torch
+    from app.policies.arkhai_common import extract_actions_from_logits
+
+    # Create mock output (action_logits, values)
+    action_logits = torch.randn(1, 11)  # 9 price + 2 sell
+    values = torch.randn(1, 1)
+
+    output = (action_logits, values)
+
+    price_idx, sell_flag = extract_actions_from_logits(output)
+
+    assert isinstance(price_idx, int), "price_idx should be int"
+    assert isinstance(sell_flag, int), "sell_flag should be int"
+    assert 0 <= price_idx <= 8, f"price_idx should be 0-8, got {price_idx}"
+    assert sell_flag in (0, 1), f"sell_flag should be 0 or 1, got {sell_flag}"
+
+
+def test_buyer_model_path_environment_variable(monkeypatch):
+    """Test that ARKHAI_BUYER_MODEL_PATH environment variable is respected."""
+    from app.policies.arkhai_common import _MODEL_CACHE
+    # Clear cache to ensure fresh load attempt
+    _MODEL_CACHE.clear()
+
+    from app.policies.torch_arkhai_buyer import _get_model
+
+    test_path = "/tmp/test_arkhai_buyer_model.pt"
+    monkeypatch.setenv("ARKHAI_BUYER_MODEL_PATH", test_path)
+
+    model = _get_model(obs_dim_val=21)
+
+    # Model should be None since file doesn't exist
+    assert model is None, "Model should be None when file doesn't exist"
+
+    # Clean up cache
+    _MODEL_CACHE.clear()
+
+
+def test_obs_dim_calculation():
+    """Test observation dimension calculation for different node type counts."""
+    from app.policies.arkhai_common import obs_dim
+
+    # 3 node types (default): 12 + 3*3 = 21
+    assert obs_dim(3) == 21
+    # 1 node type: 12 + 3*1 = 15
+    assert obs_dim(1) == 15
+    # 5 node types: 12 + 3*5 = 27
+    assert obs_dim(5) == 27
+
+
+def test_build_action_parameters():
+    """Test action parameter builder includes expected keys."""
+    from app.policies.arkhai_common import build_action_parameters
+
+    params = build_action_parameters(
+        order_id="test-order-123",
+        price_idx=4,
+        sell_flag=1,
+    )
+
+    assert params["order_id"] == "test-order-123"
+    assert params["price_idx"] == 4
+    assert params["price_multiplier"] == 1.0  # idx 4 = 1.0x multiplier
+    assert params["sell_flag"] == 1
+    assert params["energy_sell_action"] == "sell_50_percent"

--- a/core/agent/.env.sample
+++ b/core/agent/.env.sample
@@ -21,3 +21,14 @@ TOKEN_REGISTRY_PATH=../core/agent/app/data/token_registry.json
 SSH_PUBLIC_KEY="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDemoPublicKeyForComputeAccess alice@example.com"
 ZEROTIER_NETWORK=5170efff3f3bf6ba
 USE_MOCK_PROVISIONING=true
+
+# --- Arkhai RL Policy Configuration ---
+# Number of GPU node types in the environment (obs_dim = 12 + 3 * N)
+# ARKHAI_NODE_TYPES=3
+# Maps GPU model names to observation vector slots (comma-separated GPU_NAME:SLOT)
+# ARKHAI_GPU_SLOT_MAP="H200:0, Tesla V100:1, RTX 5080:2"
+# Per-slot job GPU node counts (comma-separated, one per slot)
+# ARKHAI_JOB_GPU_NODES="10,10,10"
+# Override default model paths
+# ARKHAI_SELLER_MODEL_PATH=app/policies/models/arkhai_seller.pt
+# ARKHAI_BUYER_MODEL_PATH=app/policies/models/arkhai_buyer.pt

--- a/core/agent/Dockerfile
+++ b/core/agent/Dockerfile
@@ -27,6 +27,9 @@ RUN uv sync --frozen
 ARG COMMIT_SHA=""
 ENV COMMIT_SHA=${COMMIT_SHA}
 
+ARG MODEL_VERSION=""
+ENV MODEL_VERSION=${MODEL_VERSION}
+
 EXPOSE 8080
 
 CMD ["uv", "run", "uvicorn", "core.agent.app.server:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/core/agent/Makefile
+++ b/core/agent/Makefile
@@ -171,8 +171,13 @@ train-arkhai:
 		--train.total-timesteps $$TOTAL_TIMESTEPS \
 		$$WANDB_FLAG $$TAG_FLAG $$ARGS
 
+# Patch pufferlib's eval loop to guard driver.render() with a render_mode check.
+# Re-run after every `uv sync`.
+patch-puffer-eval:
+	uv --project .. run python scripts/patch_puffer_eval.py
+
 # Evaluate Arkhai policy with upstream puffer CLI.
-# Usage: make eval-arkhai [MODEL=latest] [DEVICE=cpu] [ARGS="..."]
+# Usage: make eval-arkhai [MODEL=latest] [DEVICE=cpu] [ARGS="--render-mode None"]
 eval-arkhai:
 	@echo "Evaluating Arkhai model via puffer..."
 	@MODEL=$${MODEL:-latest}; \
@@ -181,13 +186,11 @@ eval-arkhai:
 	echo "Model: $$MODEL"; \
 	echo "Device: $$DEVICE"; \
 	[ -n "$$ARGS" ] && echo "Extra args: $$ARGS" || true; \
+	$(MAKE) patch-puffer-eval; \
 	uv --project .. run puffer eval puffer_arkhai \
 		--load-model-path $$MODEL \
 		--train.device $$DEVICE \
 		$$ARGS
-
-# Backward-compatible alias for previous target name.
-eval-arkhai-seller: eval-arkhai
 
 # Export model weights in puffer's native format.
 # Usage: make export-arkhai-weights [MODEL=latest]
@@ -196,9 +199,6 @@ export-arkhai-weights:
 	@MODEL=$${MODEL:-latest}; \
 	echo "Model: $$MODEL"; \
 	uv --project .. run puffer export puffer_arkhai --load-model-path $$MODEL
-
-# Backward-compatible alias for previous target name.
-export-arkhai-model: export-arkhai-weights
 
 # Test Arkhai environment integration
 # Usage: make test-arkhai-env

--- a/core/agent/Makefile
+++ b/core/agent/Makefile
@@ -149,6 +149,17 @@ test-env:
 	uv --project .. run python scripts/extract_anvil_addresses.py --output app/data/alkahest_anvil_addresses.json
 	uv --project .. run python -m app.utils.test_env
 # ==============================================================================
+# GPU Installation (for training)
+# ==============================================================================
+
+# Install PyTorch with CUDA support for GPU training.
+# Default install uses CPU-only torch. Run this after `make install` for GPU.
+install-gpu:
+	@command -v uv >/dev/null 2>&1 || { echo "uv is not installed. Install with: curl -LsSf https://astral.sh/uv/install.sh | sh"; exit 1; }
+	uv --project .. sync --dev
+	uv pip install torch --reinstall-package torch --index-url https://download.pytorch.org/whl/cu128
+
+# ==============================================================================
 # Arkhai Training Environment Targets
 # ==============================================================================
 
@@ -199,6 +210,121 @@ export-arkhai-weights:
 	@MODEL=$${MODEL:-latest}; \
 	echo "Model: $$MODEL"; \
 	uv --project .. run puffer export puffer_arkhai --load-model-path $$MODEL
+
+# ==============================================================================
+# Arkhai Buyer Training
+# ==============================================================================
+
+# Train Arkhai BUYER model. Buyer learns against 3 scripted sellers.
+# Usage: make train-arkhai-buyer [DEVICE=cpu] [TOTAL_TIMESTEPS=100000000] [WANDB=true] [TAG=exp_name]
+train-arkhai-buyer:
+	@echo "Training Arkhai BUYER model via puffer..."
+	@DEVICE=$${DEVICE:-cpu}; \
+	TOTAL_TIMESTEPS=$${TOTAL_TIMESTEPS:-100000000}; \
+	WANDB_FLAG=""; \
+	TAG_FLAG=""; \
+	ARGS="$${ARGS:-}"; \
+	if [ "$${WANDB:-false}" = "true" ]; then WANDB_FLAG="--wandb"; fi; \
+	if [ -n "$${TAG:-}" ]; then TAG_FLAG="--tag $${TAG}"; fi; \
+	echo "Device: $$DEVICE"; \
+	echo "Total timesteps: $$TOTAL_TIMESTEPS"; \
+	[ -n "$$ARGS" ] && echo "Extra args: $$ARGS" || true; \
+	uv --project .. run puffer train puffer_arkhai \
+		--train.device $$DEVICE \
+		--train.total-timesteps $$TOTAL_TIMESTEPS \
+		--env.ai-sellers 0 \
+		--env.ai-buyers 1 \
+		--env.scripted-sellers 3 \
+		--env.scripted-buyers 0 \
+		$$WANDB_FLAG $$TAG_FLAG $$ARGS
+
+# Evaluate Arkhai BUYER policy.
+eval-arkhai-buyer:
+	@echo "Evaluating Arkhai BUYER model via puffer..."
+	@MODEL=$${MODEL:-latest}; \
+	DEVICE=$${DEVICE:-cpu}; \
+	ARGS="$${ARGS:-}"; \
+	echo "Model: $$MODEL"; \
+	echo "Device: $$DEVICE"; \
+	[ -n "$$ARGS" ] && echo "Extra args: $$ARGS" || true; \
+	$(MAKE) patch-puffer-eval; \
+	uv --project .. run puffer eval puffer_arkhai \
+		--load-model-path $$MODEL \
+		--train.device $$DEVICE \
+		--env.ai-sellers 0 \
+		--env.ai-buyers 1 \
+		--env.scripted-sellers 3 \
+		--env.scripted-buyers 0 \
+		$$ARGS
+
+# ==============================================================================
+# Arkhai Bilateral Training (Experimental)
+# ==============================================================================
+
+# Train both AI seller and AI buyer simultaneously.
+train-arkhai-bilateral:
+	@echo "Training Arkhai BILATERAL model via puffer (experimental)..."
+	@DEVICE=$${DEVICE:-cpu}; \
+	TOTAL_TIMESTEPS=$${TOTAL_TIMESTEPS:-100000000}; \
+	WANDB_FLAG=""; \
+	TAG_FLAG=""; \
+	ARGS="$${ARGS:-}"; \
+	if [ "$${WANDB:-false}" = "true" ]; then WANDB_FLAG="--wandb"; fi; \
+	if [ -n "$${TAG:-}" ]; then TAG_FLAG="--tag $${TAG}"; fi; \
+	echo "Device: $$DEVICE"; \
+	echo "Total timesteps: $$TOTAL_TIMESTEPS"; \
+	[ -n "$$ARGS" ] && echo "Extra args: $$ARGS" || true; \
+	uv --project .. run puffer train puffer_arkhai \
+		--train.device $$DEVICE \
+		--train.total-timesteps $$TOTAL_TIMESTEPS \
+		--env.ai-sellers 1 \
+		--env.ai-buyers 1 \
+		--env.scripted-sellers 0 \
+		--env.scripted-buyers 0 \
+		$$WANDB_FLAG $$TAG_FLAG $$ARGS
+
+# ==============================================================================
+# Model Release & Download
+# ==============================================================================
+
+REPO ?= arkhai-io/simple-market-service
+
+# Download trained models from a GitHub release.
+# Usage: make download-models [VERSION=model-v0.1.0]
+download-models:
+	@VERSION=$${VERSION:-latest}; \
+	echo "Downloading models (version: $$VERSION)..."; \
+	bash scripts/download_models.sh $$VERSION
+
+# Create a GitHub release with trained model artifacts.
+# Usage: make release-models VERSION=model-v0.1.0 [MODELS_DIR=path/to/models]
+MODELS_DIR ?= ../../agent/app/policies/models
+release-models:
+	@if [ -z "$${VERSION:-}" ]; then echo "ERROR: VERSION is required. Usage: make release-models VERSION=model-v0.1.0"; exit 1; fi; \
+	MODELS_DIR="$(MODELS_DIR)"; \
+	ASSETS=""; \
+	if [ -f "$$MODELS_DIR/arkhai_seller.pt" ]; then ASSETS="$$ASSETS $$MODELS_DIR/arkhai_seller.pt"; fi; \
+	if [ -f "$$MODELS_DIR/arkhai_buyer.pt" ]; then ASSETS="$$ASSETS $$MODELS_DIR/arkhai_buyer.pt"; fi; \
+	if [ -z "$$ASSETS" ]; then echo "ERROR: No .pt model files found in $$MODELS_DIR"; exit 1; fi; \
+	echo "Creating release $$VERSION with:$$ASSETS"; \
+	git tag "$$VERSION" || true; \
+	git push origin "$$VERSION" || true; \
+	NOTES="Model Release $$VERSION"; \
+	NOTES="$$NOTES\n\nPufferLib commit: ef59f84c"; \
+	NOTES="$$NOTES\nEnvironment: puffer_arkhai (node_types=3, episode_length=100)"; \
+	NOTES="$$NOTES\n\nArtifacts:"; \
+	if [ -f "$$MODELS_DIR/arkhai_seller.pt" ]; then NOTES="$$NOTES\n- arkhai_seller.pt: Single-agent seller (1 AI seller vs 3 scripted buyers)"; fi; \
+	if [ -f "$$MODELS_DIR/arkhai_buyer.pt" ]; then NOTES="$$NOTES\n- arkhai_buyer.pt: Single-agent buyer (1 AI buyer vs 3 scripted sellers)"; fi; \
+	gh release create "$$VERSION" \
+		--repo $(REPO) \
+		--title "Model Release $$VERSION" \
+		--notes "$$(printf "$$NOTES")" \
+		$$ASSETS; \
+	echo "Release $$VERSION created successfully."
+
+# ==============================================================================
+# Test Arkhai environment integration
+# ==============================================================================
 
 # Test Arkhai environment integration
 # Usage: make test-arkhai-env

--- a/core/agent/app/agent.py
+++ b/core/agent/app/agent.py
@@ -20,7 +20,8 @@ import uuid
 from datetime import datetime
 import ast
 from alkahest_py import AlkahestClient
-from typing import AsyncGenerator, Any, Dict, Optional, override, Tuple
+from typing import AsyncGenerator, Any, Dict, Optional, Tuple
+from typing_extensions import override
 from enum import Enum
 import re
 

--- a/core/agent/app/policy/manager.py
+++ b/core/agent/app/policy/manager.py
@@ -52,6 +52,7 @@ class PolicyManager:
 
         # Auto-discover and bulk-register callable policies
         discover_and_register("core.agent.app.policy")
+        discover_and_register("app.policies")
         self._policy_store.register_callables(CALLABLE_REGISTRY)
         self._initialized = True
         logger.info(f"[POLICY MANAGER] Initialized and registered {len(CALLABLE_REGISTRY)} callable policies")

--- a/core/agent/app/policy/seeding.py
+++ b/core/agent/app/policy/seeding.py
@@ -91,6 +91,8 @@ class ComputePolicySeeder:
                 policy_name="make_offer.default.v1",
                 components=[
                     "mo.guard.trigger_is_make_offer",
+                    "mo.action.torch_arkhai_seller",
+                    "mo.action.torch_arkhai_buyer",
                     "mo.action.accept_offer",
                 ],
             )

--- a/core/agent/scripts/download_models.sh
+++ b/core/agent/scripts/download_models.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Download trained model artifacts from the latest (or specified) GitHub Release.
+# Usage:
+#   ./scripts/download_models.sh                    # latest release
+#   ./scripts/download_models.sh model-v0.2.0       # specific version
+#
+# Requires: gh CLI (authenticated) OR curl with GITHUB_TOKEN
+
+set -euo pipefail
+
+REPO="arkhai-io/simple-market-service"
+VERSION="${1:-latest}"
+DEST_DIR="${2:-../../agent/app/policies/models}"
+
+mkdir -p "$DEST_DIR"
+
+download_asset() {
+    local asset_name="$1"
+    local dest_path="${DEST_DIR}/${asset_name}"
+
+    echo "Downloading ${asset_name} from release ${VERSION}..."
+
+    if command -v gh &>/dev/null; then
+        if [ "$VERSION" = "latest" ]; then
+            gh release download --repo "$REPO" --pattern "$asset_name" --dir "$DEST_DIR" --clobber 2>/dev/null
+        else
+            gh release download "$VERSION" --repo "$REPO" --pattern "$asset_name" --dir "$DEST_DIR" --clobber 2>/dev/null
+        fi
+    elif [ -n "${GITHUB_TOKEN:-}" ]; then
+        local release_url
+        if [ "$VERSION" = "latest" ]; then
+            release_url="https://api.github.com/repos/${REPO}/releases/latest"
+        else
+            release_url="https://api.github.com/repos/${REPO}/releases/tags/${VERSION}"
+        fi
+        local asset_url
+        asset_url=$(curl -sH "Authorization: token ${GITHUB_TOKEN}" "$release_url" \
+            | python3 -c "
+import sys, json
+assets = json.load(sys.stdin).get('assets', [])
+url = next((a['url'] for a in assets if a['name'] == '${asset_name}'), '')
+print(url)
+")
+        if [ -z "$asset_url" ]; then
+            echo "  WARNING: Asset ${asset_name} not found in release ${VERSION}"
+            return 1
+        fi
+        curl -sL -H "Authorization: token ${GITHUB_TOKEN}" -H "Accept: application/octet-stream" \
+            "$asset_url" -o "$dest_path"
+    else
+        echo "  ERROR: Neither 'gh' CLI nor GITHUB_TOKEN available"
+        return 1
+    fi
+
+    if [ -f "$dest_path" ]; then
+        echo "  -> Saved to ${dest_path} ($(du -h "$dest_path" | cut -f1))"
+    else
+        echo "  WARNING: Failed to download ${asset_name}"
+        return 1
+    fi
+}
+
+# Download both models; failures are non-fatal (graceful degradation at runtime)
+download_asset "arkhai_seller.pt" || echo "  (seller model not available; will use fallback policy at runtime)"
+download_asset "arkhai_buyer.pt" || echo "  (buyer model not available; will use fallback policy at runtime)"
+
+echo "Done. Models available in ${DEST_DIR}/"

--- a/core/agent/scripts/patch_puffer_eval.py
+++ b/core/agent/scripts/patch_puffer_eval.py
@@ -1,0 +1,77 @@
+"""Patch pufferlib's eval loop with three fixes:
+
+1. Guard driver.render() so --render-mode None actually skips it.
+2. Replace `while True:` with a bounded episode loop (default 5 episodes,
+   override with --max-runs N).
+3. Unpack the full step tuple and print per-step reward/action output.
+
+Re-run after every `uv sync`:
+    uv run python scripts/patch_puffer_eval.py
+or:
+    make patch-puffer-eval
+"""
+import pathlib
+import sys
+
+PATCHES = [
+    (
+        "render guard",
+        "        render = driver.render()",
+        (
+            "        render = ("
+            "driver.render()"
+            " if getattr(driver, 'render_mode', 'auto') not in ('None', None)"
+            " else None"
+            ")"
+        ),
+    ),
+    (
+        "bounded episode loop",
+        "    frames = []\n    while True:",
+        "    frames = []\n    _ep, _step, _max_ep = 0, 0, args.get('max_runs', 5)\n    while _ep < _max_ep:",
+    ),
+    (
+        "step unpack + logging + episode reset",
+        "        ob = vecenv.step(action)[0]",
+        "\n".join([
+            "        ob, _rew, _done, _trunc, _ = vecenv.step(action)",
+            "        _step += 1",
+            "        print(",
+            "            f'[eval] ep {_ep+1}/{_max_ep}  step {_step:4d}"
+            "  rew {float(_rew[0]):+.4f}  act {action[0].tolist()}',"
+            "            flush=True,",
+            "        )",
+            "        if bool(_done[0]) or bool(_trunc[0]):",
+            "            _ep += 1",
+            "            if _ep < _max_ep:",
+            "                ob, _ = vecenv.reset()",
+            "                for _v in state.values():",
+            "                    _v.zero_()",
+            "            _step = 0",
+        ]),
+    ),
+]
+
+venv = pathlib.Path(".venv")
+matches = list(venv.rglob("pufferlib/pufferl.py"))
+if not matches:
+    print("ERROR: pufferlib not found in .venv — run `uv sync` first", file=sys.stderr)
+    sys.exit(1)
+
+target = matches[0]
+text = target.read_text()
+changed = False
+
+for desc, old, new in PATCHES:
+    if old not in text:
+        print(f"  skip  [{desc}] — already applied or pattern not found")
+        continue
+    text = text.replace(old, new)
+    print(f"  patch [{desc}]")
+    changed = True
+
+if changed:
+    target.write_text(text)
+    print(f"Written to {target}")
+else:
+    print("Nothing to do — all patches already applied.")

--- a/core/schemas.py
+++ b/core/schemas.py
@@ -6,7 +6,9 @@ map in/out without immediate domain extraction.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import datetime, timezone
+
+UTC = timezone.utc
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, SerializeAsAny


### PR DESCRIPTION
# Changes Made
- Added shared `arkhai_common` module with observation building, model caching, action extraction, and GPU slot map configuration for both seller and buyer policy adapters.
- Added `torch_arkhai_buyer` policy adapter with buyer-specific price-sensitive thresholds (accept/counter/reject).
- Refactored `torch_arkhai_seller` to use `arkhai_common` shared infrastructure instead of inline implementations.
- Wired RL policies into the policy discovery system (`discover_and_register("app.policies")`) and added them to the `make_offer` composite chain (seller → buyer → rule-based fallback).
- Added training configs for seller, buyer, and bilateral (experimental) with sweep-tuned PPO hyperparameters from upstream ArkhaiPufferEnv (100M timesteps).
- Added `validate-model-release` GitHub Actions workflow triggered on tag push (`model-v*.*.*`) to validate `.pt` checkpoint files.
- Added model download step to Cloud Build staging pipeline — downloads trained model artifacts from GitHub Releases before Docker build.
- Added Makefile targets for training, evaluation, model release, model download, and GPU install.
- Added `MODEL_VERSION` build arg to Dockerfile and Arkhai RL config section to `.env.sample`.
- Added integration tests for both seller and buyer policy adapters.
- Added `conftest.py` for agent tests to fix import chain (repo root on sys.path).
- Fixed Python 3.10 compatibility: `typing_extensions.override` in `agent.py`, `datetime.timezone.utc` in `core/schemas.py`.
- Added `download_models.sh` and `patch_puffer_eval.py` scripts.

# Testing

## 1. Run integration tests
```bash
cd agent && uv run pytest tests/integration/test_arkhai.py tests/integration/test_arkhai_buyer.py -v
```
Verify 11 passed, 1 skipped.

## 2. Run unit tests
```bash
cd agent && uv run pytest tests/unit -v
```
Verify 106 passed (10 pre-existing failures can be addressed outside this PR, probably as part of refactor).

## 3. Training smoke test — seller
```bash
cd core/agent && make train-arkhai DEVICE=cpu TOTAL_TIMESTEPS=1000000
```
Verify training completes and produces a `.pt` checkpoint under `experiments/`.

## 4. Training smoke test — buyer
```bash
cd core/agent && make train-arkhai-buyer DEVICE=cpu TOTAL_TIMESTEPS=1000000
```
Verify training completes and produces a `.pt` checkpoint under `experiments/`.

## 5. Copy trained models to deployment path
```bash
cp experiments/puffer_arkhai_*/model_*.pt ../../agent/app/policies/models/arkhai_seller.pt
cp experiments/puffer_arkhai_*buyer*/model_*.pt ../../agent/app/policies/models/arkhai_buyer.pt
```

## 6. Create model release (tag-triggered workflow)
```bash
cd core/agent && make release-models VERSION=model-v0.1.0
```
Verify:
- Tag `model-v0.1.0` is created and pushed.
- GitHub Release is created with `arkhai_seller.pt` and `arkhai_buyer.pt` assets.
- `validate-model-release` workflow triggers and passes.

## 7. Test model download from release
```bash
cd core/agent && bash scripts/download_models.sh model-v0.1.0
```

Verify:

* Both arkhai_seller.pt and arkhai_buyer.pt are downloaded to ../../agent/app/policies/models/.
* File sizes match the uploaded release assets.

