### PR TITLE
Refactor: Persist Oracle Address in Market Order

### DIFF
--- a/agent/tests/unit/test_action_executor.py
+++ b/agent/tests/unit/test_action_executor.py
@@ -1,5 +1,6 @@
 """Unit tests for action executor helpers."""
 
+import dataclasses
 import json
 import sqlite3
 from datetime import datetime
@@ -13,6 +14,7 @@ from core.agent.app.schema.pydantic_models import (
     ERC20TokenMetadata,
     EventType,
     GPUModel,
+    MarketOrder,
     Region,
     TokenResource,
 )
@@ -160,6 +162,7 @@ async def test_accept_offer_passes_duration_and_hourly_rate(monkeypatch):
         "offer_resource": _compute_resource().model_dump(mode="json"),
         "demand_resource": _token_rate(rate).model_dump(mode="json"),
         "duration_hours": duration_hours,
+        "oracle_address": "0xBuyerWallet",
     }
 
     async def fake_buy_compute_with_erc20(
@@ -337,6 +340,7 @@ async def test_accept_offer_updates_buyer_order_only(monkeypatch, tmp_path):
         "offer_resource": _token_rate(1_000_000).model_dump(mode="json"),
         "demand_resource": _compute_resource().model_dump(mode="json"),
         "duration_hours": 1,
+        "oracle_address": "0xBuyerWallet",
     }
 
     await action_executor.accept_offer(
@@ -481,3 +485,186 @@ async def test_execute_action_trust_falls_back_for_non_url_counterparty(monkeypa
     await action_executor.execute_action(action, alkahest_client=None, ctx=_FakeCtx())
 
     assert captured["agent_url"] == "http://fallback.example:9000"
+
+
+# ---------------------------------------------------------------------------
+# Oracle address lookup
+# ---------------------------------------------------------------------------
+
+BUYER_WALLET = "0xBuyerWallet000000000000000000000000000000"
+
+
+def test_create_order_deficit_sets_oracle_address(monkeypatch):
+    """Token-offering (deficit) maker stamps their wallet as oracle_address."""
+    monkeypatch.setattr(
+        action_executor,
+        "CONFIG",
+        dataclasses.replace(action_executor.CONFIG, agent_wallet_address=BUYER_WALLET),
+    )
+
+    result = action_executor.create_order(
+        gpu_model_str="H200",
+        sla=99.0,
+        region_str="California, US",
+        imbalance_type="deficit",
+    )
+
+    assert result is not None
+    assert result["oracle_address"] == BUYER_WALLET
+
+
+def test_create_order_surplus_oracle_address_is_none(monkeypatch):
+    """Compute-offering (surplus) maker leaves oracle_address unset."""
+    monkeypatch.setattr(
+        action_executor,
+        "CONFIG",
+        dataclasses.replace(action_executor.CONFIG, agent_wallet_address=BUYER_WALLET),
+    )
+
+    result = action_executor.create_order(
+        gpu_model_str="H200",
+        sla=99.0,
+        region_str="California, US",
+        imbalance_type="surplus",
+    )
+
+    assert result is not None
+    assert result["oracle_address"] is None
+
+
+@pytest.mark.asyncio
+async def test_accept_offer_passes_oracle_address_to_escrow(monkeypatch):
+    """oracle_address on the order is forwarded to buy_compute_with_erc20."""
+    captured: dict = {}
+
+    async def fake_buy_compute_with_erc20(
+        compute_resource, token_resource, duration_hours, oracle_address, client
+    ):
+        captured["oracle_address"] = oracle_address
+        return {"log": {"uid": "escrow-abc"}}
+
+    monkeypatch.setattr(action_executor, "buy_compute_with_erc20", fake_buy_compute_with_erc20)
+
+    order_dict = {
+        "order_id": "order-oracle-1",
+        "order_maker": "buyer",
+        "offer_resource": _token_rate(1_000_000).model_dump(mode="json"),
+        "demand_resource": _compute_resource().model_dump(mode="json"),
+        "duration_hours": 1,
+        "oracle_address": BUYER_WALLET,
+    }
+
+    await action_executor.accept_offer(
+        alkahest_client=_FakeClient({}),
+        ctx=None,
+        parameters={"order": order_dict},
+    )
+
+    assert captured["oracle_address"] == BUYER_WALLET
+
+
+@pytest.mark.asyncio
+async def test_accept_offer_raises_without_oracle_address(monkeypatch):
+    """accept_offer raises ValueError when oracle_address is absent from the order."""
+    async def fake_buy_compute_with_erc20(**_kwargs):
+        return {"log": {"uid": "escrow-xyz"}}
+
+    monkeypatch.setattr(action_executor, "buy_compute_with_erc20", fake_buy_compute_with_erc20)
+
+    order_dict = {
+        "order_id": "order-no-oracle",
+        "order_maker": "seller",
+        "offer_resource": _compute_resource().model_dump(mode="json"),
+        "demand_resource": _token_rate(1_000_000).model_dump(mode="json"),
+        "duration_hours": 1,
+        # oracle_address intentionally absent
+    }
+
+    with pytest.raises(ValueError, match="oracle_address is required"):
+        await action_executor.accept_offer(
+            alkahest_client=_FakeClient({}),
+            ctx=None,
+            parameters={"order": order_dict},
+        )
+
+
+@pytest.mark.asyncio
+async def test_accept_offer_persists_oracle_address_to_db(monkeypatch, tmp_path):
+    """Compute seller (taker) persists oracle_address to the local DB on acceptance."""
+    db_path = str(tmp_path / "agent.db")
+    sqlite_client = SQLiteClient(db_path=db_path)
+
+    async def fake_buy_compute_with_erc20(**_kwargs):
+        return {"log": {"uid": "escrow-persist-1"}}
+
+    class _DummyTxn:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+        async def cancel_competing(self, *_args, **_kwargs):
+            return None
+
+        async def mark_terminal(self, *_args, **_kwargs):
+            return None
+
+    monkeypatch.setattr(action_executor, "buy_compute_with_erc20", fake_buy_compute_with_erc20)
+    monkeypatch.setattr(action_executor, "NegotiationThreadTransaction", lambda *_a, **_kw: _DummyTxn())
+    monkeypatch.setattr(action_executor, "get_sqlite_client", lambda: sqlite_client)
+
+    async def fake_send_to_remote_agent(_ctx, _event, agent_url=None):
+        return None
+
+    monkeypatch.setattr(action_executor, "send_to_remote_agent", fake_send_to_remote_agent)
+
+    class _RegistryClient:
+        async def update_order(self, *_args, **_kwargs):
+            return {"ok": True}
+
+    monkeypatch.setattr(action_executor, "get_registry_client", lambda: _RegistryClient())
+
+    order_id = "taker-oracle-order-1"
+    await sqlite_client.upsert_order(
+        order_id=order_id,
+        status="open",
+        created_at=datetime.now().isoformat(),
+        updated_at=datetime.now().isoformat(),
+        offer_resource=_token_rate(1_000_000).model_dump(mode="json"),
+        demand_resource=_compute_resource().model_dump(mode="json"),
+        fulfillment_resource=None,
+        duration_hours=1,
+        order_maker="buyer",
+        order_taker=None,
+        matched_offer_id=None,
+        maker_attestation=None,
+        taker_attestation=None,
+        escrow_uid=None,
+    )
+
+    order_dict = {
+        "order_id": order_id,
+        "order_maker": "buyer",
+        "offer_resource": _token_rate(1_000_000).model_dump(mode="json"),
+        "demand_resource": _compute_resource().model_dump(mode="json"),
+        "duration_hours": 1,
+        "oracle_address": BUYER_WALLET,
+    }
+
+    await action_executor.accept_offer(
+        alkahest_client=_FakeClient({}),
+        ctx=_FakeCtx(),
+        parameters={"order": order_dict},
+    )
+
+    conn = sqlite3.connect(db_path)
+    try:
+        cur = conn.cursor()
+        cur.execute("SELECT oracle_address FROM orders WHERE order_id=?", (order_id,))
+        row = cur.fetchone()
+    finally:
+        conn.close()
+
+    assert row is not None
+    assert row[0] == BUYER_WALLET

--- a/agent/tests/unit/test_action_executor.py
+++ b/agent/tests/unit/test_action_executor.py
@@ -232,7 +232,11 @@ async def test_execute_action_fulfill_sends_event_on_success(monkeypatch):
 
     action = Action(
         action_type=ActionType.FULFILL_COMPUTE_OBLIGATION,
-        parameters={"escrow_uid": "escrow-2", "ssh_public_key": "ssh-rsa AAA"},
+        parameters={
+            "escrow_uid": "escrow-2",
+            "ssh_public_key": "ssh-rsa AAA",
+            "counterparty_url": "http://buyer.example:8000",
+        },
         timestamp=datetime.now(),
     )
 
@@ -326,7 +330,7 @@ async def test_accept_offer_updates_buyer_order_only(monkeypatch, tmp_path):
         demand_resource=_compute_resource().model_dump(mode="json"),
         fulfillment_resource=None,
         duration_hours=1,
-        order_maker="buyer",
+        order_maker="http://seller.example:8001",
         order_taker=None,
         matched_offer_id=None,
         maker_attestation=None,
@@ -336,7 +340,7 @@ async def test_accept_offer_updates_buyer_order_only(monkeypatch, tmp_path):
 
     order_dict = {
         "order_id": order_id,
-        "order_maker": "buyer",
+        "order_maker": "http://seller.example:8001",
         "offer_resource": _token_rate(1_000_000).model_dump(mode="json"),
         "demand_resource": _compute_resource().model_dump(mode="json"),
         "duration_hours": 1,
@@ -525,7 +529,15 @@ def test_create_order_surplus_oracle_address_is_none(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_accept_offer_passes_oracle_address_to_escrow(monkeypatch):
-    """oracle_address on the order is forwarded to buy_compute_with_erc20."""
+    """oracle_address (from CONFIG.agent_wallet_address) is forwarded to buy_compute_with_erc20."""
+    import dataclasses
+
+    monkeypatch.setattr(
+        action_executor,
+        "CONFIG",
+        dataclasses.replace(action_executor.CONFIG, agent_wallet_address=BUYER_WALLET),
+    )
+
     captured: dict = {}
 
     async def fake_buy_compute_with_erc20(
@@ -542,7 +554,6 @@ async def test_accept_offer_passes_oracle_address_to_escrow(monkeypatch):
         "offer_resource": _token_rate(1_000_000).model_dump(mode="json"),
         "demand_resource": _compute_resource().model_dump(mode="json"),
         "duration_hours": 1,
-        "oracle_address": BUYER_WALLET,
     }
 
     await action_executor.accept_offer(
@@ -555,33 +566,16 @@ async def test_accept_offer_passes_oracle_address_to_escrow(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_accept_offer_raises_without_oracle_address(monkeypatch):
-    """accept_offer raises ValueError when oracle_address is absent from the order."""
-    async def fake_buy_compute_with_erc20(**_kwargs):
-        return {"log": {"uid": "escrow-xyz"}}
-
-    monkeypatch.setattr(action_executor, "buy_compute_with_erc20", fake_buy_compute_with_erc20)
-
-    order_dict = {
-        "order_id": "order-no-oracle",
-        "order_maker": "seller",
-        "offer_resource": _compute_resource().model_dump(mode="json"),
-        "demand_resource": _token_rate(1_000_000).model_dump(mode="json"),
-        "duration_hours": 1,
-        # oracle_address intentionally absent
-    }
-
-    with pytest.raises(ValueError, match="oracle_address is required"):
-        await action_executor.accept_offer(
-            alkahest_client=_FakeClient({}),
-            ctx=None,
-            parameters={"order": order_dict},
-        )
-
-
-@pytest.mark.asyncio
 async def test_accept_offer_persists_oracle_address_to_db(monkeypatch, tmp_path):
-    """Compute seller (taker) persists oracle_address to the local DB on acceptance."""
+    """oracle_address (from CONFIG) is persisted to the local DB on acceptance."""
+    import dataclasses
+
+    monkeypatch.setattr(
+        action_executor,
+        "CONFIG",
+        dataclasses.replace(action_executor.CONFIG, agent_wallet_address=BUYER_WALLET),
+    )
+
     db_path = str(tmp_path / "agent.db")
     sqlite_client = SQLiteClient(db_path=db_path)
 
@@ -626,7 +620,7 @@ async def test_accept_offer_persists_oracle_address_to_db(monkeypatch, tmp_path)
         demand_resource=_compute_resource().model_dump(mode="json"),
         fulfillment_resource=None,
         duration_hours=1,
-        order_maker="buyer",
+        order_maker="http://seller.example:8001",
         order_taker=None,
         matched_offer_id=None,
         maker_attestation=None,
@@ -636,11 +630,10 @@ async def test_accept_offer_persists_oracle_address_to_db(monkeypatch, tmp_path)
 
     order_dict = {
         "order_id": order_id,
-        "order_maker": "buyer",
+        "order_maker": "http://seller.example:8001",
         "offer_resource": _token_rate(1_000_000).model_dump(mode="json"),
         "demand_resource": _compute_resource().model_dump(mode="json"),
         "duration_hours": 1,
-        "oracle_address": BUYER_WALLET,
     }
 
     await action_executor.accept_offer(

--- a/agent/tests/unit/test_action_executor.py
+++ b/agent/tests/unit/test_action_executor.py
@@ -450,8 +450,8 @@ def test_coerce_agent_reference_to_url_host_port():
 
 
 @pytest.mark.asyncio
-async def test_execute_action_trust_falls_back_for_non_url_counterparty(monkeypatch):
-    """Trust fulfillment should fall back when counterparty ref is not a URL."""
+async def test_execute_action_trust_raises_for_non_url_counterparty(monkeypatch):
+    """Trust fulfillment should raise when counterparty ref cannot be resolved to a URL."""
     async def fake_arbitrate_compute_fulfillment(**_kwargs):
         return {
             "status": "trusted",
@@ -462,15 +462,7 @@ async def test_execute_action_trust_falls_back_for_non_url_counterparty(monkeypa
             "decisions": [{"decision": True, "tx_hash": "0xdead"}],
         }
 
-    captured: dict = {}
-
-    async def fake_send_to_remote_agent(_ctx, _event, agent_url=None):
-        captured["agent_url"] = agent_url
-        return None
-
     monkeypatch.setattr(action_executor, "arbitrate_compute_fulfillment", fake_arbitrate_compute_fulfillment)
-    monkeypatch.setattr(action_executor, "send_to_remote_agent", fake_send_to_remote_agent)
-    monkeypatch.setattr(action_executor, "REMOTE_AGENT_URL_OVERRIDE", "http://fallback.example:9000")
 
     action = Action(
         action_type=ActionType.TRUST_COMPUTE_OBLIGATION_FULFILLMENT,
@@ -482,9 +474,8 @@ async def test_execute_action_trust_falls_back_for_non_url_counterparty(monkeypa
         timestamp=datetime.now(),
     )
 
-    await action_executor.execute_action(action, alkahest_client=None, ctx=_FakeCtx())
-
-    assert captured["agent_url"] == "http://fallback.example:9000"
+    with pytest.raises(ValueError, match="unresolved counterparty"):
+        await action_executor.execute_action(action, alkahest_client=None, ctx=_FakeCtx())
 
 
 # ---------------------------------------------------------------------------

--- a/agent/tests/unit/test_counterparty_url_chain.py
+++ b/agent/tests/unit/test_counterparty_url_chain.py
@@ -1,0 +1,323 @@
+"""Tests verifying counterparty URL propagation through the full Alice↔Bob flow.
+
+The chain being tested:
+  1. Bob (seller) receives Alice's offer → mo_action_accept_offer sets
+     counterparty_url = order.order_maker (Alice's URL)
+  2. Alice receives acceptance → ao_action_fulfill_after_accept sets
+     counterparty_url = order.order_taker (Bob's URL, stamped by accept_offer)
+  3. fulfill_compute_obligation result carries fulfilling_party_url = order_maker
+     (Bob's URL, so Alice knows who to thank)
+  4. Alice receives fulfillment → rcf_action_trust_fulfillment sets
+     counterparty_url = event.fulfilling_party_url (Bob's URL)
+"""
+
+from datetime import datetime
+
+import pytest
+
+from core.agent.app.schema.pydantic_models import (
+    AcceptOfferEvent,
+    ComputeResource,
+    DecisionContext,
+    ERC20TokenMetadata,
+    GPUModel,
+    MarketOrder,
+    ReceiveComputeObligationFulfillmentEvent,
+    Region,
+    TokenResource,
+)
+from core.agent.app.utils import action_executor
+from core.agent.app.utils.sqlite_client import SQLiteClient
+from domain.compute.agent.app.policy.store import (
+    ao_action_fulfill_after_accept,
+    mo_action_accept_offer,
+    rcf_action_trust_fulfillment,
+)
+
+
+ALICE_URL = "http://alice.example:8000"
+BOB_URL = "http://bob.example:8001"
+
+USDT = ERC20TokenMetadata(
+    symbol="USDT",
+    contract_address="0xdac17f958d2ee523a2206206994597c13d831ec7",
+    decimals=6,
+)
+
+
+def _compute() -> ComputeResource:
+    return ComputeResource(
+        gpu_model=GPUModel.H200,
+        quantity=1,
+        sla=99.0,
+        region=Region.CALIFORNIA_US,
+    )
+
+
+def _tokens(amount: int = 1_000_000) -> TokenResource:
+    return TokenResource(token=USDT, amount=amount)
+
+
+def _alice_order(*, order_taker: str | None = None) -> MarketOrder:
+    """Alice's token-offering (buy-compute) order."""
+    return MarketOrder(
+        order_id="alice-order-1",
+        order_maker=ALICE_URL,
+        order_taker=order_taker,
+        offer_resource=_tokens(),
+        demand_resource=_compute(),
+        duration_hours=1,
+        oracle_address="0xAliceWallet",
+    )
+
+
+def _bob_order() -> MarketOrder:
+    """Bob's compute-offering (sell-compute) order."""
+    return MarketOrder(
+        order_id="bob-order-1",
+        order_maker=BOB_URL,
+        offer_resource=_compute(),
+        demand_resource=_tokens(),
+        duration_hours=1,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Step 1: Bob receives Alice's offer → ACCEPT_OFFER action carries Alice's URL
+# ---------------------------------------------------------------------------
+
+def test_mo_action_accept_offer_sets_counterparty_to_order_maker():
+    """mo_action_accept_offer wires counterparty_url from order.order_maker (Alice's URL)."""
+    from core.agent.app.schema.pydantic_models import MakeOfferEvent
+
+    event = MakeOfferEvent(
+        event_id="evt-1",
+        source=ALICE_URL,
+        order=_alice_order(),
+    )
+    ctx = DecisionContext(event=event, agent_id="bob-agent")
+    action = mo_action_accept_offer(ctx)
+
+    assert action is not None
+    assert action.parameters["counterparty_url"] == ALICE_URL
+
+
+# ---------------------------------------------------------------------------
+# Step 2: Alice receives Bob's acceptance → FULFILL_COMPUTE_OBLIGATION carries Bob's URL
+# ---------------------------------------------------------------------------
+
+def test_ao_action_fulfill_sets_counterparty_to_order_taker():
+    """ao_action_fulfill_after_accept wires counterparty_url from order.order_taker (Bob's URL)."""
+    # Alice's order now has order_taker = Bob (stamped by accept_offer)
+    alice_order_accepted = _alice_order(order_taker=BOB_URL)
+    event = AcceptOfferEvent(
+        event_id="evt-2",
+        source=BOB_URL,
+        order=alice_order_accepted,
+        escrow_uid="escrow-123",
+        ssh_public_key="ssh-rsa AAA",
+    )
+    ctx = DecisionContext(event=event, agent_id="alice-agent")
+    action = ao_action_fulfill_after_accept(ctx)
+
+    assert action is not None
+    assert action.parameters["counterparty_url"] == BOB_URL
+
+
+# ---------------------------------------------------------------------------
+# Step 3: fulfill_compute_obligation result carries fulfilling_party_url
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_fulfill_compute_obligation_result_includes_fulfilling_party_url(
+    monkeypatch, tmp_path
+):
+    """fulfill_compute_obligation embeds fulfilling_party_url = order_maker in its result."""
+    db_path = str(tmp_path / "agent.db")
+    sqlite_client = SQLiteClient(db_path=db_path)
+
+    async def fake_provision_machine(_ssh_public_key, *, vm_host="vm1", vm_target="tenant-vm"):
+        return "user@host.example.net"
+
+    def fake_schedule_vm_shutdown(_lease_end_utc, *, vm_host="vm1", vm_target="tenant-vm"):
+        return None
+
+    monkeypatch.setattr(action_executor, "provision_machine", fake_provision_machine)
+    monkeypatch.setattr(action_executor, "mock_provision_machine", fake_provision_machine)
+    monkeypatch.setattr(action_executor, "schedule_vm_shutdown", fake_schedule_vm_shutdown)
+    monkeypatch.setattr(action_executor, "mock_schedule_vm_shutdown", fake_schedule_vm_shutdown)
+    monkeypatch.setattr(action_executor, "get_sqlite_client", lambda: sqlite_client)
+
+    class _RegistryClient:
+        async def update_order(self, *_args, **_kwargs):
+            return {"ok": True}
+
+    monkeypatch.setattr(action_executor, "get_registry_client", lambda: _RegistryClient())
+
+    order_id = "bob-order-fulfill"
+    order_dict = {
+        "order_id": order_id,
+        "order_maker": BOB_URL,
+        "offer_resource": _compute().model_dump(mode="json"),
+        "demand_resource": _tokens().model_dump(mode="json"),
+        "duration_hours": 1,
+    }
+
+    await sqlite_client.upsert_order(
+        order_id=order_id,
+        status="open",
+        created_at=datetime.now().isoformat(),
+        updated_at=datetime.now().isoformat(),
+        offer_resource=order_dict["offer_resource"],
+        demand_resource=order_dict["demand_resource"],
+        fulfillment_resource=None,
+        duration_hours=1,
+        order_maker=BOB_URL,
+        order_taker=None,
+        matched_offer_id=None,
+        maker_attestation=None,
+        taker_attestation=None,
+        escrow_uid=None,
+    )
+    await sqlite_client.upsert_resource(
+        resource_id="resource-1",
+        resource_type="compute.gpu",
+        resource_subtype="h200",
+        state="available",
+        attributes={"gpu_model": "H200", "region": "California, US", "vm_host": "vm1"},
+    )
+
+    result = await action_executor.fulfill_compute_obligation(
+        client=None,
+        escrow_uid="escrow-456",
+        ssh_public_key="ssh-rsa AAA",
+        order=order_dict,
+    )
+
+    assert result.get("fulfilling_party_url") == BOB_URL
+
+
+# ---------------------------------------------------------------------------
+# Step 4: Alice receives fulfillment → TRUST action carries Bob's URL
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Step 2b: accept_offer stamps order_taker with the taker's own URL
+# (This is the URL the seller will later use as counterparty in FULFILL step)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_accept_offer_stamps_order_taker_with_own_url(monkeypatch):
+    """accept_offer sets order_taker = BASE_URL_OVERRIDE so the seller knows where to send fulfillment."""
+    import dataclasses
+
+    monkeypatch.setattr(
+        action_executor,
+        "CONFIG",
+        dataclasses.replace(action_executor.CONFIG, agent_wallet_address="0xBobWallet"),
+    )
+    monkeypatch.setattr(action_executor, "BASE_URL_OVERRIDE", BOB_URL)
+
+    captured: dict = {}
+
+    async def fake_buy_compute_with_erc20(**_kwargs):
+        return {"log": {"uid": "escrow-stamp-test"}}
+
+    async def fake_send_to_remote_agent(_ctx, event, agent_url=None):
+        captured["event_offer"] = event.content.parts[0].function_response.response.get("offer", {})
+
+    monkeypatch.setattr(action_executor, "buy_compute_with_erc20", fake_buy_compute_with_erc20)
+    monkeypatch.setattr(action_executor, "send_to_remote_agent", fake_send_to_remote_agent)
+    monkeypatch.setattr(action_executor, "NegotiationThreadTransaction", lambda *_a, **_kw: _DummyTxn())
+    monkeypatch.setattr(action_executor, "get_sqlite_client", lambda: _NullSqliteClient())
+
+    class _RegistryClient:
+        async def update_order(self, *_a, **_kw):
+            return {"ok": True}
+
+    monkeypatch.setattr(action_executor, "get_registry_client", lambda: _RegistryClient())
+
+    order_dict = {
+        "order_id": "alice-order-stamp",
+        "order_maker": ALICE_URL,
+        "offer_resource": _tokens().model_dump(mode="json"),
+        "demand_resource": _compute().model_dump(mode="json"),
+        "duration_hours": 1,
+    }
+
+    class _FakeCtx:
+        invocation_id = "inv-1"
+        branch = "main"
+
+    await action_executor.accept_offer(
+        alkahest_client=_FakeClient(),
+        ctx=_FakeCtx(),
+        parameters={"order": order_dict},
+    )
+
+    assert captured["event_offer"]["order_taker"] == BOB_URL
+
+
+class _DummyTxn:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_):
+        return False
+
+    async def cancel_competing(self, *_a, **_kw):
+        return None
+
+    async def mark_terminal(self, *_a, **_kw):
+        return None
+
+
+class _NullSqliteClient:
+    async def update_order(self, *_a, **_kw):
+        return None
+
+    async def find_symmetric_open_order(self, *_a, **_kw):
+        return None
+
+
+class _FakeClient:
+    class _Util:
+        async def approve(self, *_a, **_kw):
+            return "approved"
+
+    class _ERC20:
+        def __init__(self):
+            class _NonTierable:
+                async def create(self, *_a, **_kw):
+                    return {"log": {"uid": "escrow-stamp-test"}}
+
+            class _Escrow:
+                def __init__(self):
+                    self.non_tierable = _NonTierable()
+
+            self.escrow = _Escrow()
+            self.util = _FakeClient._Util()
+
+    def __init__(self):
+        self.erc20 = self._ERC20()
+
+
+# ---------------------------------------------------------------------------
+# Step 4: Alice receives fulfillment → TRUST action carries Bob's URL
+# ---------------------------------------------------------------------------
+
+def test_rcf_action_trust_sets_counterparty_from_fulfilling_party_url():
+    """rcf_action_trust_fulfillment wires counterparty_url from fulfilling_party_url (Bob's URL)."""
+    event = ReceiveComputeObligationFulfillmentEvent(
+        event_id="evt-4",
+        source=BOB_URL,
+        escrow_uid="escrow-123",
+        fulfillment_uid="ful-123",
+        connection_details="user@host.example.net",
+        fulfilling_party_url=BOB_URL,
+    )
+    ctx = DecisionContext(event=event, agent_id="alice-agent")
+    action = rcf_action_trust_fulfillment(ctx)
+
+    assert action is not None
+    assert action.parameters["counterparty_url"] == BOB_URL

--- a/core/agent/.env.sample
+++ b/core/agent/.env.sample
@@ -1,8 +1,6 @@
 GEMINI_API_KEY=AIxx
 BASE_URL_OVERRIDE=http://localhost:8000/
 PORT=8000
-REMOTE_AGENT_URL_OVERRIDE=http://localhost:8001
-ENABLE_EVENT_QUEUE=False
 AGENT_DB_PATH=./agent.db
 AGENT_ID=agent_xxx
 LOG_FILE_PATH=./logs/maker_agent.log

--- a/core/agent/app/schema/pydantic_models.py
+++ b/core/agent/app/schema/pydantic_models.py
@@ -377,6 +377,10 @@ class ReceiveComputeObligationFulfillmentEvent(DomainEvent):
         default=None,
         description="Connection string/details for the provisioned compute",
     )
+    fulfilling_party_url: str | None = Field(
+        default=None,
+        description="URL of the compute seller who fulfilled the obligation",
+    )
 
     @classmethod
     def from_payload(cls, payload: dict[str, Any]) -> "ReceiveComputeObligationFulfillmentEvent":
@@ -389,6 +393,7 @@ class ReceiveComputeObligationFulfillmentEvent(DomainEvent):
             escrow_uid=escrow_uid,
             fulfillment_uid=payload.get("fulfillment_uid"),
             connection_details=payload.get("connection_details"),
+            fulfilling_party_url=payload.get("fulfilling_party_url"),
             data=payload,
         )
 

--- a/core/agent/app/schema/pydantic_models.py
+++ b/core/agent/app/schema/pydantic_models.py
@@ -216,6 +216,10 @@ class MarketOrder(BaseModel):
         default=None,
         description="The attestation of the satisfied demand in escrow (None for open orders)",
     )
+    oracle_address: str | None = Field(
+        default=None,
+        description="The oracle wallet address used for arbitration and escrow workflows",
+    )
 
     @model_validator(mode="before")
     @classmethod
@@ -315,6 +319,7 @@ class MakeOfferEvent(DomainEvent):
                 "offer_resource": order.offer_resource.model_dump(mode="json"),
                 "demand_resource": order.demand_resource.model_dump(mode="json"),
                 "duration_hours": order.duration_hours,
+                "oracle_address": order.oracle_address,
             },
         )
 
@@ -354,6 +359,7 @@ class AcceptOfferEvent(DomainEvent):
                 "duration_hours": order.duration_hours,
                 "escrow_uid": escrow_uid,
                 "ssh_public_key": ssh_public_key,
+                "oracle_address": order.oracle_address,
             },
         )
 

--- a/core/agent/app/utils/action_executor.py
+++ b/core/agent/app/utils/action_executor.py
@@ -298,13 +298,12 @@ async def execute_action(
                         order_dict = order_obj.model_dump(mode="json") if order_obj else {}
                     else:
                         order_dict = {}
-                    counterparty_ref = order_dict.get("order_taker") if order_dict else None
+                    counterparty_ref = parameters.get("counterparty_url") or (order_dict.get("order_taker") if order_dict else None)
                     counterparty_url = _coerce_agent_reference_to_url(counterparty_ref)
-                    if not counterparty_url or not str(counterparty_url).strip():
-                        logger.warning(
-                            "[A2A] fulfill_compute_obligation: unresolved counterparty URL from order_taker=%s; parameters keys=%s",
-                            counterparty_ref,
-                            list(parameters.keys()),
+                    if not counterparty_url:
+                        raise ValueError(
+                            f"fulfill_compute_obligation: cannot notify buyer — "
+                            f"unresolved counterparty={counterparty_ref!r}"
                         )
                     try:
                         event = Event(
@@ -321,7 +320,7 @@ async def execute_action(
                             invocation_id=ctx.invocation_id,
                             branch=ctx.branch,
                         )
-                        await send_to_remote_agent(ctx, event, agent_url=counterparty_url or None)
+                        await send_to_remote_agent(ctx, event, agent_url=counterparty_url)
                     except Exception as send_err:
                         logger.warning("[ACTION] Failed to send fulfillment to remote agent: %s", send_err)
             else:
@@ -1003,16 +1002,14 @@ async def accept_offer(
             logger.debug(f"[REGISTRY] Update order traceback: {traceback.format_exc()}")
 
     # Counterparty to notify is the order maker (we are the taker accepting their offer).
-    counterparty_ref = order_dict.get("order_maker") or parameters.get("their_agent_id")
+    counterparty_ref = parameters.get("counterparty_url") or order_dict.get("order_maker")
     counterparty_url = _coerce_agent_reference_to_url(counterparty_ref)
-    if not counterparty_url or not counterparty_url.strip():
-        logger.warning(
-            "[A2A] accept_offer: unresolved counterparty reference from order_maker/their_agent_id=%s; order_dict keys=%s",
-            counterparty_ref,
-            list(order_dict.keys()),
+    if not counterparty_url:
+        raise ValueError(
+            f"accept_offer: cannot send acceptance — unresolved counterparty={counterparty_ref!r}"
         )
     try:
-        result = await send_to_remote_agent(ctx, event, agent_url=counterparty_url or None)
+        result = await send_to_remote_agent(ctx, event, agent_url=counterparty_url)
         return {
             "status": "sent",
             "message": "Offer accepted and forwarded to counterparty",
@@ -1796,6 +1793,7 @@ async def fulfill_compute_obligation(
         "fulfillment_uid": fulfillment_uid,
         "connection_details": connection_details,
         "ssh_public_key": ssh_public_key,
+        "fulfilling_party_url": (order_dict or {}).get("order_maker"),
     }
 
 async def arbitrate_compute_fulfillment(

--- a/core/agent/app/utils/action_executor.py
+++ b/core/agent/app/utils/action_executor.py
@@ -388,7 +388,7 @@ oracle_address = parameters.get("oracle_address") or order_dict.get("oracle_addr
                         invocation_id=ctx.invocation_id,
                         branch=ctx.branch,
                     )
-                    await send_to_remote_agent(ctx, event, agent_url=counterparty_url or None)
+                    await send_to_remote_agent(ctx, event, agent_url=counterparty_url)
                 except Exception as send_err:
                     logger.warning("[ACTION] Failed to send arbitration result to remote agent: %s", send_err)
             outcome["result"] = result

--- a/core/agent/app/utils/action_executor.py
+++ b/core/agent/app/utils/action_executor.py
@@ -57,9 +57,7 @@ from core.agent.app.policy.action_builders import CounterOfferParams
 from .validation import determine_strategy_from_order
 
 BASE_URL_OVERRIDE = CONFIG.base_url_override
-REMOTE_AGENT_URL_OVERRIDE = CONFIG.remote_agent_url_override
 PORT = CONFIG.port
-REMOTE_AGENT_PORT = CONFIG.remote_agent_port
 AGENT_ID = CONFIG.agent_id
 SSH_PUBLIC_KEY = CONFIG.ssh_public_key
 
@@ -363,17 +361,11 @@ async def execute_action(
                 # Counterparty to notify is whoever sent the fulfillment (source of the trust action).
                 counterparty_ref = parameters.get("counterparty_url") or parameters.get("agent_url")
                 counterparty_url = _coerce_agent_reference_to_url(counterparty_ref)
-                if not counterparty_url or not str(counterparty_url).strip():
-                    logger.warning(
-                        "[A2A] trust_compute_obligation_fulfillment: unresolved counterparty reference=%s",
-                        counterparty_ref,
+                if not counterparty_url:
+                    raise ValueError(
+                        f"trust_compute_obligation_fulfillment: cannot send arbitration result — "
+                        f"unresolved counterparty reference={counterparty_ref!r}"
                     )
-                    if REMOTE_AGENT_URL_OVERRIDE:
-                        counterparty_url = REMOTE_AGENT_URL_OVERRIDE
-                        logger.warning(
-                            "[A2A] trust_compute_obligation_fulfillment: using REMOTE_AGENT_URL_OVERRIDE fallback=%s",
-                            counterparty_url,
-                        )
                 try:
                     event = Event(
                         author=AGENT_ID,
@@ -474,32 +466,11 @@ async def execute_action(
 
 
 def connect_to_remote_agent(agent_url: str | None = None):
-    """Connect to a remote agent by URL.
-
-    Args:
-        agent_url: Agent URL (defaults to REMOTE_AGENT_URL_OVERRIDE for backward compatibility)
-
-    Warning:
-        If agent_url is None, falls back to REMOTE_AGENT_URL_OVERRIDE which may misroute
-        counter-offers in staging environments.
-    """
+    """Connect to a remote agent by URL."""
     if agent_url is None:
-        logger.warning(
-            "[A2A] No agent_url provided, falling back to REMOTE_AGENT_URL_OVERRIDE. "
-            "This may misroute messages in staging environments."
-        )
-        if logger.isEnabledFor(logging.DEBUG):
-            logger.debug("[A2A] Fallback call stack:\n%s", "".join(traceback.format_stack(limit=8)[:-1]))
-        agent_url = REMOTE_AGENT_URL_OVERRIDE
+        raise ValueError("[A2A] send_to_remote_agent called with no agent_url")
     resolved_agent_url = _coerce_agent_reference_to_url(agent_url)
-    if not resolved_agent_url:
-        logger.warning(
-            "[A2A] Invalid agent_url reference '%s'. Falling back to REMOTE_AGENT_URL_OVERRIDE=%s",
-            agent_url,
-            REMOTE_AGENT_URL_OVERRIDE,
-        )
-        resolved_agent_url = REMOTE_AGENT_URL_OVERRIDE
-    if not _is_http_url(resolved_agent_url):
+    if not resolved_agent_url or not _is_http_url(resolved_agent_url):
         raise ValueError(f"Unable to resolve valid remote agent URL from reference '{agent_url}'")
     agent_url = resolved_agent_url
     agent_card_url = f"{agent_url.rstrip('/')}{AGENT_CARD_WELL_KNOWN_PATH}"
@@ -764,14 +735,10 @@ async def counter_offer(
 
         # Validate that we have a valid agent URL for the counterparty
         if not their_agent_id:
-            logger.warning(
-                f"[ACTION] Order {params.order_id} missing 'order_maker' field. "
-                f"Counter-offer may be misrouted to fallback REMOTE_AGENT_URL_OVERRIDE"
-            )
+            logger.warning(f"[ACTION] Order {params.order_id} missing 'order_maker' field.")
         elif not their_agent_id.startswith(("http://", "https://")):
             logger.warning(
-                f"[ACTION] Order {params.order_id} has invalid 'order_maker' URL: {their_agent_id}. "
-                f"Counter-offer may be misrouted to fallback REMOTE_AGENT_URL_OVERRIDE"
+                f"[ACTION] Order {params.order_id} has invalid 'order_maker' URL: {their_agent_id}"
             )
 
         # Determine our strategy by looking up our order (for internal policy use)
@@ -1359,7 +1326,6 @@ async def make_offer(ctx: InvocationContext, order: MarketOrder | dict, alkahest
     """Propagate an offer to the network using registry discovery.
     
     Queries the registry for matching orders and sends offers to discovered agents.
-    Falls back to REMOTE_AGENT_URL_OVERRIDE if registry discovery is disabled or fails.
     
     Args:
         ctx: Invocation context
@@ -1476,18 +1442,9 @@ async def make_offer(ctx: InvocationContext, order: MarketOrder | dict, alkahest
         elif result.get("status") == "no_delivery":
             return result
         elif result.get("status") == "error":
-            logger.warning(f"[REGISTRY] Registry discovery failed: {result.get('message')}, falling back to default")
+            raise RuntimeError(f"Registry discovery failed: {result.get('message')}")
         else:
-            logger.warning(f"[REGISTRY] Unexpected result status: {result.get('status')}, falling back to default")
-    
-    # Fallback to hard-coded remote agent URL (backward compatibility)
-    try:
-        logger.info(f"[A2A] Using fallback: sending to {REMOTE_AGENT_URL_OVERRIDE}")
-        result = await send_to_remote_agent(ctx, event)
-        return result
-    except Exception as e:
-        logger.error(f"[TOOL] Failed to make offer: {e}")
-        raise
+            raise RuntimeError(f"Registry discovery returned unexpected status: {result.get('status')}")
 
 
 def encode_compute_lease(

--- a/core/agent/app/utils/action_executor.py
+++ b/core/agent/app/utils/action_executor.py
@@ -844,9 +844,9 @@ async def accept_offer(
     # - If maker offers tokens (deficit): taker buys compute (demand_resource) and pays tokens (offer_resource)
     escrow_uid = None
     escrow_receipt = None
+    oracle_address = CONFIG.agent_wallet_address
 
     if alkahest_client:
-        oracle_address = CONFIG.agent_wallet_address
 
         compute_resource, token_resource = extract_compute_and_token_from_order_dict(order_dict)
 

--- a/core/agent/app/utils/action_executor.py
+++ b/core/agent/app/utils/action_executor.py
@@ -273,8 +273,9 @@ async def execute_action(
             escrow_uid = parameters.get("escrow_uid")
             ssh_public_key = parameters.get("ssh_public_key")
             order = parameters.get("order")
-order_dict = order if isinstance(order, dict) else {}
-oracle_address = parameters.get("oracle_address") or order_dict.get("oracle_address")
+            order_dict = order if isinstance(order, dict) else {}
+            oracle_address = parameters.get("oracle_address") or order_dict.get("oracle_address")
+            
             if not escrow_uid:
                 raise ValueError("escrow_uid is required for fulfill_compute_obligation")
             if not ssh_public_key:

--- a/core/agent/app/utils/action_executor.py
+++ b/core/agent/app/utils/action_executor.py
@@ -63,12 +63,6 @@ REMOTE_AGENT_PORT = CONFIG.remote_agent_port
 AGENT_ID = CONFIG.agent_id
 SSH_PUBLIC_KEY = CONFIG.ssh_public_key
 
-# TODO: Make this a lookup!
-# LOCAL ANVIL
-DEMO_ORACLE_ADDRESS = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
-# BASE SEPOLIA
-# DEMO_ORACLE_ADDRESS = "0x8C523BC3EA8AC363E0b58Fd6cefff706D7885B3e"
-
 logger = logging.getLogger(__name__)
 
 
@@ -99,10 +93,6 @@ def _serialize_decisions(decisions: Any) -> list[Any]:
         return [_serialize_decision(d) for d in decisions]
     return [_serialize_decision(decisions)]
 
-
-def _resolve_oracle_address(oracle_address: str | None) -> str:
-    """Return the oracle signer address."""
-    return oracle_address or DEMO_ORACLE_ADDRESS
 
 
 def _is_http_url(value: str | None) -> bool:
@@ -247,6 +237,7 @@ async def execute_action(
                         matched_offer_id=parameters.get("matched_offer_id"),
                         maker_attestation=order.get("maker_attestation"),
                         taker_attestation=order.get("taker_attestation"),
+                        oracle_address=order.get("oracle_address"),
                         escrow_uid=None,
                     )
                 except Exception as exc:
@@ -293,7 +284,7 @@ async def execute_action(
             result = await fulfill_compute_obligation(
                 client=alkahest_client,
                 escrow_uid=escrow_uid,
-                oracle_address=_resolve_oracle_address(parameters.get("oracle_address")),
+                oracle_address=parameters.get("oracle_address"),
                 ssh_public_key=ssh_public_key,
                 order=order,
             )
@@ -348,7 +339,7 @@ async def execute_action(
             result = await arbitrate_compute_fulfillment(
                 client=alkahest_client,
                 fulfillment_uid=parameters.get("fulfillment_uid"),
-                oracle_address=_resolve_oracle_address(parameters.get("oracle_address")),
+                oracle_address=parameters.get("oracle_address"),
                 escrow_uid=parameters.get("escrow_uid"),
             )
             logger.info(f"[ALKAHEST]: {result}")
@@ -888,8 +879,12 @@ async def accept_offer(
     escrow_receipt = None
     
     if alkahest_client:
+        oracle_address = order_dict.get("oracle_address")
+        if not oracle_address:
+            raise ValueError("oracle_address is required on the order to create an escrow")
+
         compute_resource, token_resource = extract_compute_and_token_from_order_dict(order_dict)
-        
+
         # Retry logic with exponential backoff
         max_retries = 3
         base_delay = 1.0  # seconds
@@ -901,7 +896,7 @@ async def accept_offer(
                     compute_resource=compute_resource,
                     token_resource=token_resource,
                     duration_hours=order_dict.get("duration_hours", 1),
-                    oracle_address=DEMO_ORACLE_ADDRESS,
+                    oracle_address=oracle_address,
                     client=alkahest_client,
                 )
                 escrow_uid = escrow_receipt.get("log", {}).get("uid")
@@ -1007,6 +1002,7 @@ async def accept_offer(
                 taker_attestation=escrow_uid,
                 escrow_uid=escrow_uid,
                 matched_offer_id=their_order_id,
+                oracle_address=order_dict.get("oracle_address"),
             )
     except Exception as exc:
         logger.warning("[LOCAL DB] Failed to update order %s as accepted: %s", our_order_id, exc)
@@ -1136,6 +1132,9 @@ def create_order(
                 amount=9 * 10**settlement_token.decimals,
             )
     
+    # Token offerer (deficit) sets their own wallet as oracle so both sides agree on the oracle.
+    oracle_address = CONFIG.agent_wallet_address if imbalance_type == "deficit" else None
+
     order = MarketOrder(
         order_id=str(uuid.uuid4()),
         order_maker=BASE_URL_OVERRIDE,
@@ -1144,7 +1143,8 @@ def create_order(
         demand_resource=demand_resource,
         duration_hours=duration_hours,
         maker_attestation=None,
-        taker_attestation=None
+        taker_attestation=None,
+        oracle_address=oracle_address,
     )
 
     order_dict = order.model_dump(mode='json')
@@ -1661,7 +1661,6 @@ async def fulfill_compute_obligation(
     
     When the maker fulfills, this sets maker_attestation in the registry.
     """
-    oracle_address = _resolve_oracle_address(oracle_address)
     fulfillment_uid = None
     maker_attestation = None
     duration_hours = 1
@@ -1844,7 +1843,6 @@ async def arbitrate_compute_fulfillment(
     oracle_address: str | None,
     escrow_uid: str | None = None,
 ):
-    oracle_address = _resolve_oracle_address(oracle_address)
     logger.info(f"[ALKAHEST] Oracle address: {oracle_address}")
     
     async def decision_function(attestation, demand):

--- a/core/agent/app/utils/action_executor.py
+++ b/core/agent/app/utils/action_executor.py
@@ -273,7 +273,8 @@ async def execute_action(
             escrow_uid = parameters.get("escrow_uid")
             ssh_public_key = parameters.get("ssh_public_key")
             order = parameters.get("order")
-
+order_dict = order if isinstance(order, dict) else {}
+oracle_address = parameters.get("oracle_address") or order_dict.get("oracle_address")
             if not escrow_uid:
                 raise ValueError("escrow_uid is required for fulfill_compute_obligation")
             if not ssh_public_key:

--- a/core/agent/app/utils/action_executor.py
+++ b/core/agent/app/utils/action_executor.py
@@ -845,9 +845,10 @@ async def accept_offer(
     escrow_uid = None
     escrow_receipt = None
     oracle_address = CONFIG.agent_wallet_address
+    if not oracle_address:
+        raise ValueError("Agent wallet address is required for accept_offer but not configured")
 
     if alkahest_client:
-
         compute_resource, token_resource = extract_compute_and_token_from_order_dict(order_dict)
 
         # Retry logic with exponential backoff

--- a/core/agent/app/utils/action_executor.py
+++ b/core/agent/app/utils/action_executor.py
@@ -284,7 +284,7 @@ async def execute_action(
             result = await fulfill_compute_obligation(
                 client=alkahest_client,
                 escrow_uid=escrow_uid,
-                oracle_address=parameters.get("oracle_address"),
+                oracle_address=parameters.get("oracle_address") or (order if isinstance(order, dict) else {}).get("oracle_address"),
                 ssh_public_key=ssh_public_key,
                 order=order,
             )
@@ -336,10 +336,12 @@ async def execute_action(
 
         case ActionType.TRUST_COMPUTE_OBLIGATION_FULFILLMENT.value:
             logger.info(f"[ACTION] Trusting compute fulfillment with params: {parameters}")
+            # The agent trusting a fulfillment is always the oracle (token buyer).
+            oracle_address = parameters.get("oracle_address") or CONFIG.agent_wallet_address
             result = await arbitrate_compute_fulfillment(
                 client=alkahest_client,
                 fulfillment_uid=parameters.get("fulfillment_uid"),
-                oracle_address=parameters.get("oracle_address"),
+                oracle_address=oracle_address,
                 escrow_uid=parameters.get("escrow_uid"),
             )
             logger.info(f"[ALKAHEST]: {result}")
@@ -877,11 +879,9 @@ async def accept_offer(
     # - If maker offers tokens (deficit): taker buys compute (demand_resource) and pays tokens (offer_resource)
     escrow_uid = None
     escrow_receipt = None
-    
+
     if alkahest_client:
-        oracle_address = order_dict.get("oracle_address")
-        if not oracle_address:
-            raise ValueError("oracle_address is required on the order to create an escrow")
+        oracle_address = CONFIG.agent_wallet_address
 
         compute_resource, token_resource = extract_compute_and_token_from_order_dict(order_dict)
 
@@ -929,6 +929,7 @@ async def accept_offer(
     # Stamp taker metadata onto the order.
     order_dict["order_taker"] = BASE_URL_OVERRIDE
     order_dict["taker_attestation"] = escrow_uid
+    order_dict["oracle_address"] = oracle_address
 
     event_payload = {
         "event_type": EventType.ACCEPT_OFFER.value,
@@ -1002,7 +1003,7 @@ async def accept_offer(
                 taker_attestation=escrow_uid,
                 escrow_uid=escrow_uid,
                 matched_offer_id=their_order_id,
-                oracle_address=order_dict.get("oracle_address"),
+                oracle_address=oracle_address,
             )
     except Exception as exc:
         logger.warning("[LOCAL DB] Failed to update order %s as accepted: %s", our_order_id, exc)
@@ -1132,8 +1133,11 @@ def create_order(
                 amount=9 * 10**settlement_token.decimals,
             )
     
-    # Token offerer (deficit) sets their own wallet as oracle so both sides agree on the oracle.
-    oracle_address = CONFIG.agent_wallet_address if imbalance_type == "deficit" else None
+    # The token-offering side is always the oracle/buyer.
+    offering_tokens = isinstance(offer_resource, TokenResource) or (
+        isinstance(offer_resource, dict) and "token" in offer_resource
+    )
+    oracle_address = CONFIG.agent_wallet_address if offering_tokens else None
 
     order = MarketOrder(
         order_id=str(uuid.uuid4()),

--- a/core/agent/app/utils/action_executor.py
+++ b/core/agent/app/utils/action_executor.py
@@ -837,9 +837,6 @@ async def accept_offer(
         logger.warning("[TOOL] Cannot accept offer: no order payload provided.")
         return {"status": "error", "message": "Missing order payload for accept_offer"}
 
-    escrow_uid = None
-    escrow_receipt = None
-
     # If alkahest_client provided, attempt on-chain buy to escrow tokens with retry logic.
     # When accepting an offer, the taker is buying compute and paying tokens.
     # The mapping depends on what the maker is offering:

--- a/core/agent/app/utils/config.py
+++ b/core/agent/app/utils/config.py
@@ -109,8 +109,6 @@ class Config:
     base_url_override_raw: str
     base_url_override: str
     port: int
-    remote_agent_port: int
-    remote_agent_url_override: str
     chain_rpc_url: str
     agent_priv_key: str
     agent_wallet_address: str
@@ -193,10 +191,6 @@ def load_config() -> Config:
         base_url_override_raw=base_url_override_raw,
         base_url_override=base_url_override_resolved,
         port=_get_int_env("PORT", 8000),
-        remote_agent_port=_get_int_env("REMOTE_AGENT_PORT", 8000),
-        remote_agent_url_override=os.getenv(
-            "REMOTE_AGENT_URL_OVERRIDE", "http://localhost:8001"
-        ),
         chain_rpc_url=os.getenv("CHAIN_RPC_URL"),
         agent_priv_key=os.getenv("AGENT_PRIV_KEY"),
         agent_wallet_address=os.getenv("AGENT_WALLET_ADDRESS"),

--- a/core/agent/app/utils/sqlite_client.py
+++ b/core/agent/app/utils/sqlite_client.py
@@ -156,7 +156,8 @@ class SQLiteClient:
                   matched_offer_id TEXT,
                   maker_attestation TEXT,
                   taker_attestation TEXT,
-                  escrow_uid TEXT
+                  escrow_uid TEXT,
+                  oracle_address TEXT
                 )
                 """
             )
@@ -856,6 +857,7 @@ class SQLiteClient:
         maker_attestation: str | None = None,
         taker_attestation: str | None = None,
         escrow_uid: str | None = None,
+        oracle_address: str | None = None,
     ) -> None:
         def _save() -> None:
             conn = sqlite3.connect(self.db_path)
@@ -877,9 +879,10 @@ class SQLiteClient:
                       matched_offer_id,
                       maker_attestation,
                       taker_attestation,
-                      escrow_uid
+                      escrow_uid,
+                      oracle_address
                     )
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     ON CONFLICT(order_id) DO UPDATE SET
                       status=excluded.status,
                       updated_at=excluded.updated_at,
@@ -892,7 +895,8 @@ class SQLiteClient:
                       matched_offer_id=excluded.matched_offer_id,
                       maker_attestation=excluded.maker_attestation,
                       taker_attestation=excluded.taker_attestation,
-                      escrow_uid=excluded.escrow_uid
+                      escrow_uid=excluded.escrow_uid,
+                      oracle_address=excluded.oracle_address
                     """,
                     (
                         order_id,
@@ -909,6 +913,7 @@ class SQLiteClient:
                         maker_attestation,
                         taker_attestation,
                         escrow_uid,
+                        oracle_address,
                     ),
                 )
                 conn.commit()
@@ -933,6 +938,7 @@ class SQLiteClient:
         maker_attestation: str | None = None,
         taker_attestation: str | None = None,
         escrow_uid: str | None = None,
+        oracle_address: str | None = None,
     ) -> None:
         def _save() -> None:
             updates: list[str] = []
@@ -956,6 +962,7 @@ class SQLiteClient:
             add("maker_attestation", maker_attestation)
             add("taker_attestation", taker_attestation)
             add("escrow_uid", escrow_uid)
+            add("oracle_address", oracle_address)
 
             if not updates:
                 return
@@ -982,6 +989,7 @@ class SQLiteClient:
         fulfillment_resource: Any | None = None,
         maker_attestation: str | None = None,
         taker_attestation: str | None = None,
+        oracle_address: str | None = None,
     ) -> None:
         """
         Update order fields based on escrow_uid, when order_id is not available.
@@ -1001,6 +1009,7 @@ class SQLiteClient:
             add("fulfillment_resource", fulfillment_resource, serialize=True)
             add("maker_attestation", maker_attestation)
             add("taker_attestation", taker_attestation)
+            add("oracle_address", oracle_address)
 
             if not updates:
                 return

--- a/domain/compute/agent/app/policy/store.py
+++ b/domain/compute/agent/app/policy/store.py
@@ -162,6 +162,7 @@ def ao_action_fulfill_after_accept(context: DecisionContext) -> DomainAction | N
             "order": context.event.order.model_dump(mode="json"),
             "escrow_uid": escrow_uid,
             "ssh_public_key": ssh_key,
+            "oracle_address": context.event.order.oracle_address,
         },
     )
 

--- a/domain/compute/agent/app/policy/store.py
+++ b/domain/compute/agent/app/policy/store.py
@@ -163,6 +163,7 @@ def ao_action_fulfill_after_accept(context: DecisionContext) -> DomainAction | N
             "escrow_uid": escrow_uid,
             "ssh_public_key": ssh_key,
             "oracle_address": context.event.order.oracle_address,
+            "counterparty_url": context.event.order.order_taker,
         },
     )
 
@@ -178,10 +179,7 @@ def rcf_action_trust_fulfillment(context: DecisionContext) -> DomainAction | Non
             "escrow_uid": context.event.escrow_uid,
             "fulfillment_uid": context.event.fulfillment_uid,
             "connection_details": context.event.connection_details,
-            "counterparty_url": (
-                (getattr(context.event, "data", {}) or {}).get("source_url")
-                or getattr(context.event, "source", None)
-            ),
+            "counterparty_url": context.event.fulfilling_party_url,
         },
     )
 
@@ -536,6 +534,7 @@ def mo_action_accept_offer(context: DecisionContext) -> DomainAction | None:
             "order": order,
             "offer_resource": offer_resource.model_dump(mode='json'),
             "demand_resource": demand_resource.model_dump(mode='json'),
+            "counterparty_url": order.order_maker,
         }
     )
 


### PR DESCRIPTION
# Changes Made
- Added `oracle_address` to schema
- Added behavior where `oracle_address` is set to Buyer's wallet address for both maker (upon creating) and taker (upon accepting)
- Removed placeholder oracle address resolution
- Removed hardcoded counterparty/remote agent fallback from config
- Removed logic paths that use the remote agent fallback
- Added logic for explicitly sending the counterparty URL

# Testing
1. Pre-set-up (contracts, registry indexer, register both agents)
2. Import test resources.
   ```
   market portfolio import-csv app/data/resources.sample.csv -e .env.bob.local
   ```
4. Create buy order.
   ```
   market order create -d '{"gpu_model": "H200", "quantity": 1, "sla": 90.0, "region": "California, US"}' -o '{"token":"MOCK","amount":1.0}' -a http://10.10.10.185:8000
   ```
5. Create sell order.
   ```
   market order create -o '{"gpu_model": "H200", "quantity": 1, "sla": 90.0, "region": "California, US"}' -d '{"token":"MOCK","amount":1.0}' -a http://10.10.10.185:8001
   ```