### PR TITLE
Fix: CI/CD Docker Pipeline and SSH Private Key Injection

### DIFF
--- a/.github/workflows/docker-build-push-async-provisioning.yml
+++ b/.github/workflows/docker-build-push-async-provisioning.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - develop
-      - fix/ci-cd-image-build-pipeline
     paths:
       - 'async-provisioning-service/**'
       - '.github/workflows/docker-build-push-async-provisioning.yml'

--- a/.github/workflows/docker-build-push-async-provisioning.yml
+++ b/.github/workflows/docker-build-push-async-provisioning.yml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:  # Allow manual triggers
 
 env:
-  GAR_REGISTRY: asia-southeast1-docker.pkg.dev
+  GAR_REGISTRY: us-east4-docker.pkg.dev
   GCP_PROJECT_ID: ww-migration-arkhai
   GAR_REPOSITORY: async-provisioning-service
   IMAGE_NAME: async-provisioning-service

--- a/.github/workflows/docker-build-push-async-provisioning.yml
+++ b/.github/workflows/docker-build-push-async-provisioning.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
       - develop
-      - feature/registry-containerization
+      - fix/ci-cd-image-build-pipeline
     paths:
       - 'async-provisioning-service/**'
       - '.github/workflows/docker-build-push-async-provisioning.yml'
@@ -16,8 +16,10 @@ on:
   workflow_dispatch:  # Allow manual triggers
 
 env:
-  DOCKER_REGISTRY_ORG: whitewidget
-  IMAGE_NAME: arkhai-async-provisioning-service
+  GAR_REGISTRY: asia-southeast1-docker.pkg.dev
+  GCP_PROJECT_ID: ww-migration-arkhai
+  GAR_REPOSITORY: async-provisioning-service
+  IMAGE_NAME: async-provisioning-service
   PYTHON_VERSION: "3.13"
   UV_VERSION: "0.10.0"
 
@@ -26,7 +28,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
     
     steps:
       - name: Checkout code
@@ -38,18 +39,24 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to Docker Hub
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Log in to GCP Artifact Registry
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.GAR_REGISTRY }}
+          username: _json_key
+          password: ${{ secrets.GCP_SA_KEY }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: |
-            ${{ env.DOCKER_REGISTRY_ORG }}/${{ env.IMAGE_NAME }}
+            ${{ env.GAR_REGISTRY }}/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY }}/${{ env.IMAGE_NAME }}
           tags: |
             # Branch pushes: use git SHA
             type=sha,format=short,enable=${{ github.ref_type == 'branch' }}
@@ -82,9 +89,9 @@ jobs:
         run: |
           echo "### Docker Image Build Summary :rocket:" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Image:** \`${{ env.DOCKER_REGISTRY_ORG }}/${{ env.IMAGE_NAME }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** \`${{ env.GAR_REGISTRY }}/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY }}/${{ env.IMAGE_NAME }}\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Registry:** Docker Hub" >> $GITHUB_STEP_SUMMARY
+          echo "**Registry:** GCP Artifact Registry" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Tags:**" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
@@ -93,7 +100,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Pull command:**" >> $GITHUB_STEP_SUMMARY
           echo '```bash' >> $GITHUB_STEP_SUMMARY
-          echo "docker pull ${{ env.DOCKER_REGISTRY_ORG }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_STEP_SUMMARY
+          echo "docker pull ${{ env.GAR_REGISTRY }}/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Event:** ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/docker-build-push-erc8004-registry.yml
+++ b/.github/workflows/docker-build-push-erc8004-registry.yml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:  # Allow manual triggers
 
 env:
-  GAR_REGISTRY: asia-southeast1-docker.pkg.dev
+  GAR_REGISTRY: us-east4-docker.pkg.dev
   GCP_PROJECT_ID: ww-migration-arkhai
   GAR_REPOSITORY: erc-8004-registry
   IMAGE_NAME: erc-8004-registry-py

--- a/.github/workflows/docker-build-push-erc8004-registry.yml
+++ b/.github/workflows/docker-build-push-erc8004-registry.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
       - develop
-      - feature/registry-containerization
+      - fix/ci-cd-image-build-pipeline
     paths:
       - 'erc-8004-registry-py/**'
       - '.github/workflows/docker-build-push-erc8004-registry.yml'
@@ -16,8 +16,10 @@ on:
   workflow_dispatch:  # Allow manual triggers
 
 env:
-  DOCKER_REGISTRY_ORG: whitewidget
-  IMAGE_NAME: arkhai-erc-8004-registry
+  GAR_REGISTRY: asia-southeast1-docker.pkg.dev
+  GCP_PROJECT_ID: ww-migration-arkhai
+  GAR_REPOSITORY: erc-8004-registry
+  IMAGE_NAME: erc-8004-registry-py
   PYTHON_VERSION: "3.13"
   UV_VERSION: "0.10.0"
   APP_PORT: "8080"
@@ -28,7 +30,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
     
     steps:
       - name: Checkout code
@@ -37,18 +38,24 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to Docker Hub
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Log in to GCP Artifact Registry
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.GAR_REGISTRY }}
+          username: _json_key
+          password: ${{ secrets.GCP_SA_KEY }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: |
-            ${{ env.DOCKER_REGISTRY_ORG }}/${{ env.IMAGE_NAME }}
+            ${{ env.GAR_REGISTRY }}/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY }}/${{ env.IMAGE_NAME }}
           tags: |
             # Branch pushes: use git SHA
             type=sha,format=short,enable=${{ github.ref_type == 'branch' }}
@@ -83,9 +90,9 @@ jobs:
         run: |
           echo "### Docker Image Build Summary :rocket:" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Image:** \`${{ env.DOCKER_REGISTRY_ORG }}/${{ env.IMAGE_NAME }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** \`${{ env.GAR_REGISTRY }}/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY }}/${{ env.IMAGE_NAME }}\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Registry:** Docker Hub" >> $GITHUB_STEP_SUMMARY
+          echo "**Registry:** GCP Artifact Registry" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Tags:**" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
@@ -94,7 +101,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Pull command:**" >> $GITHUB_STEP_SUMMARY
           echo '```bash' >> $GITHUB_STEP_SUMMARY
-          echo "docker pull ${{ env.DOCKER_REGISTRY_ORG }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_STEP_SUMMARY
+          echo "docker pull ${{ env.GAR_REGISTRY }}/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Event:** ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/docker-build-push-erc8004-registry.yml
+++ b/.github/workflows/docker-build-push-erc8004-registry.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - develop
-      - fix/ci-cd-image-build-pipeline
     paths:
       - 'erc-8004-registry-py/**'
       - '.github/workflows/docker-build-push-erc8004-registry.yml'

--- a/async-provisioning-service/Dockerfile
+++ b/async-provisioning-service/Dockerfile
@@ -78,6 +78,9 @@ ENV FRP_SERVER_ADDR=""
 ENV FRP_DOMAIN=""
 ENV FRP_DASHBOARD_PASSWORD=""
 
+# SSH private key (base64-encoded or raw PEM). Written to ~/.ssh/id_ed25519 at startup.
+ENV SSH_PRIVATE_KEY=""
+
 # Authentication
 ENV ENABLE_AUTH=false
 ENV REGISTRY_URL=""

--- a/async-provisioning-service/start.sh
+++ b/async-provisioning-service/start.sh
@@ -1,6 +1,16 @@
 #!/bin/sh
 set -e
 
+# Write SSH private key from env if provided
+if [ -n "$SSH_PRIVATE_KEY" ]; then
+    mkdir -p ~/.ssh
+    chmod 700 ~/.ssh
+    printf '%s' "$SSH_PRIVATE_KEY" | base64 -d > ~/.ssh/id_ed25519 2>/dev/null || \
+        printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
+    chmod 600 ~/.ssh/id_ed25519
+    echo "SSH private key written to ~/.ssh/id_ed25519"
+fi
+
 # Start the background worker
 uv run python -m async_provisioning_service.worker &
 WORKER_PID=$!


### PR DESCRIPTION
# Changes Made
- Added CI/CD dockerization for the Async Provisioning Service
- Added pipeline behavior to build and push the Docker image to Google Cloud Artifact Registry
- Added SSH private key injection for the Async Provisioning Service to enable Ansible access to target hosts

# Testing
1. Trigger the CI/CD pipeline for the Async Provisioning Service repository
2. Verify the Docker image is successfully built during the pipeline run
3. Verify the image is pushed to GCP Artifact Registry
   ```bash
   gcloud artifacts docker images list <artifact-registry-repo>