### PR TITLE
Refactor: Services ERC 8004 Registry

### DIFF
--- a/core/uv.lock
+++ b/core/uv.lock
@@ -2760,6 +2760,7 @@ dependencies = [
     { name = "google-adk", extra = ["a2a"] },
     { name = "google-cloud-aiplatform", extra = ["evaluation"] },
     { name = "google-cloud-logging" },
+    { name = "market-service" },
     { name = "opentelemetry-exporter-gcp-trace" },
     { name = "psycopg2-binary" },
     { name = "pufferlib" },
@@ -2800,6 +2801,7 @@ requires-dist = [
     { name = "google-cloud-aiplatform", extras = ["evaluation"], specifier = ">=1.118.0,<2.0.0" },
     { name = "google-cloud-logging", specifier = ">=3.12.0,<4.0.0" },
     { name = "jupyter", marker = "extra == 'jupyter'", specifier = ">=1.0.0,<2.0.0" },
+    { name = "market-service", editable = "../service" },
     { name = "mypy", marker = "extra == 'lint'", specifier = ">=1.15.0,<2.0.0" },
     { name = "opentelemetry-exporter-gcp-trace", specifier = ">=1.9.0,<2.0.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.10,<3.0.0" },
@@ -2817,6 +2819,31 @@ provides-extras = ["jupyter", "lint"]
 [package.metadata.requires-dev]
 dev = [
     { name = "nest-asyncio", specifier = ">=1.6.0,<2.0.0" },
+    { name = "pytest", specifier = ">=8.3.4,<9.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23.8,<1.0.0" },
+]
+
+[[package]]
+name = "market-service"
+version = "0.1.0"
+source = { editable = "../service" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "eth-account" },
+    { name = "pydantic" },
+    { name = "web3" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiohttp", specifier = ">=3.12.15" },
+    { name = "eth-account" },
+    { name = "pydantic", specifier = ">=2" },
+    { name = "web3", specifier = ">=7.14.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
     { name = "pytest", specifier = ">=8.3.4,<9.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.8,<1.0.0" },
 ]

--- a/service/src/service/clients/alkahest.py
+++ b/service/src/service/clients/alkahest.py
@@ -1,0 +1,268 @@
+import json
+import copy
+import os
+from functools import lru_cache
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+NETWORK_ANVIL = "anvil"
+NETWORK_BASE_SEPOLIA = "base_sepolia"
+NETWORK_ETHEREUM_MAINNET = "ethereum_mainnet"
+SUPPORTED_NETWORKS = {
+    NETWORK_ANVIL,
+    NETWORK_BASE_SEPOLIA,
+    NETWORK_ETHEREUM_MAINNET,
+}
+
+
+BASE_SEPOLIA_ADDRESSES: dict[str, Any] = {
+    "arbiters_addresses": {
+        "eas": "0x4200000000000000000000000000000000000021",
+        "trivial_arbiter": "0x50EDa6c29C740bfbA6875422287025D985b96b7b",
+        "trusted_oracle_arbiter": "0x3664b11BcCCeCA27C21BBAB43548961eD14d4D6D",
+        "intrinsics_arbiter": "0x24aAFec3f86CAd330600dD2397DEB8498D44bfd9",
+        "intrinsics_arbiter_2": "0x51a28Ad45BE6eb6fd6D76af56a7D62ECd99547C7",
+        "erc8004_arbiter": "0x67B23406dd9e9EA884B3d14746ef73106b1C35d6",
+        "any_arbiter": "0xaaC3465f340C7A2841A120F81Ce6744cda00d263",
+        "all_arbiter": "0x0D95c1Cd62cd9C7cCCB237a3Ae08aA61Ed83381f",
+        "attester_arbiter": "0xB0d19784373EC5FDd2E44A2b594B10FE9bBecC94",
+        "expiration_time_after_arbiter": "0x05Ae296859454612a9a346B2EeBE6915319993Ec",
+        "expiration_time_before_arbiter": "0x698008cC7F4714D331Aa27278BfE6B74FA925cF7",
+        "expiration_time_equal_arbiter": "0x4d05EA86C2C0af7CA94dc71Da45aba9368e664e4",
+        "recipient_arbiter": "0xE6CB55B60b6B47B45de05df75B48D656E4bD3730",
+        "ref_uid_arbiter": "0xdEc95668f431639AAE975CfA9101Bb2A5b5803F6",
+        "revocable_arbiter": "0x550eF7e901F612914651f3c92c0798eBab037AF6",
+        "schema_arbiter": "0xc15Ef82Adf03820dA8a0705200602107a06652BE",
+        "time_after_arbiter": "0xd88274b04194bebA06B32D3F67265e4b530F4C4d",
+        "time_before_arbiter": "0xEC177a4FA6c42B1EA2bbEC70F3FFaE2aCD94e4aF",
+        "time_equal_arbiter": "0x0E16A9f94aD457214d5e8AdD30c64D8c6FD4a416",
+        "uid_arbiter": "0x0Be4E6D777D5C1AE3DDF338AF2398A279571511b",
+        "exclusive_revocable_confirmation_arbiter": "0xBA0e678f4F1a62f5d737F9289B7e1F2F8580DD8D",
+        "exclusive_unrevocable_confirmation_arbiter": "0x141Bfd94A1C2B2728dF693657d1C7589b06A139E",
+        "nonexclusive_revocable_confirmation_arbiter": "0xB78A1870C5412EBa6042a5b1dE895E8f879AbeC6",
+        "nonexclusive_unrevocable_confirmation_arbiter": "0x74FaFAAEa1bA879E73Cd7e38ec6F3ff86554D4B7",
+    },
+    "string_obligation_addresses": {
+        "eas": "0x4200000000000000000000000000000000000021",
+        "obligation": "0x544873C22A3228798F91a71C4ef7a9bFe96E7CE0",
+    },
+    "commit_reveal_obligation_addresses": {
+        "eas": "0x4200000000000000000000000000000000000021",
+        "obligation": "0x447b11ce03237f0C674eF7F16c913c3B2e8ef494",
+    },
+    "erc20_addresses": {
+        "eas": "0x4200000000000000000000000000000000000021",
+        "barter_utils": "0x946Ef4E912897B4A24b9250513dfeE3fc4303Dde",
+        "escrow_obligation_nontierable": "0x1Fe964348Ec42D9Bb1A072503ce8b4744266FF43",
+        "escrow_obligation_tierable": "0x0000000000000000000000000000000000000000",
+        "payment_obligation": "0x8d13d7542E64D9Da29AB66B6E9b4a6583C64b3F6",
+    },
+    "erc721_addresses": {
+        "eas": "0x4200000000000000000000000000000000000021",
+        "barter_utils": "0x707f280Fa738b4cc175A369d450f2f603094cbAf",
+        "escrow_obligation_nontierable": "0x7675a56b2880EF059cFC725E715E1139D689c07B",
+        "escrow_obligation_tierable": "0x0000000000000000000000000000000000000000",
+        "payment_obligation": "0x9Daf829f183cA46ad2146F489E7d14335C9B59a9",
+    },
+    "erc1155_addresses": {
+        "eas": "0x4200000000000000000000000000000000000021",
+        "barter_utils": "0x4E4F0F883B1fEC20F219E0c8D2ec0061FE3c1328",
+        "escrow_obligation_nontierable": "0xB8A3107DA5428a34f818ea4229233fBAe59C16F2",
+        "escrow_obligation_tierable": "0x0000000000000000000000000000000000000000",
+        "payment_obligation": "0x6f71429bD940Bf3345780a8E5F5cf3BcdffE80C1",
+    },
+    "native_token_addresses": {
+        "eas": "0x4200000000000000000000000000000000000021",
+        "barter_utils": "0xaaB70Cfc37C5E73e185E2976609A82Ba22A4310d",
+        "escrow_obligation_nontierable": "0x8a1172D32B8cEf14094cF1E7d6F3d1A36D949FDe",
+        "escrow_obligation_tierable": "0x0000000000000000000000000000000000000000",
+        "payment_obligation": "0xAB1E9714fbD4f9B5546e891B7Ba392b08c44c37A",
+    },
+    "token_bundle_addresses": {
+        "eas": "0x4200000000000000000000000000000000000021",
+        "barter_utils": "0x47C033F49D5A1559AC48f27571204a29b8E728b8",
+        "escrow_obligation_nontierable": "0x38e8E5684aFB24A88cD9B276032bCBD19C4b9d6e",
+        "escrow_obligation_tierable": "0x0000000000000000000000000000000000000000",
+        "payment_obligation": "0xFa5446475De31fa3c6457E2b62EA5a8F8172Cd29",
+    },
+    "attestation_addresses": {
+        "eas": "0x4200000000000000000000000000000000000021",
+        "eas_schema_registry": "0x4200000000000000000000000000000000000020",
+        "barter_utils": "0x84D390BCd90d5f65D14ff66f6860DCa45e776666",
+        "escrow_obligation_nontierable": "0x9D133Cbd51270a2A410465F82dAFFD6c1C87322D",
+        "escrow_obligation_tierable": "0x0000000000000000000000000000000000000000",
+        "escrow_obligation_2_nontierable": "0xa076e9ca47f192E6AfB67817608E382074CF0Dcf",
+        "escrow_obligation_2_tierable": "0x0000000000000000000000000000000000000000",
+    },
+}
+
+# Synced from alkahest Rust SDK at pinned revision in agent/uv.lock (2cbafc6).
+ETHEREUM_MAINNET_ADDRESSES: dict[str, Any] = {
+    "arbiters_addresses": {
+        "eas": "0xA1207F3BBa224E2c9c3c6D5aF63D0eb1582Ce587",
+        "trivial_arbiter": "0x594E79466b6ac01C6416C929e428264a4bdF0C92",
+        "trusted_oracle_arbiter": "0x3B2a812E3eb3B729D40d866Da16c2BB2b6cDd2f2",
+        "intrinsics_arbiter": "0xaabdDAa76651d20922d1F561f924a40F6fE7710c",
+        "intrinsics_arbiter_2": "0xF486f9a62eeb085e99828e1D706bBA5dfC1bD1fD",
+        "erc8004_arbiter": "0xBE7fE4d7CEb2140eeBdf01e12D198AEBAdC1F54D",
+        "any_arbiter": "0xe968dFA581B8aBb94eC5F24d0b56163DE69511fD",
+        "all_arbiter": "0x847F69d27E4F1A8a115aCa3F4358B079706dc9CE",
+        "attester_arbiter": "0x6CC4068d471E96A1669097918e18017f5764f72a",
+        "expiration_time_after_arbiter": "0x309509db364526C7aE202eA9ED94a398a0819d38",
+        "expiration_time_before_arbiter": "0xFAf8a07709dB9f90d0A0415876CfE00D904cd40B",
+        "expiration_time_equal_arbiter": "0x7c782ac7741BB78DB7491Ee222af0a04f7f2bc0b",
+        "recipient_arbiter": "0xF1C9E20078A13816ACdDF3153e2eAaDd93Fd6E57",
+        "ref_uid_arbiter": "0xE9ee2c57B18283b66d342D33d63C55f1427f9e9B",
+        "revocable_arbiter": "0xeda25079f76ef93c54cC042116Be8D88E49D3439",
+        "schema_arbiter": "0x913eAdD13dcCdeD9CD5518075083b6C7A9574A8c",
+        "time_after_arbiter": "0x0ea9e144FfDc6456E5cE8d1f75c686112e8f29c5",
+        "time_before_arbiter": "0x68A6e6022ab9984Ee1A9A6cee384FF2aE8be5264",
+        "time_equal_arbiter": "0x208385Fb349c01af2CfA8C6b86F633F6642718e2",
+        "uid_arbiter": "0xae4fa2D5d7EDD6Aaf697dC0c98EDb921F0fEc058",
+        "exclusive_revocable_confirmation_arbiter": "0x941044D43F9d75dfA8Ad24880B9B9cAD6e116a66",
+        "exclusive_unrevocable_confirmation_arbiter": "0x16aeE626D398B547eDD5fa4BdAA638524C92921d",
+        "nonexclusive_revocable_confirmation_arbiter": "0xe483EDA58b5f9Eba06A1ad0151dA5e4a5fFC8300",
+        "nonexclusive_unrevocable_confirmation_arbiter": "0x01666d869918aDDDED1B30eF2d36f3C990F09BDE",
+    },
+    "string_obligation_addresses": {
+        "eas": "0xA1207F3BBa224E2c9c3c6D5aF63D0eb1582Ce587",
+        "obligation": "0xC51C938f5497be8157DAf8CCc3Eb11Afb8b752C0",
+    },
+    "commit_reveal_obligation_addresses": {
+        "eas": "0xA1207F3BBa224E2c9c3c6D5aF63D0eb1582Ce587",
+        "obligation": "0x05d9Aa2A6AE38619b864Ff7f87A8f94301ecAB42",
+    },
+    "erc20_addresses": {
+        "eas": "0xA1207F3BBa224E2c9c3c6D5aF63D0eb1582Ce587",
+        "barter_utils": "0x5bf7c8b0d60d05af0a3De531EB876De271E80dbc",
+        "escrow_obligation_nontierable": "0xB2c808911E84E80156101983897Da7c80e13cB47",
+        "escrow_obligation_tierable": "0x0000000000000000000000000000000000000000",
+        "payment_obligation": "0xb822aA07F55a8B75Ee133ede1f21C4E49DE7952f",
+    },
+    "erc721_addresses": {
+        "eas": "0xA1207F3BBa224E2c9c3c6D5aF63D0eb1582Ce587",
+        "barter_utils": "0xEB0C0c41F708B8b3556a6F44a1a015a6832C2d2C",
+        "escrow_obligation_nontierable": "0x2A7df117e45D93d34a7893CC3aE8B105Ae0B561C",
+        "escrow_obligation_tierable": "0x0000000000000000000000000000000000000000",
+        "payment_obligation": "0x59A9c929778Ad2cC4D5DB6151bDEf0F9Fa7A068C",
+    },
+    "erc1155_addresses": {
+        "eas": "0xA1207F3BBa224E2c9c3c6D5aF63D0eb1582Ce587",
+        "barter_utils": "0x52De4B30721b3E3660A79da7491a9B2F8a9cB1D5",
+        "escrow_obligation_nontierable": "0xf04d9CA943f57353A3A735494E503280C1cD5e77",
+        "escrow_obligation_tierable": "0x0000000000000000000000000000000000000000",
+        "payment_obligation": "0x52748DD0E39eD6eA9f626179b5eb512302adA7D9",
+    },
+    "native_token_addresses": {
+        "eas": "0xA1207F3BBa224E2c9c3c6D5aF63D0eb1582Ce587",
+        "barter_utils": "0xA42032D8BFeE2302cC6F80ff51D283Ffc5a4081f",
+        "escrow_obligation_nontierable": "0x9bA50DB048d1E5db034377abf97F92496D027C71",
+        "escrow_obligation_tierable": "0x0000000000000000000000000000000000000000",
+        "payment_obligation": "0xf60db64506E366a0A6c1f4cF9D849Adc7bB886D6",
+    },
+    "token_bundle_addresses": {
+        "eas": "0xA1207F3BBa224E2c9c3c6D5aF63D0eb1582Ce587",
+        "barter_utils": "0xA7EacA68Bffc9443eA08fd58633Eeed3f5EE8A92",
+        "escrow_obligation_nontierable": "0x677Aa9e1CD9D05f57FbCa2327155EA7479ec7Ac3",
+        "escrow_obligation_tierable": "0x0000000000000000000000000000000000000000",
+        "payment_obligation": "0x36Fcf1Ddee838a94B1358285A11e8bbbb90eD9A1",
+    },
+    "attestation_addresses": {
+        "eas": "0xA1207F3BBa224E2c9c3c6D5aF63D0eb1582Ce587",
+        "eas_schema_registry": "0xA7b39296258348C78294F95B872b282326A97BDF",
+        "barter_utils": "0x5E6602F080E9B37267aa52306c699ae54Cd71056",
+        "escrow_obligation_nontierable": "0x6eb7792D821f32914Be75901F1b4269B13Efad2e",
+        "escrow_obligation_tierable": "0x0000000000000000000000000000000000000000",
+        "escrow_obligation_2_nontierable": "0x1A7c6F951e0a33F4910dbe56a200Eb413AEca17b",
+        "escrow_obligation_2_tierable": "0x0000000000000000000000000000000000000000",
+    },
+}
+
+NETWORK_ADDRESS_CONFIGS: dict[str, dict[str, Any]] = {
+    NETWORK_BASE_SEPOLIA: BASE_SEPOLIA_ADDRESSES,
+    NETWORK_ETHEREUM_MAINNET: ETHEREUM_MAINNET_ADDRESSES,
+}
+
+
+def _dict_to_namespace(value: Any) -> Any:
+    if isinstance(value, dict):
+        return SimpleNamespace(**{k: _dict_to_namespace(v) for k, v in value.items()})
+    if isinstance(value, list):
+        return [_dict_to_namespace(item) for item in value]
+    return value
+
+
+def get_alkahest_network(value: str | None) -> str:
+    network = (value or NETWORK_BASE_SEPOLIA).strip().lower()
+    if network not in SUPPORTED_NETWORKS:
+        raise ValueError(
+            f"Unsupported ALKAHEST_NETWORK '{network}'. "
+            f"Supported values: {sorted(SUPPORTED_NETWORKS)}"
+        )
+    return network
+
+
+@lru_cache(maxsize=8)
+def _load_override_config_cached(path_str: str) -> dict[str, Any]:
+    path = Path(path_str)
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("ALKAHEST_ADDRESS_CONFIG_PATH must point to a JSON object")
+    return data
+
+
+def _load_override_config(
+    config_path: str | None,
+) -> dict[str, Any] | None:
+    if config_path and config_path.strip():
+        normalized_path = str(Path(config_path).expanduser().resolve())
+        # Return a copy so callers cannot mutate cached state.
+        return copy.deepcopy(_load_override_config_cached(normalized_path))
+    return None
+
+
+def prewarm_alkahest_address_config_cache(config_path: str | None = None) -> None:
+    """Eagerly load/validate the configured address override JSON (if any)."""
+    _load_override_config(
+        config_path if config_path is not None else os.getenv("ALKAHEST_ADDRESS_CONFIG_PATH")
+    )
+
+
+def resolve_alkahest_address_config(
+    network: str,
+    *,
+    config_path: str | None = None,
+) -> Any | None:
+    selected = get_alkahest_network(network)
+    override = _load_override_config(config_path)
+    if override is not None:
+        return _dict_to_namespace(override)
+
+    if selected == NETWORK_BASE_SEPOLIA:
+        return None
+    if selected == NETWORK_ETHEREUM_MAINNET:
+        return _dict_to_namespace(ETHEREUM_MAINNET_ADDRESSES)
+
+    raise ValueError(
+        "ALKAHEST_NETWORK=anvil requires ALKAHEST_ADDRESS_CONFIG_PATH "
+        "with deployed local addresses."
+    )
+
+
+def get_trusted_oracle_arbiter() -> str:
+    selected = get_alkahest_network(os.getenv("ALKAHEST_NETWORK", "base_sepolia"))
+    override = _load_override_config(os.getenv("ALKAHEST_ADDRESS_CONFIG_PATH"))
+    if override is not None:
+        return str(override["arbiters_addresses"]["trusted_oracle_arbiter"])
+    if selected in NETWORK_ADDRESS_CONFIGS:
+        return str(
+            NETWORK_ADDRESS_CONFIGS[selected]["arbiters_addresses"][
+                "trusted_oracle_arbiter"
+            ]
+        )
+
+    raise ValueError(
+        "ALKAHEST_NETWORK=anvil requires ALKAHEST_ADDRESS_CONFIG_PATH "
+        "with deployed local addresses."
+    )

--- a/service/src/service/clients/erc8004/abi.py
+++ b/service/src/service/clients/erc8004/abi.py
@@ -1,0 +1,645 @@
+# ERC-8004 IdentityRegistry ABI - Complete extracted from deployed contract artifacts
+# Contains ALL functions and events from the deployed IdentityRegistry contract
+
+IDENTITY_REGISTRY_ABI = [
+    # Agent registration functions - ALL THREE OVERLOADED VERSIONS
+    {
+        "inputs": [],
+        "name": "register",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "agentId",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "string",
+                "name": "tokenUri",
+                "type": "string"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "string",
+                        "name": "key",
+                        "type": "string"
+                    },
+                    {
+                        "internalType": "bytes",
+                        "name": "value",
+                        "type": "bytes"
+                    }
+                ],
+                "internalType": "struct IdentityRegistry.MetadataEntry[]",
+                "name": "metadata",
+                "type": "tuple[]"
+            }
+        ],
+        "name": "register",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "agentId",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "string",
+                "name": "tokenUri",
+                "type": "string"
+            }
+        ],
+        "name": "register",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "agentId",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+
+    # ERC721 ownership functions
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "to",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "tokenId",
+                "type": "uint256"
+            }
+        ],
+        "name": "approve",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "owner",
+                "type": "address"
+            }
+        ],
+        "name": "balanceOf",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "tokenId",
+                "type": "uint256"
+            }
+        ],
+        "name": "getApproved",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "owner",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "operator",
+                "type": "address"
+            }
+        ],
+        "name": "isApprovedForAll",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "name",
+        "outputs": [
+            {
+                "internalType": "string",
+                "name": "",
+                "type": "string"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "owner",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "tokenId",
+                "type": "uint256"
+            }
+        ],
+        "name": "ownerOf",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "renounceOwnership",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "from",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "to",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "tokenId",
+                "type": "uint256"
+            }
+        ],
+        "name": "safeTransferFrom",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "from",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "to",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "tokenId",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "name": "safeTransferFrom",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "operator",
+                "type": "address"
+            },
+            {
+                "internalType": "bool",
+                "name": "approved",
+                "type": "bool"
+            }
+        ],
+        "name": "setApprovalForAll",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes4",
+                "name": "interfaceId",
+                "type": "bytes4"
+            }
+        ],
+        "name": "supportsInterface",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "symbol",
+        "outputs": [
+            {
+                "internalType": "string",
+                "name": "",
+                "type": "string"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "tokenId",
+                "type": "uint256"
+            }
+        ],
+        "name": "tokenURI",
+        "outputs": [
+            {
+                "internalType": "string",
+                "name": "",
+                "type": "string"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "from",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "to",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "tokenId",
+                "type": "uint256"
+            }
+        ],
+        "name": "transferFrom",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "newOwner",
+                "type": "address"
+            }
+        ],
+        "name": "transferOwnership",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+
+    # Metadata management functions
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "agentId",
+                "type": "uint256"
+            },
+            {
+                "internalType": "string",
+                "name": "key",
+                "type": "string"
+            }
+        ],
+        "name": "getMetadata",
+        "outputs": [
+            {
+                "internalType": "bytes",
+                "name": "",
+                "type": "bytes"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "agentId",
+                "type": "uint256"
+            },
+            {
+                "internalType": "string",
+                "name": "newUri",
+                "type": "string"
+            }
+        ],
+        "name": "setAgentUri",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "agentId",
+                "type": "uint256"
+            },
+            {
+                "internalType": "string",
+                "name": "key",
+                "type": "string"
+            },
+            {
+                "internalType": "bytes",
+                "name": "value",
+                "type": "bytes"
+            }
+        ],
+        "name": "setMetadata",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    }
+]
+
+# Events from the deployed contract
+IDENTITY_REGISTRY_EVENTS = [
+    {
+        "anonymous": False,
+        "inputs": [
+            {
+                "indexed": True,
+                "internalType": "address",
+                "name": "owner",
+                "type": "address"
+            },
+            {
+                "indexed": True,
+                "internalType": "address",
+                "name": "approved",
+                "type": "address"
+            },
+            {
+                "indexed": True,
+                "internalType": "uint256",
+                "name": "tokenId",
+                "type": "uint256"
+            }
+        ],
+        "name": "Approval",
+        "type": "event"
+    },
+    {
+        "anonymous": False,
+        "inputs": [
+            {
+                "indexed": True,
+                "internalType": "address",
+                "name": "owner",
+                "type": "address"
+            },
+            {
+                "indexed": True,
+                "internalType": "address",
+                "name": "operator",
+                "type": "address"
+            },
+            {
+                "indexed": False,
+                "internalType": "bool",
+                "name": "approved",
+                "type": "bool"
+            }
+        ],
+        "name": "ApprovalForAll",
+        "type": "event"
+    },
+    {
+        "anonymous": False,
+        "inputs": [
+            {
+                "indexed": False,
+                "internalType": "uint256",
+                "name": "_fromTokenId",
+                "type": "uint256"
+            },
+            {
+                "indexed": False,
+                "internalType": "uint256",
+                "name": "_toTokenId",
+                "type": "uint256"
+            }
+        ],
+        "name": "BatchMetadataUpdate",
+        "type": "event"
+    },
+    {
+        "anonymous": False,
+        "inputs": [
+            {
+                "indexed": True,
+                "internalType": "uint256",
+                "name": "agentId",
+                "type": "uint256"
+            },
+            {
+                "indexed": True,
+                "internalType": "string",
+                "name": "indexedKey",
+                "type": "string"
+            },
+            {
+                "indexed": False,
+                "internalType": "string",
+                "name": "key",
+                "type": "string"
+            },
+            {
+                "indexed": False,
+                "internalType": "bytes",
+                "name": "value",
+                "type": "bytes"
+            }
+        ],
+        "name": "MetadataSet",
+        "type": "event"
+    },
+    {
+        "anonymous": False,
+        "inputs": [
+            {
+                "indexed": False,
+                "internalType": "uint256",
+                "name": "_tokenId",
+                "type": "uint256"
+            }
+        ],
+        "name": "MetadataUpdate",
+        "type": "event"
+    },
+    {
+        "anonymous": False,
+        "inputs": [
+            {
+                "indexed": True,
+                "internalType": "address",
+                "name": "previousOwner",
+                "type": "address"
+            },
+            {
+                "indexed": True,
+                "internalType": "address",
+                "name": "newOwner",
+                "type": "address"
+            }
+        ],
+        "name": "OwnershipTransferred",
+        "type": "event"
+    },
+    {
+        "anonymous": False,
+        "inputs": [
+            {
+                "indexed": True,
+                "internalType": "uint256",
+                "name": "agentId",
+                "type": "uint256"
+            },
+            {
+                "indexed": False,
+                "internalType": "string",
+                "name": "tokenURI",
+                "type": "string"
+            },
+            {
+                "indexed": True,
+                "internalType": "address",
+                "name": "owner",
+                "type": "address"
+            }
+        ],
+        "name": "Registered",
+        "type": "event"
+    },
+    {
+        "anonymous": False,
+        "inputs": [
+            {
+                "indexed": True,
+                "internalType": "address",
+                "name": "from",
+                "type": "address"
+            },
+            {
+                "indexed": True,
+                "internalType": "address",
+                "name": "to",
+                "type": "address"
+            },
+            {
+                "indexed": True,
+                "internalType": "uint256",
+                "name": "tokenId",
+                "type": "uint256"
+            }
+        ],
+        "name": "Transfer",
+        "type": "event"
+    },
+    {
+        "anonymous": False,
+        "inputs": [
+            {
+                "indexed": True,
+                "internalType": "uint256",
+                "name": "agentId",
+                "type": "uint256"
+            },
+            {
+                "indexed": False,
+                "internalType": "string",
+                "name": "newUri",
+                "type": "string"
+            },
+            {
+                "indexed": True,
+                "internalType": "address",
+                "name": "updatedBy",
+                "type": "address"
+            }
+        ],
+        "name": "UriUpdated",
+        "type": "event"
+    }
+]
+
+# Combined ABI with both functions and events
+FULL_IDENTITY_REGISTRY_ABI = IDENTITY_REGISTRY_ABI + IDENTITY_REGISTRY_EVENTS

--- a/service/src/service/clients/erc8004/blockchain.py
+++ b/service/src/service/clients/erc8004/blockchain.py
@@ -1,0 +1,122 @@
+"""
+Blockchain utilities for agent registration.
+"""
+import logging
+from typing import Optional
+from urllib.parse import urlparse, urlunparse
+
+logger = logging.getLogger(__name__)
+
+
+def rpc_url_for_http_provider(rpc_url: str) -> str:
+    """
+    Convert an RPC URL to an HTTP(S) URL compatible with web3 HTTPProvider.
+
+    Generic behavior:
+    - ws:// -> http://
+    - wss:// -> https://
+
+    Provider-specific behavior:
+    - Infura websocket endpoints use /ws/v3/<project_id>, while HTTP uses
+      /v3/<project_id>. This rewrite is Infura-specific.
+    """
+    if not rpc_url:
+        return rpc_url
+
+    parsed = urlparse(rpc_url.strip())
+    scheme = parsed.scheme.lower()
+
+    if scheme == "ws":
+        parsed = parsed._replace(scheme="http")
+    elif scheme == "wss":
+        parsed = parsed._replace(scheme="https")
+
+    path = parsed.path or ""
+    # Infura-specific path normalization: /ws/v3/<project_id> -> /v3/<project_id>
+    if path.startswith("/ws/v3/"):
+        parsed = parsed._replace(path=path.replace("/ws/v3/", "/v3/", 1))
+
+    return urlunparse(parsed)
+
+
+def build_erc8004_canonical_id(chain_id: int, identity_registry: str, agent_id: int) -> str:
+    """
+    Build ERC-8004 canonical ID from components.
+
+    Format: eip155:{chainId}:{identityRegistry}:{agentId}
+
+    Args:
+        chain_id: Chain ID (e.g., 1337 for Anvil)
+        identity_registry: Registry contract address (will be normalized to lowercase)
+        agent_id: Numeric ERC-721 tokenId
+
+    Returns:
+        Canonical ID string with lowercase address
+    """
+    normalized_registry = identity_registry.lower()
+    return f"eip155:{chain_id}:{normalized_registry}:{agent_id}"
+
+
+def find_agent_id_by_owner(w3, contract, owner_address: str) -> Optional[int]:
+    """
+    Find agent ID by checking balance.
+
+    Args:
+        w3: Web3 instance
+        contract: Contract instance
+        owner_address: Owner wallet address
+
+    Returns:
+        Agent ID if found, None otherwise
+    """
+    try:
+        balance = contract.functions.balanceOf(owner_address).call()
+        if balance == 0:
+            return None
+
+        # Find the first token owned by this address
+        for token_id in range(balance + 10):
+            try:
+                if contract.functions.ownerOf(token_id).call().lower() == owner_address.lower():
+                    return int(token_id)
+            except Exception:
+                continue
+        return None
+    except Exception as e:
+        logger.warning(f"[BLOCKCHAIN] Could not find agent for owner: {e}")
+        return None
+
+
+def extract_agent_id_from_receipt(contract, receipt) -> Optional[int]:
+    """
+    Extract agent ID from transaction receipt.
+
+    Args:
+        contract: Contract instance
+        receipt: Transaction receipt
+
+    Returns:
+        Agent ID if found, None otherwise
+    """
+    for log in receipt.logs:
+        try:
+            event = contract.events.Registered().process_log(log)
+            if event:
+                # Try different ways to access agentId (handles different web3.py versions)
+                agent_id_value = None
+                if hasattr(event.args, 'agentId'):
+                    agent_id_value = event.args.agentId
+                elif hasattr(event.args, 'agent_id'):
+                    agent_id_value = event.args.agent_id
+                elif isinstance(event.args, dict):
+                    agent_id_value = event.args.get('agentId') or event.args.get('agent_id')
+                elif isinstance(event.args, (list, tuple)) and len(event.args) > 0:
+                    agent_id_value = event.args[0]
+
+                if agent_id_value is not None:
+                    return int(agent_id_value)
+        except Exception as e:
+            # Log the exception for debugging but continue trying other logs
+            logger.debug(f"[BLOCKCHAIN] Error parsing event log: {e}")
+            continue
+    return None

--- a/service/src/service/clients/erc8004/heartbeat.py
+++ b/service/src/service/clients/erc8004/heartbeat.py
@@ -1,0 +1,239 @@
+"""
+Heartbeat functionality for agent registration.
+"""
+import asyncio
+import json
+import logging
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Optional
+
+try:
+    from eth_account import Account
+    from eth_account.messages import encode_defunct
+    HAS_ETH_ACCOUNT = True
+except ImportError:
+    HAS_ETH_ACCOUNT = False
+
+# Try to use aiohttp for async HTTP, fallback to urllib
+try:
+    import aiohttp
+    HAS_AIOHTTP = True
+except ImportError:
+    HAS_AIOHTTP = False
+
+logger = logging.getLogger(__name__)
+
+# Heartbeat interval (seconds) - should be less than Indexer's heartbeat_ttl_secs
+HEARTBEAT_INTERVAL = 30  # Send heartbeat every 30 seconds
+HEARTBEAT_DELAY = 5
+
+
+async def send_heartbeat(
+    agent_id: str,
+    indexer_url: str,
+    private_key: Optional[str] = None,
+    owner_address: Optional[str] = None
+) -> bool:
+    """
+    Send heartbeat to Indexer to indicate agent is alive.
+
+    Signs the heartbeat with the agent's private key to authenticate the request.
+
+    Args:
+        agent_id: Agent ID (from Indexer registration)
+        indexer_url: Indexer API URL
+        private_key: Private key for signing heartbeat (optional if agent has no owner)
+        owner_address: Owner wallet address (optional, used for logging)
+
+    Returns:
+        True if successful, False otherwise
+    """
+    try:
+        timestamp = int(time.time())
+
+        # Prepare request body with signature if private key is available
+        body = {}
+        if private_key:
+            if not HAS_ETH_ACCOUNT:
+                logger.warning("[HEARTBEAT] eth_account not available, sending heartbeat without signature")
+            else:
+                try:
+                    # Construct message to sign
+                    message = f"heartbeat:{agent_id}:{timestamp}"
+
+                    # Sign message using EIP-191 personal sign format
+                    message_hash = encode_defunct(text=message)
+                    signed_message = Account.sign_message(message_hash, private_key)
+                    signature = signed_message.signature.hex()
+
+                    body = {
+                        "signature": signature,
+                        "timestamp": timestamp
+                    }
+                except Exception as e:
+                    logger.warning(f"[HEARTBEAT] Failed to sign heartbeat: {e}")
+
+        # URL-encode the agent_id for use in path parameter (handles canonical IDs with colons)
+        encoded_agent_id = urllib.parse.quote(agent_id, safe='')
+
+        if HAS_AIOHTTP:
+            try:
+                async with aiohttp.ClientSession() as session:
+                    async with session.post(
+                        f"{indexer_url.rstrip('/')}/agents/{encoded_agent_id}/heartbeat",
+                        json=body,
+                        timeout=aiohttp.ClientTimeout(total=5)
+                    ) as response:
+                        if response.status == 200:
+                            return True
+                        elif response.status == 401:
+                            logger.warning(f"[HEARTBEAT] Authentication failed (401) - signature may be invalid for agent {agent_id}")
+                            return False
+                        elif response.status == 404:
+                            logger.warning(f"[HEARTBEAT] Agent not found (404) - agent {agent_id} may not be indexed yet")
+                            return False
+                        else:
+                            # Try to read error response body for more context
+                            try:
+                                error_body = await response.text()
+                                logger.warning(f"[HEARTBEAT] HTTP {response.status} error for agent {agent_id}: {error_body[:200]}")
+                            except:
+                                logger.warning(f"[HEARTBEAT] HTTP {response.status} error for agent {agent_id}")
+                            return False
+            except aiohttp.ClientError as e:
+                logger.warning(f"[HEARTBEAT] Network error sending heartbeat for agent {agent_id}: {e}")
+                return False
+            except asyncio.TimeoutError:
+                logger.warning(f"[HEARTBEAT] Timeout sending heartbeat to {indexer_url} for agent {agent_id}")
+                return False
+        else:
+            req = urllib.request.Request(
+                f"{indexer_url.rstrip('/')}/agents/{encoded_agent_id}/heartbeat",
+                data=json.dumps(body).encode('utf-8'),
+                headers={'Content-Type': 'application/json'},
+                method='POST'
+            )
+            try:
+                with urllib.request.urlopen(req, timeout=5) as response:
+                    if response.status == 200:
+                        return True
+                    else:
+                        logger.warning(f"[HEARTBEAT] HTTP {response.status} error for agent {agent_id}")
+                        return False
+            except urllib.error.HTTPError as e:
+                if e.code == 401:
+                    logger.warning(f"[HEARTBEAT] Authentication failed (401) - signature may be invalid for agent {agent_id}")
+                elif e.code == 404:
+                    logger.warning(f"[HEARTBEAT] Agent not found (404) - agent {agent_id} may not be indexed yet")
+                else:
+                    logger.warning(f"[HEARTBEAT] HTTP {e.code} error for agent {agent_id}: {e.reason}")
+                return False
+            except urllib.error.URLError as e:
+                logger.warning(f"[HEARTBEAT] Network error sending heartbeat for agent {agent_id}: {e.reason}")
+                return False
+            except Exception as e:
+                logger.warning(f"[HEARTBEAT] Failed to send heartbeat for agent {agent_id} (urllib): {type(e).__name__}: {e}")
+                return False
+    except Exception as e:
+        logger.warning(f"[HEARTBEAT] Unexpected error sending heartbeat for agent {agent_id}: {type(e).__name__}: {e}")
+    return False
+
+
+async def heartbeat_loop(
+    agent_id: Optional[str],
+    indexer_url: str,
+    private_key: Optional[str] = None,
+    owner_address: Optional[str] = None
+):
+    """
+    Background task to periodically send heartbeats to Indexer.
+
+    Args:
+        agent_id: Agent ID from registration (None if not registered)
+        indexer_url: Indexer API URL
+        private_key: Private key for signing heartbeats (optional)
+        owner_address: Owner wallet address (optional, for logging)
+    """
+    if agent_id is None:
+        logger.debug("[HEARTBEAT] No agent ID, skipping heartbeat loop")
+        return
+
+    logger.info(f"[HEARTBEAT] Starting heartbeat loop for agent {agent_id}")
+    if private_key:
+        logger.debug("[HEARTBEAT] Heartbeats will be signed for authentication")
+    else:
+        logger.warning("[HEARTBEAT] No private key provided - heartbeats will be unsigned (may fail if Indexer requires auth)")
+
+    while True:
+        try:
+            await asyncio.sleep(HEARTBEAT_INTERVAL)
+            success = await send_heartbeat(agent_id, indexer_url, private_key, owner_address)
+            if success:
+                logger.debug(f"[HEARTBEAT] Heartbeat sent successfully")
+        except asyncio.CancelledError:
+            logger.info("[HEARTBEAT] Heartbeat loop cancelled")
+            break
+        except Exception as e:
+            logger.error(f"[HEARTBEAT] Error in heartbeat loop: {e}")
+            await asyncio.sleep(HEARTBEAT_INTERVAL)  # Wait before retrying
+
+
+async def start_agent_heartbeat(config: dict) -> Optional[str]:
+    """
+    Start agent heartbeat loop. Requires onchain_agent_id from config dict.
+
+    Args:
+        config: dict with keys: indexer_url, identity_registry_address,
+                agent_wallet_address, onchain_agent_id, chain_rpc_url, agent_priv_key
+    """
+    indexer_url = config.get("indexer_url")
+    identity_registry_address = config.get("identity_registry_address")
+    agent_wallet_address = config.get("agent_wallet_address")
+    onchain_agent_id = config.get("onchain_agent_id")
+    chain_rpc_url = config.get("chain_rpc_url")
+    agent_priv_key = config.get("agent_priv_key")
+
+    if not indexer_url or not identity_registry_address:
+        return None
+
+    if not agent_wallet_address:
+        logger.error("[HEARTBEAT] No wallet address configured")
+        return None
+
+    if not onchain_agent_id:
+        logger.warning("[HEARTBEAT] ONCHAIN_AGENT_ID not set. Run 'make register' first.")
+        return None
+
+    try:
+        agent_id = int(onchain_agent_id)
+    except ValueError:
+        logger.error(f"[HEARTBEAT] Invalid ONCHAIN_AGENT_ID: {onchain_agent_id}")
+        return None
+
+    await asyncio.sleep(HEARTBEAT_DELAY)
+
+    chain_id = 1337  # Default
+    try:
+        from web3 import Web3
+        from web3.providers import HTTPProvider
+        from .blockchain import rpc_url_for_http_provider, build_erc8004_canonical_id
+        if chain_rpc_url:
+            http_url = rpc_url_for_http_provider(chain_rpc_url)
+            w3 = Web3(HTTPProvider(http_url, request_kwargs={"timeout": 5}))
+            chain_id = w3.eth.chain_id
+    except Exception:
+        from .blockchain import build_erc8004_canonical_id
+
+    from .blockchain import build_erc8004_canonical_id
+    canonical_id = build_erc8004_canonical_id(
+        chain_id=chain_id,
+        identity_registry=identity_registry_address,
+        agent_id=agent_id,
+    )
+
+    asyncio.create_task(heartbeat_loop(canonical_id, indexer_url, agent_priv_key, agent_wallet_address))
+    logger.info(f"[HEARTBEAT] Started heartbeat for {canonical_id}")
+    return agent_wallet_address

--- a/service/src/service/clients/erc8004/registration.py
+++ b/service/src/service/clients/erc8004/registration.py
@@ -1,0 +1,662 @@
+"""
+On-chain registration logic for ERC-8004 Identity Registry.
+"""
+import json
+import logging
+import os
+import re
+import urllib.request
+from typing import Optional, Tuple
+
+try:
+    from web3 import Web3
+    from web3.providers import HTTPProvider
+    HAS_WEB3 = True
+except ImportError:
+    HAS_WEB3 = False
+
+# Try to use aiohttp for async HTTP, fallback to urllib
+try:
+    import aiohttp
+    HAS_AIOHTTP = True
+except ImportError:
+    HAS_AIOHTTP = False
+
+from .blockchain import (
+    find_agent_id_by_owner,
+    extract_agent_id_from_receipt,
+    rpc_url_for_http_provider,
+)
+from .abi import FULL_IDENTITY_REGISTRY_ABI
+
+logger = logging.getLogger(__name__)
+
+
+def _extract_revert_reason(error: Exception) -> str:
+    """Best-effort extraction of Solidity revert reason from provider error text."""
+    msg = str(error)
+    m = re.search(r"execution reverted(?::\s*(.*))?$", msg, flags=re.IGNORECASE)
+    if m:
+        reason = (m.group(1) or "").strip()
+        return reason or "execution reverted (no reason string)"
+    return msg
+
+
+def build_agent_card_url(base_url: str) -> str:
+    """
+    Build the agent card URL consistently.
+
+    Args:
+        base_url: Base URL of the agent (e.g., http://localhost:8000)
+
+    Returns:
+        Agent card URL (e.g., http://localhost:8000/.well-known/agent-card.json)
+    """
+    return f"{base_url.rstrip('/')}/.well-known/agent-card.json"
+
+
+def build_registration_file_url(base_url: str) -> str:
+    """
+    Build the ERC-8004 registration file URL (token_uri) consistently.
+
+    Per ERC-8004 spec, tokenURI MUST resolve to the agent registration file.
+
+    Args:
+        base_url: Base URL of the agent (e.g., http://localhost:8000)
+
+    Returns:
+        Registration file URL (e.g., http://localhost:8000/.well-known/erc-8004-registration.json)
+    """
+    return f"{base_url.rstrip('/')}/.well-known/erc-8004-registration.json"
+
+
+async def register_onchain_from_env(
+    base_url: Optional[str] = None,
+    chain_id: Optional[int] = None,
+    explicit_agent_id: Optional[str] = None
+) -> Optional[Tuple[str, int, Optional[dict]]]:
+    """
+    Register agent on-chain using environment variables.
+    Convenience wrapper around register_onchain() that reads from env vars.
+
+    Args:
+        base_url: Optional base URL override (defaults to BASE_URL_OVERRIDE env var)
+        chain_id: Optional chain ID override (defaults to CHAIN_ID env var)
+        explicit_agent_id: Optional explicit agent ID override (defaults to ONCHAIN_AGENT_ID env var)
+
+    Returns:
+        Same as register_onchain(): Tuple of (tx_hash, agent_id, updates_dict) or None
+    """
+    # Read required env vars
+    agent_priv_key = os.getenv("AGENT_PRIV_KEY")
+    chain_rpc_url = os.getenv("CHAIN_RPC_URL")
+    identity_registry_address = os.getenv("IDENTITY_REGISTRY_ADDRESS")
+    agent_wallet_address = os.getenv("AGENT_WALLET_ADDRESS")
+    base_url_override = base_url or os.getenv("BASE_URL_OVERRIDE", "http://localhost:8000")
+
+    # Validate required variables
+    missing = []
+    if not agent_priv_key:
+        missing.append("AGENT_PRIV_KEY")
+    if not chain_rpc_url:
+        missing.append("CHAIN_RPC_URL")
+    if not identity_registry_address:
+        missing.append("IDENTITY_REGISTRY_ADDRESS")
+    if not agent_wallet_address:
+        missing.append("AGENT_WALLET_ADDRESS")
+
+    if missing:
+        raise ValueError(f"Missing required environment variables: {', '.join(missing)}")
+
+    # Get optional values
+    explicit_agent_id = explicit_agent_id or os.getenv("ONCHAIN_AGENT_ID")
+
+    # Get agent name (for on-chain metadata and agent card)
+    agent_name = os.getenv("AGENT_NAME") or os.getenv("AGENT_ID") or "root_agent"
+
+    # Build agent card URL (used to build registration file URL)
+    agent_card_url = build_agent_card_url(base_url_override)
+
+    # Call the core registration function
+    # Note: register_onchain will build the registration file URL from agent_card_url
+    return await register_onchain(
+        agent_card_url=agent_card_url,
+        private_key=agent_priv_key,
+        rpc_url=chain_rpc_url,
+        contract_address=identity_registry_address,
+        owner_address=agent_wallet_address,
+        explicit_agent_id=explicit_agent_id,
+        indexer_url=None,  # Not needed for standalone registration
+        agent_name=agent_name
+    )
+
+
+
+
+async def update_existing_agent(
+    contract,
+    account,
+    agent_id: int,
+    desired_token_uri: str,
+    desired_metadata: list,
+    w3,
+    private_key: str
+) -> Tuple[Optional[str], dict]:
+    """
+    Update existing agent if changes detected.
+
+    Args:
+        contract: Web3 contract instance
+        account: Web3 account instance
+        agent_id: Existing agent ID
+        desired_token_uri: Desired token URI (agent card URL)
+        desired_metadata: List of desired metadata dicts with 'key' and 'value' (hex-encoded)
+        w3: Web3 instance
+        private_key: Private key for signing transactions
+
+    Returns:
+        Tuple of (last_tx_hash_if_updated, updates_dict) where updates_dict indicates what was updated:
+        {
+            'token_uri_updated': bool,
+            'metadata_updated': list of updated keys,
+            'no_changes': bool
+        }
+    """
+    updates = {
+        'token_uri_updated': False,
+        'metadata_updated': [],
+        'no_changes': True
+    }
+    last_tx_hash = None
+
+    try:
+        # Fetch current token URI from contract
+        current_token_uri = contract.functions.tokenURI(agent_id).call()
+
+        # Normalize URIs for comparison (strip trailing slashes, handle http/https)
+        def normalize_uri(uri: str) -> str:
+            uri = uri.rstrip('/')
+            # Normalize http/https (optional - uncomment if needed)
+            # uri = uri.replace('https://', 'http://')
+            return uri
+
+        normalized_current = normalize_uri(current_token_uri)
+        normalized_desired = normalize_uri(desired_token_uri)
+
+        logger.debug(f"[UPDATE] Current token URI: {current_token_uri}")
+        logger.debug(f"[UPDATE] Desired token URI: {desired_token_uri}")
+
+        # Compare normalized token URIs
+        if normalized_current != normalized_desired:
+            logger.info(f"[UPDATE] Token URI changed: {current_token_uri} -> {desired_token_uri}")
+            try:
+                # Call setAgentUri
+                tx = contract.functions.setAgentUri(agent_id, desired_token_uri).build_transaction({
+                    "from": account.address,
+                    "nonce": w3.eth.get_transaction_count(account.address),
+                    "gas": 200000,
+                    "gasPrice": w3.eth.gas_price,
+                })
+
+                signed_tx = account.sign_transaction(tx)
+                tx_hash = w3.eth.send_raw_transaction(signed_tx.raw_transaction)
+                tx_hash_str = tx_hash.hex() if hasattr(tx_hash, 'hex') else str(tx_hash)
+
+                # Wait for confirmation
+                receipt = w3.eth.wait_for_transaction_receipt(tx_hash, timeout=60)
+                if receipt.status == 1:
+                    logger.info(f"[UPDATE] ✓ Token URI updated! TX: {tx_hash_str}")
+                    updates['token_uri_updated'] = True
+                    updates['no_changes'] = False
+                    last_tx_hash = tx_hash_str
+                else:
+                    logger.error(f"[UPDATE] ✗ Token URI update failed! TX reverted.")
+            except Exception as e:
+                logger.error(f"[UPDATE] Error updating token URI: {e}")
+        else:
+            logger.debug(f"[UPDATE] Token URI unchanged")
+
+        # Fetch current metadata and compare
+        for desired_meta in desired_metadata:
+            key = desired_meta['key']
+            desired_value_hex = desired_meta['value']
+
+            try:
+                # Fetch current metadata value (returns bytes)
+                current_value_bytes = contract.functions.getMetadata(agent_id, key).call()
+
+                # Convert desired hex string to bytes for comparison
+                # Web3.to_hex returns hex string with '0x' prefix, so we need to handle that
+                if isinstance(desired_value_hex, str):
+                    if desired_value_hex.startswith('0x'):
+                        desired_value_bytes = bytes.fromhex(desired_value_hex[2:])
+                    else:
+                        desired_value_bytes = bytes.fromhex(desired_value_hex)
+                else:
+                    desired_value_bytes = desired_value_hex
+
+                # Compare bytes
+                if current_value_bytes != desired_value_bytes:
+                    logger.info(f"[UPDATE] Metadata key '{key}' changed (size: {len(desired_value_bytes)} bytes)")
+                    try:
+                        # Build transaction first
+                        tx = contract.functions.setMetadata(agent_id, key, desired_value_bytes).build_transaction({
+                            "from": account.address,
+                            "nonce": w3.eth.get_transaction_count(account.address),
+                            "gasPrice": w3.eth.gas_price,
+                        })
+
+                        # Estimate gas - use higher multiplier for large values like agentCard
+                        try:
+                            estimated_gas = contract.functions.setMetadata(agent_id, key, desired_value_bytes).estimate_gas({
+                                "from": account.address
+                            })
+                            # Add 20% buffer for safety
+                            gas_limit = int(estimated_gas * 1.2)
+                            logger.debug(f"[UPDATE] Estimated gas for '{key}': {estimated_gas}, using {gas_limit}")
+                        except Exception as est_error:
+                            # Fallback: use size-based estimation if gas estimation fails
+                            logger.warning(f"[UPDATE] Gas estimation failed for '{key}': {est_error}, using size-based estimate")
+                            base_gas = 200000
+                            # Rough estimate: ~200 gas per byte for storage operations
+                            size_based_gas = base_gas + (len(desired_value_bytes) * 200)
+                            gas_limit = min(size_based_gas, 2000000)  # Cap at 2M gas
+
+                        tx['gas'] = gas_limit
+
+                        signed_tx = account.sign_transaction(tx)
+                        tx_hash = w3.eth.send_raw_transaction(signed_tx.raw_transaction)
+                        tx_hash_str = tx_hash.hex() if hasattr(tx_hash, 'hex') else str(tx_hash)
+
+                        logger.debug(f"[UPDATE] Sending transaction for '{key}' with gas limit: {gas_limit}")
+
+                        # Wait for confirmation
+                        receipt = w3.eth.wait_for_transaction_receipt(tx_hash, timeout=60)
+                        if receipt.status == 1:
+                            logger.info(f"[UPDATE] ✓ Metadata key '{key}' updated! TX: {tx_hash_str} (gas used: {receipt.gasUsed}/{gas_limit})")
+                            updates['metadata_updated'].append(key)
+                            updates['no_changes'] = False
+                            last_tx_hash = tx_hash_str
+                        else:
+                            logger.error(f"[UPDATE] ✗ Metadata key '{key}' update failed! TX reverted. Gas used: {receipt.gasUsed}/{gas_limit}")
+                            # Log transaction for debugging
+                            try:
+                                logger.error(f"[UPDATE] Failed transaction hash: {tx_hash_str}")
+                                logger.error(f"[UPDATE] Receipt status: {receipt.status}, gas used: {receipt.gasUsed}")
+                            except:
+                                pass
+                    except Exception as e:
+                        logger.error(f"[UPDATE] Error updating metadata key '{key}': {e}")
+                        import traceback
+                        logger.debug(f"[UPDATE] Traceback: {traceback.format_exc()}")
+                else:
+                    logger.debug(f"[UPDATE] Metadata key '{key}' unchanged")
+            except Exception as e:
+                # Metadata key might not exist yet, treat as changed
+                logger.debug(f"[UPDATE] Metadata key '{key}' not found on-chain (or error): {e}, will update")
+                try:
+                    # Convert desired hex to bytes
+                    if isinstance(desired_value_hex, str):
+                        if desired_value_hex.startswith('0x'):
+                            desired_value_bytes = bytes.fromhex(desired_value_hex[2:])
+                        else:
+                            desired_value_bytes = bytes.fromhex(desired_value_hex)
+                    else:
+                        desired_value_bytes = desired_value_hex
+
+                    # Call setMetadata
+                    # Build transaction first
+                    tx = contract.functions.setMetadata(agent_id, key, desired_value_bytes).build_transaction({
+                        "from": account.address,
+                        "nonce": w3.eth.get_transaction_count(account.address),
+                        "gasPrice": w3.eth.gas_price,
+                    })
+
+                    # Estimate gas - use higher multiplier for large values like agentCard
+                    try:
+                        estimated_gas = contract.functions.setMetadata(agent_id, key, desired_value_bytes).estimate_gas({
+                            "from": account.address
+                        })
+                        # Add 20% buffer for safety
+                        gas_limit = int(estimated_gas * 1.2)
+                        logger.debug(f"[UPDATE] Estimated gas for '{key}': {estimated_gas}, using {gas_limit}")
+                    except Exception as est_error:
+                        # Fallback: use size-based estimation if gas estimation fails
+                        logger.warning(f"[UPDATE] Gas estimation failed for '{key}': {est_error}, using size-based estimate")
+                        base_gas = 200000
+                        # Rough estimate: ~200 gas per byte for storage operations
+                        size_based_gas = base_gas + (len(desired_value_bytes) * 200)
+                        gas_limit = min(size_based_gas, 2000000)  # Cap at 2M gas
+
+                    tx['gas'] = gas_limit
+
+                    signed_tx = account.sign_transaction(tx)
+                    tx_hash = w3.eth.send_raw_transaction(signed_tx.raw_transaction)
+                    tx_hash_str = tx_hash.hex() if hasattr(tx_hash, 'hex') else str(tx_hash)
+
+                    logger.debug(f"[UPDATE] Sending transaction for '{key}' with gas limit: {gas_limit}")
+
+                    # Wait for confirmation
+                    receipt = w3.eth.wait_for_transaction_receipt(tx_hash, timeout=60)
+                    if receipt.status == 1:
+                        logger.info(f"[UPDATE] ✓ Metadata key '{key}' set! TX: {tx_hash_str} (gas used: {receipt.gasUsed}/{gas_limit})")
+                        updates['metadata_updated'].append(key)
+                        updates['no_changes'] = False
+                        last_tx_hash = tx_hash_str
+                    else:
+                        logger.error(f"[UPDATE] ✗ Metadata key '{key}' set failed! TX reverted. Gas used: {receipt.gasUsed}/{gas_limit}")
+                except Exception as e2:
+                    logger.error(f"[UPDATE] Error setting metadata key '{key}': {e2}")
+
+        if updates['no_changes']:
+            logger.info(f"[UPDATE] ✓ No changes detected for agent {agent_id}")
+
+        return (last_tx_hash, updates)
+
+    except Exception as e:
+        logger.error(f"[UPDATE] Error in update_existing_agent: {e}")
+        return (None, updates)
+
+
+async def register_onchain(
+    agent_card_url: str,
+    private_key: str,
+    rpc_url: str,
+    contract_address: str,
+    owner_address: Optional[str] = None,
+    explicit_agent_id: Optional[str] = None,
+    indexer_url: Optional[str] = None,
+    agent_name: Optional[str] = None,
+    agent_card_data: dict | None = None
+) -> Optional[Tuple[str, int, Optional[dict]]]:
+    """
+    Register or update agent on-chain by calling the ERC-8004 Identity Registry contract.
+    Checks if agent is already registered and updates metadata instead of re-registering.
+
+    Priority order for finding existing agent:
+    1. Explicit agent ID from environment variable (ONCHAIN_AGENT_ID)
+    2. Search blockchain events (finds most recent registration by owner)
+
+    Note: Each agent instance registers independently. Multiple agents on different ports
+    will each get their own on-chain agent ID (auto-incremented by contract).
+    No local caching is used - agents always check the blockchain for existing registrations.
+
+    Args:
+        agent_card_url: URL to the agent card (used as tokenURI)
+        private_key: Private key for signing the transaction
+        rpc_url: Blockchain RPC URL
+        contract_address: ERC-8004 Identity Registry contract address
+        owner_address: Optional owner address (defaults to signer address)
+        explicit_agent_id: Explicit agent ID from env var (highest priority)
+        indexer_url: Indexer API URL to query for existing agent
+        agent_name: Optional agent name (from AGENT_NAME env var). If not provided, uses agent card name or falls back to AGENT_ID
+        agent_card_data: Optional agent card data dict. If None, will attempt to fetch from agent_card_url.
+
+    Returns:
+        Tuple of (tx_hash, agent_id, updates_dict) if successful, None otherwise
+        - For new registrations: (tx_hash, agent_id, None)
+        - For existing agents with updates: (tx_hash, agent_id, updates_dict) where tx_hash is the last update transaction hash
+        - For existing agents with no changes: (None, agent_id, updates_dict) where updates_dict['no_changes'] is True
+    """
+    if not HAS_WEB3:
+        logger.error("[ONCHAIN REGISTRATION] web3 package not installed. Cannot perform on-chain registration.")
+        return None
+
+    logger.info(f"[ONCHAIN REGISTRATION] Attempting on-chain registration...")
+    logger.info(f"[ONCHAIN REGISTRATION] Token URI: {agent_card_url}")
+    logger.info(f"[ONCHAIN REGISTRATION] Contract: {contract_address}")
+
+    try:
+        # Use HTTP provider for chain calls; normalize ws/wss RPC URLs if needed.
+        http_url = rpc_url_for_http_provider(rpc_url)
+        logger.debug(f"[REGISTRATION] Connecting to RPC: {http_url} (converted from {rpc_url})")
+
+        try:
+            w3 = Web3(HTTPProvider(http_url, request_kwargs={'timeout': 10}))
+            if not w3.is_connected():
+                logger.error(f"[REGISTRATION] Cannot connect to RPC at {http_url} (original: {rpc_url})")
+                logger.error(f"[REGISTRATION] Please ensure your blockchain node is running and accessible")
+                return None
+        except Exception as conn_error:
+            logger.error(f"[REGISTRATION] RPC connection error: {conn_error}")
+            logger.error(f"[REGISTRATION] Failed to connect to {http_url} (original: {rpc_url})")
+            logger.error(f"[REGISTRATION] Please check:")
+            logger.error(f"[REGISTRATION]   1. Is your blockchain node running?")
+            logger.error(f"[REGISTRATION]   2. Is the RPC URL correct?")
+            logger.error(f"[REGISTRATION]   3. Is the port accessible?")
+            return None
+
+        account = w3.eth.account.from_key(private_key)
+        # Official contract always mints to msg.sender (the account signing)
+        # If owner_address differs, we'd need to transfer after registration
+        signer_address = account.address
+
+        contract = w3.eth.contract(
+            address=Web3.to_checksum_address(contract_address),
+            abi=FULL_IDENTITY_REGISTRY_ABI
+        )
+
+        # Check if agent is already registered (priority order)
+        agent_id = None
+
+        # 1. Explicit agent ID from env var (highest priority - user override)
+        if explicit_agent_id:
+            try:
+                # Handle both numeric ID and canonical ID formats
+                if explicit_agent_id.startswith("eip155:"):
+                    # Extract numeric agent ID from canonical ID format: eip155:{chainId}:{registry}:{agentId}
+                    parts = explicit_agent_id.split(":")
+                    if len(parts) == 4:
+                        agent_id = int(parts[3])
+                        logger.info(f"[REGISTRATION] Extracted numeric agent ID {agent_id} from canonical ID {explicit_agent_id}")
+                    else:
+                        raise ValueError(f"Invalid canonical ID format: {explicit_agent_id}")
+                else:
+                    # Assume it's a numeric ID
+                    agent_id = int(explicit_agent_id)
+
+                logger.info(f"[REGISTRATION] Using explicit agent ID {agent_id} (searching for owner {owner_address or signer_address})")
+                # Verify it's valid
+                owner = contract.functions.ownerOf(agent_id).call()
+                logger.info(f"[REGISTRATION] Agent {agent_id} owned by {owner}")
+
+                # Check if owner matches what we expect
+                expected_owner = owner_address if owner_address else signer_address
+                if owner.lower() != expected_owner.lower():
+                    logger.warning(f"[REGISTRATION] Explicit agent ID {agent_id} owned by {owner}, expected {expected_owner}, ignoring")
+                    agent_id = None
+                else:
+                    logger.info(f"[REGISTRATION] ✓ Explicit agent ID {agent_id} ownership confirmed")
+            except Exception as e:
+                logger.warning(f"[REGISTRATION] Invalid explicit agent ID {explicit_agent_id}: {e}")
+                agent_id = None
+
+        # 2. Search blockchain events (finds most recent registration by owner)
+        if agent_id is None:
+            logger.debug(f"[REGISTRATION] Searching blockchain for existing registration by owner...")
+            # Use owner_address if provided, otherwise signer_address
+            search_address = owner_address if owner_address else signer_address
+            agent_id = find_agent_id_by_owner(w3, contract, search_address)
+            if agent_id is not None:
+                logger.info(f"[REGISTRATION] Found existing registration (ID: {agent_id}) for owner {search_address}")
+                # Continue to idempotent check below
+
+        # Build agent card from config (server may not be running yet)
+        # Try to fetch from URL first, fallback to building from config
+        if agent_card_data is None:
+            try:
+                if HAS_AIOHTTP:
+                    async with aiohttp.ClientSession() as session:
+                        async with session.get(agent_card_url, timeout=aiohttp.ClientTimeout(total=5)) as response:
+                            if response.status == 200:
+                                agent_card_data = await response.json()
+                                logger.debug(f"[REGISTRATION] Fetched agent card from {agent_card_url}")
+                else:
+                    card_req = urllib.request.Request(agent_card_url, method='GET')
+                    with urllib.request.urlopen(card_req, timeout=5) as response:
+                        agent_card_data = json.loads(response.read().decode('utf-8'))
+                        logger.debug(f"[REGISTRATION] Fetched agent card from {agent_card_url}")
+            except Exception as e:
+                logger.info(f"[REGISTRATION] Could not fetch agent card from URL (server may not be running): {e}")
+                logger.info(f"[REGISTRATION] Building agent card from configuration...")
+
+        # Use empty dict as fallback if agent_card_data is still None
+        if agent_card_data is None:
+            agent_card_data = {}
+
+        # Build ERC-8004 registration file URL (tokenURI per spec)
+        # Per ERC-8004 spec: tokenURI MUST resolve to the agent registration file
+        base_url = agent_card_url.replace("/.well-known/agent-card.json", "")
+        registration_file_url = build_registration_file_url(base_url)
+
+        # Get chain_id for registration file
+        chain_id = w3.eth.chain_id
+
+        # Build metadata for on-chain storage
+        final_agent_name = agent_name or agent_card_data.get("name") or os.getenv("AGENT_NAME") or os.getenv("AGENT_ID") or "root_agent"
+        labels = {"category": "compute", "type": "trader"}  # Default labels
+
+        # Official contract: register(string tokenUri, MetadataEntry[] metadata)
+        # MetadataEntry is {string key, bytes value} - format matches viem's toHex output
+        # Store essential metadata on-chain for composability
+        metadata = [
+            # Store agent name on-chain (as per ERC-8004 spec example)
+            # Uses AGENT_NAME env var if provided, otherwise from agent card, otherwise AGENT_ID
+            {"key": "agentName", "value": Web3.to_hex(text=final_agent_name)},
+            # Store category and type for filtering/discovery
+            {"key": "category", "value": Web3.to_hex(text=labels.get("category", "compute"))},
+            {"key": "type", "value": Web3.to_hex(text=labels.get("type", "trader"))},
+            # Store full agent card JSON as bytes for on-chain access
+            # Convert agent card dict to JSON string, then to bytes, then to hex
+            {"key": "agentCard", "value": Web3.to_hex(text=json.dumps(agent_card_data, separators=(',', ':')))},
+        ]
+
+        # If we found an existing agent ID, check for changes and update if needed (idempotent)
+        # CRITICAL: Use 'is not None' instead of truthy check because agent_id 0 is valid!
+        if agent_id is not None:
+            logger.info(f"[REGISTRATION] ✓ Agent already registered with ID: {agent_id}")
+            logger.info(f"[REGISTRATION] Checking for changes and updating if needed...")
+
+            # Update existing agent if changes detected
+            # Use registration file URL as tokenURI (per ERC-8004 spec)
+            update_tx_hash, updates = await update_existing_agent(
+                contract=contract,
+                account=account,
+                agent_id=agent_id,
+                desired_token_uri=registration_file_url,
+                desired_metadata=metadata,
+                w3=w3,
+                private_key=private_key
+            )
+
+            if updates['no_changes']:
+                logger.info(f"[REGISTRATION] ✓ No changes detected, using existing agent ID {agent_id}")
+            else:
+                if updates['token_uri_updated']:
+                    logger.info(f"[REGISTRATION] ✓ Token URI updated")
+                if updates['metadata_updated']:
+                    logger.info(f"[REGISTRATION] ✓ Metadata keys updated: {', '.join(updates['metadata_updated'])}")
+
+            # Return (tx_hash_if_updated, agent_id, updates_dict) - tx_hash is None if no updates were made
+            return (update_tx_hash, agent_id, updates)
+
+        # No existing registration found, register new
+        logger.info(f"[ONCHAIN REGISTRATION] Registering new agent on-chain...")
+        # Note: agentId is already the ERC-721 tokenId, so we don't store it as metadata
+        # Description and other details are in the tokenURI registration file, not on-chain
+
+        # Log metadata for debugging
+        logger.debug(f"[ONCHAIN REGISTRATION] Metadata to store: {json.dumps(metadata, indent=2)}")
+
+        # Preflight: estimate gas first. If this fails, provider usually includes
+        # the contract revert reason and we can exit before broadcasting a tx.
+        register_fn = contract.functions.register(registration_file_url, metadata)
+        try:
+            estimated_gas = register_fn.estimate_gas({"from": account.address})
+            logger.debug(f"[REGISTRATION] register() gas estimate: {estimated_gas}")
+        except Exception as gas_error:
+            revert_reason = _extract_revert_reason(gas_error)
+            logger.error(f"[REGISTRATION] register() preflight failed: {revert_reason}")
+            return None
+
+        # Build transaction - no 'to' parameter, always mints to msg.sender
+        # Per ERC-8004 spec: tokenURI MUST resolve to the agent registration file
+        tx = register_fn.build_transaction({
+            "from": account.address,
+            "nonce": w3.eth.get_transaction_count(account.address),
+            "gas": max(int(estimated_gas * 2), 500000),
+            "gasPrice": w3.eth.gas_price,
+        })
+
+        # Sign and send transaction
+        signed_tx = account.sign_transaction(tx)
+        tx_hash = w3.eth.send_raw_transaction(signed_tx.raw_transaction)
+
+        # Handle both bytes and HexBytes types for tx_hash
+        tx_hash_str = tx_hash.hex() if hasattr(tx_hash, 'hex') else str(tx_hash)
+        logger.info(f"[ONCHAIN REGISTRATION] On-chain registration submitted! TX: {tx_hash_str}")
+
+        # Wait for confirmation
+        receipt = w3.eth.wait_for_transaction_receipt(tx_hash, timeout=60)
+
+        if receipt.status == 1:
+            logger.info(f"[ONCHAIN REGISTRATION] On-chain registration confirmed! Block: {receipt.blockNumber}")
+
+            # Extract agent ID from Registered event
+            onchain_id = extract_agent_id_from_receipt(contract, receipt)
+
+            # Fallback: query contract if event parsing failed
+            if onchain_id is None:
+                logger.warning(f"[REGISTRATION] Could not extract agent ID from events, querying contract...")
+                onchain_id = find_agent_id_by_owner(w3, contract, signer_address)
+
+            # Handle NFT transfer if needed
+            if onchain_id is not None:
+                # If owner_address was specified and differs from signer, transfer NFT
+                if owner_address and owner_address.lower() != signer_address.lower():
+                    logger.info(f"[REGISTRATION] Transferring agent NFT to {owner_address}...")
+                    # Execute ERC721 transfer
+                    transfer_tx = contract.functions.transferFrom(
+                        signer_address,
+                        owner_address,
+                        onchain_id
+                    ).build_transaction({
+                        'from': signer_address,
+                        'nonce': w3.eth.get_transaction_count(signer_address),
+                        'gas': 200000,
+                        'gasPrice': w3.eth.gas_price,
+                        'chainId': w3.eth.chain_id
+                    })
+
+                    # Sign and send transfer transaction
+                    signed_transfer_tx = w3.eth.account.sign_transaction(transfer_tx, private_key)
+                    transfer_tx_hash = w3.eth.send_raw_transaction(signed_transfer_tx.rawTransaction)
+
+                    # Wait for transfer confirmation
+                    transfer_receipt = w3.eth.wait_for_transaction_receipt(transfer_tx_hash, timeout=60)
+
+                    if transfer_receipt.status == 1:
+                        logger.info(f"[REGISTRATION] ✓ Agent NFT transferred to {owner_address}")
+                    else:
+                        logger.error(f"[REGISTRATION] ✗ NFT transfer failed for agent {onchain_id}")
+
+            # Return (tx_hash, agent_id, None) tuple - None indicates new registration
+            if onchain_id is not None:
+                tx_hash_str = tx_hash.hex() if hasattr(tx_hash, 'hex') else str(tx_hash)
+                return (tx_hash_str, onchain_id, None)
+            else:
+                logger.error(f"[REGISTRATION] Registration succeeded but could not extract agent ID")
+                return None
+        else:
+            logger.error(f"[REGISTRATION] On-chain registration failed! TX reverted.")
+            logger.error(
+                "[REGISTRATION] Reverted tx details: hash=%s block=%s gasUsed=%s",
+                tx_hash_str,
+                receipt.blockNumber,
+                receipt.gasUsed,
+            )
+            return None
+
+    except Exception as e:
+        logger.error(f"[REGISTRATION] On-chain registration error: {e}")
+        return None

--- a/service/src/service/clients/indexer.py
+++ b/service/src/service/clients/indexer.py
@@ -1,0 +1,321 @@
+"""Registry client for discovering agents and querying market orders."""
+
+from __future__ import annotations
+
+import logging
+import os
+import aiohttp
+from typing import Any, Dict, List, Optional
+from datetime import datetime, timedelta
+
+logger = logging.getLogger(__name__)
+
+
+class RegistryClient:
+    """Client for interacting with the ERC-8004 registry API."""
+
+    def __init__(self, base_url: str | None = None, timeout: int = 30):
+        """Initialize registry client.
+
+        Args:
+            base_url: Base URL of the registry API (defaults to INDEXER_URL env var)
+            timeout: Request timeout in seconds
+        """
+        self.base_url = (base_url or os.getenv("INDEXER_URL", os.getenv("REGISTRY_URL", "http://localhost:8080"))).rstrip('/')
+        self.timeout = aiohttp.ClientTimeout(total=timeout)
+        self._session: Optional[aiohttp.ClientSession] = None
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        """Get or create aiohttp session."""
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession(timeout=self.timeout)
+        return self._session
+
+    async def close(self):
+        """Close the HTTP session."""
+        if self._session and not self._session.closed:
+            await self._session.close()
+
+    async def discover_agents(
+        self,
+        filters: Dict[str, Any] | None = None,
+        limit: int = 50,
+        offset: int = 0
+    ) -> List[Dict[str, Any]]:
+        """Discover agents from the registry.
+
+        Args:
+            filters: Optional filters (q, endpoint_type, trust_model)
+            limit: Maximum number of results
+            offset: Pagination offset
+
+        Returns:
+            List of agent dictionaries
+        """
+        try:
+            session = await self._get_session()
+            params = {"limit": limit, "offset": offset}
+            if filters:
+                params.update(filters)
+
+            async with session.get(f"{self.base_url}/agents", params=params) as response:
+                if response.status == 200:
+                    data = await response.json()
+                    return data.get("items", [])
+                else:
+                    logger.warning(f"[REGISTRY] Failed to discover agents: {response.status}")
+                    return []
+        except Exception as e:
+            logger.error(f"[REGISTRY] Error discovering agents: {e}")
+            return []
+
+    async def get_agent_orders(
+        self,
+        agent_id: str,
+        status: str | None = None,
+        limit: int = 50,
+        offset: int = 0
+    ) -> List[Dict[str, Any]]:
+        """Get orders for a specific agent.
+
+        Args:
+            agent_id: Agent ID
+            status: Optional status filter
+            limit: Maximum number of results
+            offset: Pagination offset
+
+        Returns:
+            List of order dictionaries
+        """
+        try:
+            session = await self._get_session()
+            params = {"limit": limit, "offset": offset}
+            if status:
+                params["status"] = status
+
+            async with session.get(f"{self.base_url}/agents/{agent_id}/orders", params=params) as response:
+                if response.status == 200:
+                    data = await response.json()
+                    return data.get("items", [])
+                elif response.status == 404:
+                    # Agent not found - expected if agent hasn't registered yet
+                    logger.debug(f"[REGISTRY] Agent {agent_id} not found in registry (404) - may not be registered yet")
+                    return []
+                else:
+                    logger.warning(f"[REGISTRY] Failed to get agent orders: {response.status}")
+                    return []
+        except Exception as e:
+            logger.error(f"[REGISTRY] Error getting agent orders: {e}")
+            return []
+
+    async def get_order(self, order_id: str) -> Dict[str, Any] | None:
+        """Get a single order by ID.
+
+        Args:
+            order_id: Order ID
+
+        Returns:
+            Order dictionary or None if not found or on error
+        """
+        try:
+            session = await self._get_session()
+            async with session.get(f"{self.base_url}/orders/{order_id}") as response:
+                if response.status == 200:
+                    data = await response.json()
+                    if isinstance(data, dict) and "order" in data and isinstance(data["order"], dict):
+                        return data["order"]
+                    return data
+                if response.status == 404:
+                    logger.debug(f"[REGISTRY] Order {order_id} not found in registry (404)")
+                    return None
+                logger.warning(f"[REGISTRY] Failed to get order {order_id}: {response.status}")
+                return None
+        except Exception as e:
+            logger.error(f"[REGISTRY] Error getting order {order_id}: {e}")
+            return None
+
+    async def query_orders(
+        self,
+        filters: Dict[str, Any] | None = None,
+        bidirectional: bool = False,
+        limit: int = 50,
+        offset: int = 0
+    ) -> List[Dict[str, Any]]:
+        """Query orders with filters.
+
+        Args:
+            filters: Optional filters (offer_resource_type, demand_resource_type, region, gpu_model, sla, status)
+            bidirectional: Enable bidirectional matching
+            limit: Maximum number of results
+            offset: Pagination offset
+
+        Returns:
+            List of order dictionaries
+        """
+        try:
+            session = await self._get_session()
+            # Convert boolean to string for query params (FastAPI expects string/int/float)
+            params = {"limit": limit, "offset": offset, "bidirectional": str(bidirectional).lower()}
+            if filters:
+                params.update(filters)
+
+            async with session.get(f"{self.base_url}/orders", params=params) as response:
+                if response.status == 200:
+                    data = await response.json()
+                    return data.get("items", [])
+                else:
+                    logger.warning(f"[REGISTRY] Failed to query orders: {response.status}")
+                    return []
+        except Exception as e:
+            logger.error(f"[REGISTRY] Error querying orders: {e}")
+            return []
+
+    async def publish_order(
+        self,
+        agent_id: str,
+        order: Dict[str, Any]
+    ) -> Dict[str, Any] | None:
+        """Publish an order to the registry.
+
+        Args:
+            agent_id: Agent ID
+            order: Order dictionary (must include order_id and other MarketOrder fields)
+
+        Returns:
+            Published order data or None on error
+        """
+        try:
+            session = await self._get_session()
+            async with session.post(
+                f"{self.base_url}/agents/{agent_id}/orders",
+                json=order
+            ) as response:
+                if response.status == 201:
+                    return await response.json()
+                else:
+                    error_text = await response.text()
+                    logger.warning(f"[REGISTRY] Failed to publish order: {response.status} - {error_text}")
+                    return None
+        except Exception as e:
+            logger.error(f"[REGISTRY] Error publishing order: {e}")
+            return None
+
+    async def update_order(
+        self,
+        order_id: str,
+        updates: Dict[str, Any]
+    ) -> Dict[str, Any] | None:
+        """Update an order in the registry.
+
+        Args:
+            order_id: Order ID
+            updates: Dictionary of fields to update (status, order_taker, taker_attestation, etc.)
+
+        Returns:
+            Updated order data or None on error
+        """
+        try:
+            session = await self._get_session()
+            async with session.put(
+                f"{self.base_url}/orders/{order_id}",
+                json=updates
+            ) as response:
+                if response.status == 200:
+                    return await response.json()
+                else:
+                    error_text = await response.text()
+                    logger.warning(f"[REGISTRY] Failed to update order: {response.status} - {error_text}")
+                    return None
+        except Exception as e:
+            logger.error(f"[REGISTRY] Error updating order: {e}")
+            return None
+
+    async def delete_order(
+        self,
+        order_id: str
+    ) -> bool:
+        """Delete an order from the registry.
+
+        Args:
+            order_id: Order ID
+
+        Returns:
+            True if successful, False otherwise
+        """
+        try:
+            session = await self._get_session()
+            async with session.delete(f"{self.base_url}/orders/{order_id}") as response:
+                if response.status == 204:
+                    return True
+                else:
+                    error_text = await response.text()
+                    logger.warning(f"[REGISTRY] Failed to delete order: {response.status} - {error_text}")
+                    return False
+        except Exception as e:
+            logger.error(f"[REGISTRY] Error deleting order: {e}")
+            return False
+
+    def _get_resource_type(self, resource: Dict[str, Any]) -> str:
+        """Determine if resource is compute or token."""
+        if "token" in resource:
+            return "token"
+        elif "gpu_model" in resource:
+            return "compute"
+        return "unknown"
+
+    def match_orders(
+        self,
+        our_order: Dict[str, Any],
+        candidate_orders: List[Dict[str, Any]],
+        bidirectional: bool = True
+    ) -> List[Dict[str, Any]]:
+        """Find matching orders bidirectionally.
+
+        Args:
+            our_order: Our order dictionary
+            candidate_orders: List of candidate orders to match against
+            bidirectional: Enable bidirectional matching
+
+        Returns:
+            List of matching orders
+        """
+        matches = []
+        our_offer_type = self._get_resource_type(our_order.get("offer_resource", {}))
+        our_demand_type = self._get_resource_type(our_order.get("demand_resource", {}))
+
+        for candidate in candidate_orders:
+            their_offer_type = self._get_resource_type(candidate.get("offer_resource", {}))
+            their_demand_type = self._get_resource_type(candidate.get("demand_resource", {}))
+
+            if bidirectional:
+                # Case A: Our compute offer matches their compute demand AND our token demand matches their token offer
+                case_a = (
+                    our_offer_type == "compute" and their_demand_type == "compute" and
+                    our_demand_type == "token" and their_offer_type == "token"
+                )
+                # Case B: Our token offer matches their token demand AND our compute demand matches their compute offer
+                case_b = (
+                    our_offer_type == "token" and their_demand_type == "token" and
+                    our_demand_type == "compute" and their_offer_type == "compute"
+                )
+                if case_a or case_b:
+                    matches.append(candidate)
+            else:
+                # Direct match: our offer matches their demand and our demand matches their offer
+                if our_offer_type == their_demand_type and our_demand_type == their_offer_type:
+                    matches.append(candidate)
+
+        return matches
+
+
+# Global registry client instance
+_registry_client: Optional[RegistryClient] = None
+
+
+def get_registry_client() -> RegistryClient:
+    """Get or create global registry client instance."""
+    global _registry_client
+    if _registry_client is None:
+        timeout = int(os.getenv("REGISTRY_ORDER_TIMEOUT", "30"))
+        _registry_client = RegistryClient(timeout=timeout)
+    return _registry_client

--- a/service/src/service/clients/network.py
+++ b/service/src/service/clients/network.py
@@ -1,0 +1,157 @@
+import json
+import logging
+import subprocess
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+NetworkInfo = Dict[str, Any]
+
+ZEROTIER_IP_TOKEN = "{ZEROTIER_IP}"
+
+
+def _list_zerotier_networks(timeout: float = 5.0) -> Optional[List[NetworkInfo]]:
+    """List all ZeroTier networks via zerotier-cli."""
+    cmd = ["sudo", "zerotier-cli", "listnetworks", "-j"]
+    try:
+        proc = subprocess.run(
+            cmd,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError:
+        logger.warning("ZeroTier CLI not found.")
+        return None
+    except subprocess.TimeoutExpired:
+        logger.warning("ZeroTier CLI timed out while listing networks.")
+        return None
+    except subprocess.CalledProcessError as exc:
+        logger.warning("ZeroTier CLI error when listing networks: %s", exc.stderr or exc.stdout)
+        return None
+
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        logger.warning("ZeroTier CLI returned invalid JSON.")
+        return None
+
+
+def _check_zerotier_cli() -> bool:
+    """Return True if zerotier-cli is installed, False otherwise."""
+    try:
+        subprocess.run(
+            ["zerotier-cli", "-v"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        return True
+    except FileNotFoundError:
+        logger.warning("ZeroTier CLI not found. Install with: cd infra && make install")
+        return False
+
+
+def get_zerotier_ip(network_id: str, *, timeout: float = 5.0) -> Optional[str]:
+    """
+    Return the first assigned IP for the given ZeroTier network, if any.
+    """
+    if not network_id:
+        return None
+
+    networks = _list_zerotier_networks(timeout=timeout)
+    if not networks:
+        return None
+
+    for net in networks:
+        if net.get("id") != network_id:
+            continue
+        addresses = net.get("assignedAddresses") or []
+        if not addresses:
+            return None
+        # Take the first assigned address, drop CIDR suffix if present.
+        return addresses[0].split("/")[0]
+
+    logger.info("ZeroTier network %s not found in listnetworks output.", network_id)
+    return None
+
+
+def is_network_joined(network_id: str) -> bool:
+    """Check if the given ZeroTier network is already joined."""
+    if not network_id:
+        return False
+
+    networks = _list_zerotier_networks()
+    if not networks:
+        return False
+
+    return any(net.get("id") == network_id for net in networks)
+
+
+def join_zerotier_network(network_id: str) -> bool:
+    """
+    Join the given ZeroTier network.
+
+    Returns True if the join command was issued successfully.
+    """
+    if not network_id:
+        logger.warning("No ZeroTier network ID provided; cannot join network.")
+        return False
+
+    if is_network_joined(network_id):
+        logger.info("ZeroTier network %s already joined.", network_id)
+        return True
+
+    if not _check_zerotier_cli():
+        return False
+
+    cmd = ["sudo", "zerotier-cli", "join", network_id]
+    try:
+        subprocess.run(cmd, check=True, capture_output=True, text=True)
+        logger.info("Joined ZeroTier network %s.", network_id)
+        return True
+    except subprocess.CalledProcessError as exc:
+        logger.error("Failed to join ZeroTier network %s: %s", network_id, exc.stderr or exc.stdout)
+        return False
+
+
+def get_zerotier_node_id() -> Optional[str]:
+    """Return the local ZeroTier node ID, if available."""
+    if not _check_zerotier_cli():
+        return None
+
+    try:
+        proc = subprocess.run(
+            ["sudo", "zerotier-cli", "info"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        logger.warning("ZeroTier CLI error when getting node ID: %s", exc.stderr or exc.stdout)
+        return None
+    except FileNotFoundError:
+        # Already logged by _check_zerotier_cli
+        return None
+
+    parts = proc.stdout.split()
+    if len(parts) >= 3:
+        return parts[2]
+    return None
+
+
+# Convenience re-export for callers who need URL resolution
+try:
+    from core.agent.app.utils.zerotier import await_base_url_resolution
+except ImportError:
+    await_base_url_resolution = None  # type: ignore[assignment]
+
+__all__ = [
+    "ZEROTIER_IP_TOKEN",
+    "get_zerotier_ip",
+    "is_network_joined",
+    "join_zerotier_network",
+    "get_zerotier_node_id",
+    "await_base_url_resolution",
+]

--- a/service/tests/unit/test_alkahest.py
+++ b/service/tests/unit/test_alkahest.py
@@ -1,0 +1,45 @@
+"""Unit tests for service.clients.alkahest (ported from core tests, using monkeypatch.setenv)."""
+import pytest
+
+
+def test_get_alkahest_network_base_sepolia(monkeypatch):
+    from service.clients.alkahest import get_alkahest_network
+    assert get_alkahest_network("base_sepolia") == "base_sepolia"
+
+
+def test_get_alkahest_network_default(monkeypatch):
+    from service.clients.alkahest import get_alkahest_network
+    assert get_alkahest_network(None) == "base_sepolia"
+
+
+def test_get_alkahest_network_invalid():
+    from service.clients.alkahest import get_alkahest_network
+    with pytest.raises(ValueError, match="Unsupported ALKAHEST_NETWORK"):
+        get_alkahest_network("unknown_network")
+
+
+def test_get_trusted_oracle_arbiter_base_sepolia(monkeypatch):
+    monkeypatch.setenv("ALKAHEST_NETWORK", "base_sepolia")
+    monkeypatch.delenv("ALKAHEST_ADDRESS_CONFIG_PATH", raising=False)
+    from service.clients.alkahest import get_trusted_oracle_arbiter
+    import importlib, service.clients.alkahest as alc
+    # Clear lru_cache
+    alc._load_override_config_cached.cache_clear()
+    addr = get_trusted_oracle_arbiter()
+    assert addr.startswith("0x")
+
+
+def test_get_trusted_oracle_arbiter_ethereum_mainnet(monkeypatch):
+    monkeypatch.setenv("ALKAHEST_NETWORK", "ethereum_mainnet")
+    monkeypatch.delenv("ALKAHEST_ADDRESS_CONFIG_PATH", raising=False)
+    from service.clients.alkahest import get_trusted_oracle_arbiter
+    import service.clients.alkahest as alc
+    alc._load_override_config_cached.cache_clear()
+    addr = get_trusted_oracle_arbiter()
+    assert addr.startswith("0x")
+
+
+def test_resolve_alkahest_address_config_base_sepolia_returns_none():
+    from service.clients.alkahest import resolve_alkahest_address_config
+    result = resolve_alkahest_address_config("base_sepolia")
+    assert result is None

--- a/service/tests/unit/test_erc8004_blockchain.py
+++ b/service/tests/unit/test_erc8004_blockchain.py
@@ -1,0 +1,32 @@
+"""Unit tests for service.clients.erc8004.blockchain (pure functions, no mocking needed)."""
+from service.clients.erc8004.blockchain import (
+    rpc_url_for_http_provider,
+    build_erc8004_canonical_id,
+)
+
+
+def test_rpc_url_ws_to_http():
+    assert rpc_url_for_http_provider("ws://localhost:8545") == "http://localhost:8545"
+
+
+def test_rpc_url_wss_to_https():
+    assert rpc_url_for_http_provider("wss://mainnet.infura.io/ws/v3/abc") == "https://mainnet.infura.io/v3/abc"
+
+
+def test_rpc_url_http_unchanged():
+    assert rpc_url_for_http_provider("http://localhost:8545") == "http://localhost:8545"
+
+
+def test_rpc_url_empty():
+    assert rpc_url_for_http_provider("") == ""
+
+
+def test_build_erc8004_canonical_id():
+    cid = build_erc8004_canonical_id(1337, "0xABCDEF1234567890ABCDEF1234567890ABCDEF12", 42)
+    assert cid == "eip155:1337:0xabcdef1234567890abcdef1234567890abcdef12:42"
+
+
+def test_build_erc8004_canonical_id_lowercase():
+    cid = build_erc8004_canonical_id(1, "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", 0)
+    assert cid.startswith("eip155:1:")
+    assert cid == cid.lower() or "eip155" in cid

--- a/service/tests/unit/test_heartbeat.py
+++ b/service/tests/unit/test_heartbeat.py
@@ -1,0 +1,64 @@
+"""Unit tests for service.clients.erc8004.heartbeat."""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+@pytest.mark.asyncio
+async def test_send_heartbeat_success():
+    from service.clients.erc8004.heartbeat import send_heartbeat
+
+    mock_response = AsyncMock()
+    mock_response.status = 200
+
+    with patch("aiohttp.ClientSession") as mock_session_cls:
+        session_instance = MagicMock()
+        session_instance.__aenter__ = AsyncMock(return_value=session_instance)
+        session_instance.__aexit__ = AsyncMock(return_value=False)
+        post_cm = MagicMock()
+        post_cm.__aenter__ = AsyncMock(return_value=mock_response)
+        post_cm.__aexit__ = AsyncMock(return_value=False)
+        session_instance.post = MagicMock(return_value=post_cm)
+        mock_session_cls.return_value = session_instance
+
+        result = await send_heartbeat("agent1", "http://indexer:8080")
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_send_heartbeat_404():
+    from service.clients.erc8004.heartbeat import send_heartbeat
+
+    mock_response = AsyncMock()
+    mock_response.status = 404
+
+    with patch("aiohttp.ClientSession") as mock_session_cls:
+        session_instance = MagicMock()
+        session_instance.__aenter__ = AsyncMock(return_value=session_instance)
+        session_instance.__aexit__ = AsyncMock(return_value=False)
+        post_cm = MagicMock()
+        post_cm.__aenter__ = AsyncMock(return_value=mock_response)
+        post_cm.__aexit__ = AsyncMock(return_value=False)
+        session_instance.post = MagicMock(return_value=post_cm)
+        mock_session_cls.return_value = session_instance
+
+        result = await send_heartbeat("agent1", "http://indexer:8080")
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_start_agent_heartbeat_missing_config():
+    from service.clients.erc8004.heartbeat import start_agent_heartbeat
+    result = await start_agent_heartbeat({})
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_start_agent_heartbeat_missing_agent_id():
+    from service.clients.erc8004.heartbeat import start_agent_heartbeat
+    result = await start_agent_heartbeat({
+        "indexer_url": "http://indexer:8080",
+        "identity_registry_address": "0x1234",
+        "agent_wallet_address": "0xABCD",
+        # no onchain_agent_id
+    })
+    assert result is None

--- a/service/tests/unit/test_indexer.py
+++ b/service/tests/unit/test_indexer.py
@@ -1,0 +1,78 @@
+"""Unit tests for service.clients.indexer."""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+import aiohttp
+
+
+@pytest.fixture
+def client():
+    from service.clients.indexer import RegistryClient
+    return RegistryClient(base_url="http://test-indexer:8080", timeout=5)
+
+
+@pytest.mark.asyncio
+async def test_discover_agents_success(client):
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.json = AsyncMock(return_value={"items": [{"id": "agent1"}]})
+    mock_session = AsyncMock()
+    mock_session.get = MagicMock(return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock(return_value=False)))
+    with patch.object(client, "_get_session", return_value=mock_session):
+        result = await client.discover_agents()
+    assert result == [{"id": "agent1"}]
+
+
+@pytest.mark.asyncio
+async def test_discover_agents_failure(client):
+    mock_response = AsyncMock()
+    mock_response.status = 500
+    mock_session = AsyncMock()
+    mock_session.get = MagicMock(return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock(return_value=False)))
+    with patch.object(client, "_get_session", return_value=mock_session):
+        result = await client.discover_agents()
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_publish_order_success(client):
+    mock_response = AsyncMock()
+    mock_response.status = 201
+    mock_response.json = AsyncMock(return_value={"order_id": "ord1"})
+    mock_session = AsyncMock()
+    mock_session.post = MagicMock(return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock(return_value=False)))
+    with patch.object(client, "_get_session", return_value=mock_session):
+        result = await client.publish_order("agent1", {"order_id": "ord1"})
+    assert result == {"order_id": "ord1"}
+
+
+@pytest.mark.asyncio
+async def test_update_order_success(client):
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.json = AsyncMock(return_value={"order_id": "ord1", "status": "accepted"})
+    mock_session = AsyncMock()
+    mock_session.put = MagicMock(return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock(return_value=False)))
+    with patch.object(client, "_get_session", return_value=mock_session):
+        result = await client.update_order("ord1", {"status": "accepted"})
+    assert result["status"] == "accepted"
+
+
+@pytest.mark.asyncio
+async def test_delete_order_success(client):
+    mock_response = AsyncMock()
+    mock_response.status = 204
+    mock_session = AsyncMock()
+    mock_session.delete = MagicMock(return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock(return_value=False)))
+    with patch.object(client, "_get_session", return_value=mock_session):
+        result = await client.delete_order("ord1")
+    assert result is True
+
+
+def test_get_registry_client_singleton(monkeypatch):
+    monkeypatch.setenv("REGISTRY_ORDER_TIMEOUT", "15")
+    import service.clients.indexer as idx
+    idx._registry_client = None  # reset singleton
+    c1 = idx.get_registry_client()
+    c2 = idx.get_registry_client()
+    assert c1 is c2
+    idx._registry_client = None  # cleanup


### PR DESCRIPTION
## Overview
Adds the new canonical home for all chain/identity/registry client logic: `service/clients/`. This PR introduces only the **new modules and their tests** — nothing in `core/` is touched. The follow-up PR updates all `core/` call sites to import from `service.clients.*` directly and deletes the old modules.

Future work (stacked on this PR):
1. Update all `core/` call sites to import from `service.clients.*` directly; delete old modules
2. Extract `TokenRegistry` singleton into `service/clients/token.py`
3. Extract three-mode provisioning clients (http/ansible/mock) into `service/clients/`

## Testing
1. Run service-level unit tests:
```
cd service
uv run pytest tests/unit/test_alkahest.py \
               tests/unit/test_erc8004_blockchain.py \
               tests/unit/test_heartbeat.py \
               tests/unit/test_indexer.py -v
```
2. Confirm the new modules are importable in isolation:

```
cd service
uv run python -c "
from service.clients.indexer import RegistryClient, get_registry_client
from service.clients.erc8004.blockchain import rpc_url_for_http_provider
from service.clients.erc8004.heartbeat import start_agent_heartbeat
from service.clients.alkahest import get_alkahest_network
print('all service imports ok')
```
