### PR TITLE
Feature: Agent Provisioning updates

### DIFF
--- a/cli/market/groups/order.py
+++ b/cli/market/groups/order.py
@@ -189,7 +189,7 @@ def order_history(
     table.add_column("Status")
     table.add_column("Offer")
     table.add_column("Demand")
-    table.add_column("Fulfillment")
+    table.add_column("Fulfillment", overflow="fold")
     table.add_column("Created", justify="right")
     table.add_column("Updated", justify="right")
 

--- a/core/agent/.env.sample
+++ b/core/agent/.env.sample
@@ -19,6 +19,9 @@ TOKEN_REGISTRY_PATH=../core/agent/app/data/token_registry.json
 SSH_PUBLIC_KEY="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDemoPublicKeyForComputeAccess alice@example.com"
 ZEROTIER_NETWORK=5170efff3f3bf6ba
 USE_MOCK_PROVISIONING=true
+FRP_SERVER_ADDR=10.10.10.10
+FRP_DOMAIN=example.com
+FRP_DASHBOARD_PASSWORD=password
 
 # --- Arkhai RL Policy Configuration ---
 # Number of GPU node types in the environment (obs_dim = 12 + 3 * N)

--- a/core/agent/app/utils/action_executor.py
+++ b/core/agent/app/utils/action_executor.py
@@ -625,7 +625,7 @@ async def mock_provision_machine(ssh_public_key: str) -> str:
         String with connection details.
     """
     logger.info(f"[TOOL] (Simulated) Machine provisioned with SSH key for pubkey: {ssh_public_key}.")
-    return "demo-user@node-01.example.net"
+    return "ssh -i <your_private_key> -p 7021 demo-user@node-01.example.net | password: demo-password"
 
 
 def mock_schedule_vm_shutdown(lease_end_utc: str) -> None:

--- a/core/agent/app/utils/config.py
+++ b/core/agent/app/utils/config.py
@@ -139,6 +139,9 @@ class Config:
     order_retry_interval: int  # ORDER_RETRY_INTERVAL - interval between retry attempts in seconds
     # Provisioning settings
     use_mock_provisioning: bool  # USE_MOCK_PROVISIONING - use mock provisioning/scheduling
+    frp_server_addr: str | None  # FRP_SERVER_ADDR - FRP server address for direct provisioning
+    frp_domain: str | None  # FRP_DOMAIN - FRP domain for direct provisioning
+    frp_dashboard_password: str | None  # FRP_DASHBOARD_PASSWORD - FRP dashboard password
 
 
 DEFAULT_TOKEN_REGISTRY_PATH = (
@@ -226,6 +229,9 @@ def load_config() -> Config:
         order_retry_interval=_get_int_env("ORDER_RETRY_INTERVAL", 300),  # Default: 5 minutes
         # Provisioning settings
         use_mock_provisioning=_get_bool_env("USE_MOCK_PROVISIONING", False),
+        frp_server_addr=os.getenv("FRP_SERVER_ADDR") or os.getenv("frp_server_addr"),
+        frp_domain=os.getenv("FRP_DOMAIN") or os.getenv("frp_domain"),
+        frp_dashboard_password=os.getenv("FRP_DASHBOARD_PASSWORD") or os.getenv("frp_dashboard_password"),
     )
 
 

--- a/core/agent/app/utils/provisioning.py
+++ b/core/agent/app/utils/provisioning.py
@@ -5,6 +5,8 @@ import uuid
 from pathlib import Path
 from typing import Optional
 
+from .config import CONFIG
+
 # TODO(refactor): Provisioning behavior here is compute-domain specific.
 # Move this logic into the compute domain package in later refactor phases.
 
@@ -63,6 +65,19 @@ def _extract_tenant_user(playbook_output: str, vm_host: str | None = None) -> Op
     return None
 
 
+def _extract_tenant_password(playbook_output: str) -> Optional[str]:
+    """Extract authentication.tenant.password from playbook stdout."""
+    patterns = [
+        r'"tenant"\s*:\s*\{[\s\S]*?"password"\s*:\s*"(?P<pwd>[^"]+)"',
+        r'"tenant_password"\s*:\s*"(?P<pwd>[^"]+)"',
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, playbook_output, re.DOTALL)
+        if match:
+            return match.group("pwd").strip()
+    return None
+
+
 def _lookup_vm_host_ip(vm_host: str) -> Optional[str]:
     """Read the Ansible inventory to find the external IP for a given host."""
     project_root = _find_project_root()
@@ -103,18 +118,28 @@ def run_vm_provisioning_playbook(ssh_pubkey: str, vm_host: str = "vm1", vm_targe
         subprocess.CalledProcessError if the playbook exits with a non-zero status.
     """
     nonce = uuid.uuid4().hex
+    vm_target_suffix = uuid.uuid4().hex[:5]
     vm_vars_path = Path(f"/tmp/vm_vars_{nonce}.yml")
     escaped_pubkey = ssh_pubkey.replace('"', '\\"')
 
     vm_vars_payload = (
         f"vm_host: {vm_host}\n"
-        f"vm_target: {vm_target}\n"
+        f"vm_target: {vm_target}-{vm_target_suffix}\n"
         "vm_action: create\n"
         "vm_ram: 2048\n"
         "vm_vcpus: 2\n"
         "vm_disk_size: 25G\n"
         f'vm_tenant_pubkey: "{escaped_pubkey}"\n'
+        "image_setup_type: scratch\n"
+        "vm_gpu_provisioned: true\n"
+        "vm_gpu_count: 1\n"
     )
+    if CONFIG.frp_server_addr:
+        vm_vars_payload += f'frp_server_addr: "{CONFIG.frp_server_addr}"\n'
+    if CONFIG.frp_domain:
+        vm_vars_payload += f'frp_domain: "{CONFIG.frp_domain}"\n'
+    if CONFIG.frp_dashboard_password:
+        vm_vars_payload += f'frp_dashboard_password: "{CONFIG.frp_dashboard_password}"\n'
 
     vm_vars_path.write_text(vm_vars_payload, encoding="utf-8")
 
@@ -177,12 +202,26 @@ def run_vm_provisioning_playbook(ssh_pubkey: str, vm_host: str = "vm1", vm_targe
     else:
         logger.warning("Tenant SSH user not found in playbook output.")
 
+    tenant_password = _extract_tenant_password(result.stdout)
+
     ssh_command = None
     if external_port and vm_host_ip and tenant_user:
         ssh_command = f"ssh -i <your_private_key> -p {external_port} {tenant_user}@{vm_host_ip}"
-        logger.info("SSH command: %s", ssh_command)
+        if tenant_password:
+            ssh_command += f" | password: {tenant_password}"
+            logger.info("Tenant external SSH command and password extracted.")
+        else:
+            logger.info("SSH command: %s", ssh_command)
 
-    return ssh_command
+    if ssh_command:
+        return ssh_command
+
+    if tenant_password:
+        logger.info("Tenant password extracted without external SSH command.")
+        return f"password: {tenant_password}"
+
+    logger.warning("Tenant external SSH command not found in playbook output.")
+    return None
 
 
 def schedule_vm_shutdown(lease_end_utc: str, vm_host: str = "vm1", vm_target: str = "tenant-vm") -> None:

--- a/core/tests/unit/test_provisioning.py
+++ b/core/tests/unit/test_provisioning.py
@@ -1,0 +1,275 @@
+"""Unit tests for provisioning utility functions."""
+
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.app.utils.provisioning import (
+    _extract_external_port,
+    _extract_tenant_password,
+    _extract_tenant_user,
+    run_vm_provisioning_playbook,
+)
+
+
+# ---------------------------------------------------------------------------
+# _extract_tenant_password
+# ---------------------------------------------------------------------------
+
+class TestExtractTenantPassword:
+    def test_nested_tenant_object(self):
+        output = '{"tenant": {"password": "s3cr3t", "user": "alice"}}'
+        assert _extract_tenant_password(output) == "s3cr3t"
+
+    def test_flat_tenant_password_key(self):
+        output = 'ok: [vm1] => {"tenant_password": "flat-pass"}'
+        assert _extract_tenant_password(output) == "flat-pass"
+
+    def test_nested_with_whitespace(self):
+        output = '"tenant" : {\n  "password" : "spaced"\n}'
+        assert _extract_tenant_password(output) == "spaced"
+
+    def test_strips_surrounding_whitespace(self):
+        output = '"tenant_password": "  padded  "'
+        # The regex captures between the quotes; strip() is applied
+        result = _extract_tenant_password(output)
+        # strip() only strips the captured group, not what's inside quotes —
+        # passwords don't typically have surrounding spaces, but confirm no crash
+        assert result is not None
+
+    def test_returns_none_when_absent(self):
+        assert _extract_tenant_password("no password info here") is None
+
+    def test_returns_none_on_empty_string(self):
+        assert _extract_tenant_password("") is None
+
+    def test_prefers_nested_format_over_flat(self):
+        # Both patterns present — first match (nested) wins
+        output = '"tenant": {"password": "nested"}\n"tenant_password": "flat"'
+        assert _extract_tenant_password(output) == "nested"
+
+
+# ---------------------------------------------------------------------------
+# _extract_external_port
+# ---------------------------------------------------------------------------
+
+class TestExtractExternalPort:
+    def test_json_key(self):
+        output = 'ok: {"external_ssh_port": "7021"}'
+        assert _extract_external_port(output) == "7021"
+
+    def test_ssh_command_with_host(self):
+        output = "ssh -p 7022 alice@vm1.example.com"
+        assert _extract_external_port(output, vm_host="vm1.example.com") == "7022"
+
+    def test_generic_fallback(self):
+        output = "connect via: ssh -p 9000 user@host"
+        assert _extract_external_port(output) == "9000"
+
+    def test_returns_none_when_absent(self):
+        assert _extract_external_port("no port here") is None
+
+
+# ---------------------------------------------------------------------------
+# _extract_tenant_user
+# ---------------------------------------------------------------------------
+
+class TestExtractTenantUser:
+    def test_json_key(self):
+        output = '{"tenant_user": "bob"}'
+        assert _extract_tenant_user(output) == "bob"
+
+    def test_ssh_command(self):
+        output = "ssh -p 7021 alice@vm1"
+        assert _extract_tenant_user(output, vm_host="vm1") == "alice"
+
+    def test_returns_none_when_absent(self):
+        assert _extract_tenant_user("no user here") is None
+
+
+# ---------------------------------------------------------------------------
+# FRP config fields
+# ---------------------------------------------------------------------------
+
+class TestFrpConfig:
+    def test_frp_fields_loaded_from_env(self, monkeypatch):
+        monkeypatch.setenv("FRP_SERVER_ADDR", "10.1.2.3")
+        monkeypatch.setenv("FRP_DOMAIN", "frp.example.com")
+        monkeypatch.setenv("FRP_DASHBOARD_PASSWORD", "hunter2")
+
+        from agent.app.utils.config import load_config
+        cfg = load_config()
+
+        assert cfg.frp_server_addr == "10.1.2.3"
+        assert cfg.frp_domain == "frp.example.com"
+        assert cfg.frp_dashboard_password == "hunter2"
+
+    def test_frp_fields_none_when_unset(self, monkeypatch):
+        for key in ("FRP_SERVER_ADDR", "FRP_DOMAIN", "FRP_DASHBOARD_PASSWORD",
+                    "frp_server_addr", "frp_domain", "frp_dashboard_password"):
+            monkeypatch.delenv(key, raising=False)
+
+        from agent.app.utils.config import load_config
+        cfg = load_config()
+
+        assert cfg.frp_server_addr is None
+        assert cfg.frp_domain is None
+        assert cfg.frp_dashboard_password is None
+
+    def test_frp_fields_lowercase_fallback(self, monkeypatch):
+        monkeypatch.delenv("FRP_SERVER_ADDR", raising=False)
+        monkeypatch.setenv("frp_server_addr", "10.9.8.7")
+
+        from agent.app.utils.config import load_config
+        cfg = load_config()
+
+        assert cfg.frp_server_addr == "10.9.8.7"
+
+
+# ---------------------------------------------------------------------------
+# run_vm_provisioning_playbook — payload and return value
+# ---------------------------------------------------------------------------
+
+def _make_completed_process(stdout: str) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+def _fake_config(*, frp_server_addr=None, frp_domain=None, frp_dashboard_password=None):
+    return SimpleNamespace(
+        frp_server_addr=frp_server_addr,
+        frp_domain=frp_domain,
+        frp_dashboard_password=frp_dashboard_password,
+    )
+
+
+PLAYBOOK_STDOUT_FULL = """
+TASK [Show connection info]
+ok: [vm1] => {
+    "external_ssh_port": "7021",
+    "tenant_user": "alice",
+    "tenant": {"password": "secret123"}
+}
+"""
+
+
+@pytest.fixture
+def mock_subprocess_and_inventory():
+    """Patch subprocess.run and _lookup_vm_host_ip for playbook tests."""
+    with patch("agent.app.utils.provisioning.subprocess.run") as mock_run, \
+         patch("agent.app.utils.provisioning._lookup_vm_host_ip", return_value="192.0.2.1"), \
+         patch("agent.app.utils.provisioning._find_project_root", return_value=Path("/fake/root")):
+        mock_run.return_value = _make_completed_process(PLAYBOOK_STDOUT_FULL)
+        yield mock_run
+
+
+class TestRunVmProvisioningPlaybook:
+    def test_returns_ssh_command_with_password(self, mock_subprocess_and_inventory):
+        with patch("agent.app.utils.provisioning.CONFIG", _fake_config()):
+            result = run_vm_provisioning_playbook("ssh-ed25519 AAAA test@host")
+
+        assert result is not None
+        assert "ssh -i <your_private_key>" in result
+        assert "-p 7021" in result
+        assert "alice@192.0.2.1" in result
+        assert "| password: secret123" in result
+
+    def test_returns_password_only_when_no_ssh_details(self, mock_subprocess_and_inventory):
+        stdout = '"tenant_password": "onlypass"'
+        mock_subprocess_and_inventory.return_value = _make_completed_process(stdout)
+        with patch("agent.app.utils.provisioning.CONFIG", _fake_config()), \
+             patch("agent.app.utils.provisioning._lookup_vm_host_ip", return_value=None):
+            result = run_vm_provisioning_playbook("ssh-ed25519 AAAA test@host")
+
+        assert result == "password: onlypass"
+
+    def test_returns_none_when_nothing_extracted(self, mock_subprocess_and_inventory):
+        mock_subprocess_and_inventory.return_value = _make_completed_process("no useful output")
+        with patch("agent.app.utils.provisioning.CONFIG", _fake_config()), \
+             patch("agent.app.utils.provisioning._lookup_vm_host_ip", return_value=None):
+            result = run_vm_provisioning_playbook("ssh-ed25519 AAAA test@host")
+
+        assert result is None
+
+    def test_vm_target_has_random_suffix(self, mock_subprocess_and_inventory):
+        """vm_target in the written vars file should be 'name-<suffix>', not bare 'name'."""
+        captured_payloads = []
+
+        original_write = Path.write_text
+
+        def capturing_write(self, data, **kwargs):
+            captured_payloads.append(data)
+            return original_write(self, data, **kwargs)
+
+        with patch("agent.app.utils.provisioning.CONFIG", _fake_config()), \
+             patch.object(Path, "write_text", capturing_write):
+            run_vm_provisioning_playbook("ssh-ed25519 AAAA test@host", vm_target="tenant-vm")
+
+        vm_vars = next((p for p in captured_payloads if "vm_target" in p), None)
+        assert vm_vars is not None
+        # Should be "tenant-vm-<5-char suffix>", not plain "tenant-vm"
+        import re
+        match = re.search(r"vm_target: (.+)", vm_vars)
+        assert match is not None
+        target_value = match.group(1).strip()
+        assert target_value.startswith("tenant-vm-")
+        suffix = target_value[len("tenant-vm-"):]
+        assert len(suffix) == 5
+
+    def test_payload_includes_gpu_and_image_vars(self, mock_subprocess_and_inventory):
+        captured_payloads = []
+        original_write = Path.write_text
+
+        def capturing_write(self, data, **kwargs):
+            captured_payloads.append(data)
+            return original_write(self, data, **kwargs)
+
+        with patch("agent.app.utils.provisioning.CONFIG", _fake_config()), \
+             patch.object(Path, "write_text", capturing_write):
+            run_vm_provisioning_playbook("ssh-ed25519 AAAA test@host")
+
+        vm_vars = next((p for p in captured_payloads if "vm_target" in p), None)
+        assert "image_setup_type: scratch" in vm_vars
+        assert "vm_gpu_provisioned: true" in vm_vars
+        assert "vm_gpu_count: 1" in vm_vars
+
+    def test_payload_includes_frp_vars_when_configured(self, mock_subprocess_and_inventory):
+        captured_payloads = []
+        original_write = Path.write_text
+
+        def capturing_write(self, data, **kwargs):
+            captured_payloads.append(data)
+            return original_write(self, data, **kwargs)
+
+        cfg = _fake_config(
+            frp_server_addr="10.1.2.3",
+            frp_domain="frp.example.com",
+            frp_dashboard_password="hunter2",
+        )
+        with patch("agent.app.utils.provisioning.CONFIG", cfg), \
+             patch.object(Path, "write_text", capturing_write):
+            run_vm_provisioning_playbook("ssh-ed25519 AAAA test@host")
+
+        vm_vars = next((p for p in captured_payloads if "vm_target" in p), None)
+        assert 'frp_server_addr: "10.1.2.3"' in vm_vars
+        assert 'frp_domain: "frp.example.com"' in vm_vars
+        assert 'frp_dashboard_password: "hunter2"' in vm_vars
+
+    def test_payload_omits_frp_vars_when_not_configured(self, mock_subprocess_and_inventory):
+        captured_payloads = []
+        original_write = Path.write_text
+
+        def capturing_write(self, data, **kwargs):
+            captured_payloads.append(data)
+            return original_write(self, data, **kwargs)
+
+        with patch("agent.app.utils.provisioning.CONFIG", _fake_config()), \
+             patch.object(Path, "write_text", capturing_write):
+            run_vm_provisioning_playbook("ssh-ed25519 AAAA test@host")
+
+        vm_vars = next((p for p in captured_payloads if "vm_target" in p), None)
+        assert "frp_server_addr" not in vm_vars
+        assert "frp_domain" not in vm_vars
+        assert "frp_dashboard_password" not in vm_vars


### PR DESCRIPTION
# Changes Made
- Added FRP config to Agent provisioning logic
- Extract the tenant password and include that in the message to the buyer

Note: This updates the Agent for directly provisioning a VM from a host. However, the intention is that we migrate to fully using the **Async Provisioning Server**, which already has these in its config.

# Testing
```
cd core
python -m pytest tests/unit/test_provisioning.py
```
