### PR TITLE
Feature: Post-refactor, support Compute Seller as Maker, Compute Buyer as Taker

### DIFF
--- a/core/agent/app/agent.py
+++ b/core/agent/app/agent.py
@@ -352,10 +352,14 @@ def _parse_domain_event(payload: Dict[str, Any]) -> DomainEvent:
             order = MarketOrder.model_validate(offer_data)
             escrow_uid = data.get("escrow_uid") or payload.get("escrow_uid")
             ssh_public_key = data.get("ssh_public_key") or payload.get("ssh_public_key")
+            matched_order_id = data.get("matched_order_id") or payload.get("matched_order_id")
+            source = data.get("source") or payload.get("source")
             return AcceptOfferEvent.from_order(
                 order,
                 escrow_uid=escrow_uid,
                 ssh_public_key=ssh_public_key,
+                matched_order_id=matched_order_id,
+                source=source,
             )
             
         elif event_type == EventType.RECEIVE_COMPUTE_OBLIGATION_FULFILLMENT:
@@ -755,19 +759,8 @@ class TraderAgent(BaseAgent):
     async def _run_async_impl(
         self, ctx: InvocationContext
     ) -> AsyncGenerator[Event, None]:
-        if len(ctx.session.events[-1].content.parts) > 10:
-            yield Event(
-            author=self.name,
-            content=genai_types.Content(
-                role="model",
-                parts=[genai_types.Part.from_text(text=f"Too many message parts. Aborting.")],
-            ),
-            invocation_id=ctx.invocation_id,
-            branch=ctx.branch,
-        )
         last_event = ctx.session.events[-1]
         logger.info(f"[RUN ASYNC]: Last Event {last_event}")
-
         logger.info("[RUN ASYNC] CONTENT:")
 
         if last_event.content is None:

--- a/core/agent/app/agent.py
+++ b/core/agent/app/agent.py
@@ -76,7 +76,11 @@ from core.agent.app.schema.pydantic_models import (
     OrderCreateEvent,
     OrderCloseEvent,
 )
-from core.agent.app.resources import parse_resource_from_dict
+from core.agent.app.resources import (
+    adapt_db_resource_to_domain_resource,
+    get_supported_resource_types,
+    parse_resource_from_dict,
+)
 from core.agent.app.policy.store import PolicyStore
 from core.agent.app.policy.manager import PolicyManager
 from core.agent.app.policy.negotiation_thread import get_thread_store
@@ -549,7 +553,29 @@ class TraderAgent(BaseAgent):
         Returns:
             A dictionary representing the current portfolio stock.
         """
-        resources = await self._sqlite_client.list_resources()
+        supported_resource_types = get_supported_resource_types()
+        db_resources = await self._sqlite_client.list_resources()
+        resources: list[dict[str, Any]] = []
+
+        for db_resource in db_resources:
+            resource_type = db_resource.get("resource_type")
+            if resource_type not in supported_resource_types:
+                continue
+
+            try:
+                resource = adapt_db_resource_to_domain_resource(db_resource)
+            except Exception as exc:
+                logger.warning(
+                    "[RESOURCE PORTFOLIO] Skipping malformed supported resource %s (%s): %s",
+                    db_resource.get("resource_id"),
+                    resource_type,
+                    exc,
+                )
+                continue
+
+            if hasattr(resource, "model_dump"):
+                resources.append(resource.model_dump(mode="json"))
+
         return {"resources": resources}
 
     async def _build_domain_context(self, event: Event | DomainEvent) -> Tuple[DomainEvent, dict]:

--- a/core/agent/app/resources.py
+++ b/core/agent/app/resources.py
@@ -220,6 +220,11 @@ def get_resource_adapter(resource_type: str) -> ResourceAdapter | None:
     return _RESOURCE_TYPE_TO_ADAPTER.get(resource_type)
 
 
+def get_supported_resource_types() -> set[str]:
+    """Return resource types that have registered domain adapters."""
+    return set(_RESOURCE_TYPE_TO_ADAPTER)
+
+
 def adapt_db_resource_to_domain_resource(db_resource: dict[str, Any]) -> Any:
     """
     Adapt a DB resource dict to the appropriate domain resource instance using the registered adapter.

--- a/core/agent/app/schema/pydantic_models.py
+++ b/core/agent/app/schema/pydantic_models.py
@@ -328,11 +328,19 @@ class AcceptOfferEvent(DomainEvent):
     order: MarketOrder = Field(description="The accepted market order with taker info")
     escrow_uid: str | None = Field(
         default=None,
-        description="Escrow receipt UID supplied by the taker",
+        description="Escrow receipt UID supplied by the buyer; None when seller is merely signalling acceptance",
     )
     ssh_public_key: str | None = Field(
         default=None,
         description="Buyer-provided SSH public key for provisioning access",
+    )
+    matched_order_id: str | None = Field(
+        default=None,
+        description=(
+            "The sender's own local order_id, threaded through the acceptance handshake so the "
+            "receiver can update their DB without a reverse-lookup. "
+            "Set by the seller on the first (no-escrow) acceptance; echoed back by the buyer."
+        ),
     )
 
     @classmethod
@@ -341,14 +349,17 @@ class AcceptOfferEvent(DomainEvent):
         order: MarketOrder,
         escrow_uid: str | None = None,
         ssh_public_key: str | None = None,
+        matched_order_id: str | None = None,
+        source: str | None = None,
     ) -> "AcceptOfferEvent":
         """Create an accept-offer event from a market order and optional escrow UID."""
         return cls(
             event_id=f"acc_{order.order_id}",
-            source=order.order_taker or order.order_maker,
+            source=source or order.order_taker or order.order_maker,
             order=order,
             escrow_uid=escrow_uid,
             ssh_public_key=ssh_public_key,
+            matched_order_id=matched_order_id,
             data={
                 "order_id": order.order_id,
                 "offer_resource": order.offer_resource.model_dump(mode="json"),
@@ -357,6 +368,7 @@ class AcceptOfferEvent(DomainEvent):
                 "escrow_uid": escrow_uid,
                 "ssh_public_key": ssh_public_key,
                 "oracle_address": order.oracle_address,
+                "matched_order_id": matched_order_id,
             },
         )
 

--- a/core/agent/app/utils/action_executor.py
+++ b/core/agent/app/utils/action_executor.py
@@ -101,6 +101,54 @@ def _is_http_url(value: str | None) -> bool:
     return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
 
 
+def _normalize_agent_url(url: str | None) -> str:
+    if not url:
+        return ""
+    return url.strip().rstrip("/").lower()
+
+
+def _agent_urls_match(a: str | None, b: str | None) -> bool:
+    na, nb = _normalize_agent_url(a), _normalize_agent_url(b)
+    return bool(na and na == nb)
+
+
+def _resource_is_compute(resource: Any) -> bool:
+    """True when the resource represents compute (has gpu_model), not tokens.
+
+    Works with both Pydantic model instances and serialized dicts. ComputeResource
+    serializes with a 'gpu_model' key; TokenResource serializes with 'token'/'amount'.
+    """
+    if isinstance(resource, str):
+        try:
+            resource = json.loads(resource)
+        except Exception:
+            return False
+    if isinstance(resource, dict):
+        return "gpu_model" in resource
+    return hasattr(resource, "gpu_model")
+
+
+def _we_are_compute_buyer(order_dict: dict[str, Any]) -> bool:
+    """True when we are the compute-buying (token-paying) side of this order.
+
+    Two cases:
+    - Seller-as-maker: maker offers compute, we are the taker → we buy compute.
+    - Buyer-as-maker: maker offers tokens (us), we are the maker → we buy compute.
+    """
+    maker_offers_compute = _resource_is_compute(order_dict.get("offer_resource"))
+    we_are_maker = _agent_urls_match(order_dict.get("order_maker"), BASE_URL_OVERRIDE)
+    return (maker_offers_compute and not we_are_maker) or (not maker_offers_compute and we_are_maker)
+
+
+def _resolve_counterparty_url_from_order(order_dict: dict[str, Any]) -> str | None:
+    """Return the URL of the other party in the order (the one that is not us)."""
+    maker = order_dict.get("order_maker")
+    taker = order_dict.get("order_taker")
+    if _agent_urls_match(maker, BASE_URL_OVERRIDE):
+        return taker
+    return maker
+
+
 def _coerce_agent_reference_to_url(agent_ref: str | None) -> str | None:
     """Best-effort conversion from agent ref/alias to resolvable URL."""
     if not isinstance(agent_ref, str):
@@ -275,11 +323,26 @@ async def execute_action(
             order = parameters.get("order")
             order_dict = order if isinstance(order, dict) else {}
             oracle_address = parameters.get("oracle_address") or order_dict.get("oracle_address")
-            
+            matched_order_id = parameters.get("matched_order_id")
+
             if not escrow_uid:
                 raise ValueError("escrow_uid is required for fulfill_compute_obligation")
             if not ssh_public_key:
                 raise ValueError("ssh_public_key is required for fulfill_compute_obligation")
+
+            # Update our own local order if matched_order_id was threaded through the event.
+            # This handles the seller-as-taker case where order_id in the order dict is the
+            # buyer's order_id (not present in the seller's local DB).
+            if matched_order_id:
+                try:
+                    sqlite_client = get_sqlite_client()
+                    await sqlite_client.update_order(
+                        order_id=matched_order_id,
+                        status="accepted",
+                        escrow_uid=escrow_uid,
+                    )
+                except Exception as exc:
+                    logger.warning("[LOCAL DB] Failed to update matched_order_id %s at fulfillment: %s", matched_order_id, exc)
 
             result = await fulfill_compute_obligation(
                 client=alkahest_client,
@@ -300,7 +363,7 @@ async def execute_action(
                         order_dict = order_obj.model_dump(mode="json") if order_obj else {}
                     else:
                         order_dict = {}
-                    counterparty_ref = parameters.get("counterparty_url") or (order_dict.get("order_taker") if order_dict else None)
+                    counterparty_ref = parameters.get("counterparty_url") or _resolve_counterparty_url_from_order(order_dict)
                     counterparty_url = _coerce_agent_reference_to_url(counterparty_ref)
                     if not counterparty_url:
                         raise ValueError(
@@ -838,102 +901,9 @@ async def accept_offer(
         logger.warning("[TOOL] Cannot accept offer: no order payload provided.")
         return {"status": "error", "message": "Missing order payload for accept_offer"}
 
-    # If alkahest_client provided, attempt on-chain buy to escrow tokens with retry logic.
-    # When accepting an offer, the taker is buying compute and paying tokens.
-    # The mapping depends on what the maker is offering:
-    # - If maker offers compute (surplus): taker buys compute (offer_resource) and pays tokens (demand_resource)
-    # - If maker offers tokens (deficit): taker buys compute (demand_resource) and pays tokens (offer_resource)
-    escrow_uid = None
-    escrow_receipt = None
-    oracle_address = CONFIG.agent_wallet_address
-    if not oracle_address:
-        raise ValueError("Agent wallet address is required for accept_offer but not configured")
-
-    if alkahest_client:
-        compute_resource, token_resource = extract_compute_and_token_from_order_dict(order_dict)
-
-        # Retry logic with exponential backoff
-        max_retries = 3
-        base_delay = 1.0  # seconds
-        
-        for attempt in range(max_retries):
-            try:
-                logger.info(f"[ALKAHEST] Attempting to put tokens in escrow (attempt {attempt + 1}/{max_retries})")
-                escrow_receipt = await buy_compute_with_erc20(
-                    compute_resource=compute_resource,
-                    token_resource=token_resource,
-                    duration_hours=order_dict.get("duration_hours", 1),
-                    oracle_address=oracle_address,
-                    client=alkahest_client,
-                )
-                escrow_uid = escrow_receipt.get("log", {}).get("uid")
-                if escrow_uid:
-                    logger.info("[ALKAHEST] Created escrow via buy_with_erc20; uid=%s", escrow_uid)
-                    break
-                else:
-                    logger.warning(f"[ALKAHEST] Escrow receipt missing uid on attempt {attempt + 1}")
-            except Exception as e:
-                logger.warning(f"[ALKAHEST] Failed to create escrow on attempt {attempt + 1}/{max_retries}: {e}")
-                if attempt < max_retries - 1:
-                    delay = base_delay * (2 ** attempt)
-                    logger.info(f"[ALKAHEST] Retrying in {delay} seconds...")
-                    await asyncio.sleep(delay)
-                else:
-                    logger.error("[ALKAHEST] All retry attempts failed. Cannot create escrow.")
-                    raise RuntimeError(f"Failed to create escrow after {max_retries} attempts: {e}") from e
-        
-        if not escrow_uid:
-            if isinstance(escrow_receipt, dict):
-                escrow_uid = escrow_receipt.get("log", {}).get("uid")
-                if escrow_uid:
-                    logger.info(f"[ALKAHEST] Got escrow_uid from receipt: {escrow_uid}")
-            
-            if not escrow_uid:
-                raise RuntimeError("Failed to obtain escrow_uid from Alkahest response")
-    else:
-        raise RuntimeError("AlkahestClient is required for accept_offer. Cannot proceed without on-chain escrow.")
-
-    # Stamp taker metadata onto the order.
-    order_dict["order_taker"] = BASE_URL_OVERRIDE
-    order_dict["taker_attestation"] = escrow_uid
-    order_dict["oracle_address"] = oracle_address
-
-    event_payload = {
-        "event_type": EventType.ACCEPT_OFFER.value,
-        "offer": order_dict,
-        "escrow_uid": escrow_uid,
-        "ssh_public_key": SSH_PUBLIC_KEY,
-    }
-
-    if ctx is None:
-        logger.warning("[TOOL] No invocation context; acceptance not sent.")
-        return {
-            **event_payload,
-            "status": "pending",
-            "message": "No invocation context available to send acceptance",
-        }
-
-    event = Event(
-        author=AGENT_ID,
-        content=genai_types.Content(
-            role="model",
-            parts=[
-                genai_types.Part.from_function_response(
-                    name="accept_offer",
-                    response=event_payload,
-                )
-            ],
-        ),
-        invocation_id=ctx.invocation_id,
-        branch=ctx.branch,
-    )
-
-    logger.info("[TOOL] Accepting offer and notifying counterparty: %s", event_payload)
-
-    # Cancel competing negotiations and mark as terminal using transaction
     order_id = order_dict.get("order_id")
     our_order_id = parameters.get("our_order_id")
-    their_order_id = parameters.get("their_order_id")
+    their_order_id = parameters.get("their_order_id") or order_id
     negotiation_id = parameters.get("negotiation_id")
 
     async with NegotiationThreadTransaction("ACCEPT_OFFER") as txn:
@@ -953,7 +923,92 @@ async def accept_offer(
                 our_order_id = inferred.get("order_id")
         except Exception as exc:
             logger.warning("[LOCAL DB] Failed to infer our_order_id: %s", exc)
-        
+
+    if _we_are_compute_buyer(order_dict):
+        return await _accept_as_buyer(
+            alkahest_client=alkahest_client,
+            ctx=ctx,
+            parameters=parameters,
+            order_dict=order_dict,
+            our_order_id=our_order_id,
+            their_order_id=their_order_id,
+        )
+    else:
+        return await _accept_as_seller(
+            ctx=ctx,
+            parameters=parameters,
+            order_dict=order_dict,
+            our_order_id=our_order_id,
+            their_order_id=their_order_id,
+        )
+
+
+async def _accept_as_buyer(
+    *,
+    alkahest_client: Any | None,
+    ctx: InvocationContext | None,
+    parameters: dict[str, Any],
+    order_dict: dict[str, Any],
+    our_order_id: str | None,
+    their_order_id: str | None,
+) -> dict[str, Any]:
+    """Buyer path: create on-chain escrow and send AcceptOfferEvent with escrow_uid."""
+    oracle_address = CONFIG.agent_wallet_address
+    if not oracle_address:
+        raise ValueError("Agent wallet address is required for buyer accept_offer but not configured")
+
+    escrow_uid = None
+    escrow_receipt = None
+
+    if alkahest_client:
+        compute_resource, token_resource = extract_compute_and_token_from_order_dict(order_dict)
+        max_retries = 3
+        base_delay = 1.0
+        for attempt in range(max_retries):
+            try:
+                logger.info("[ALKAHEST] Attempting to put tokens in escrow (attempt %d/%d)", attempt + 1, max_retries)
+                escrow_receipt = await buy_compute_with_erc20(
+                    compute_resource=compute_resource,
+                    token_resource=token_resource,
+                    duration_hours=order_dict.get("duration_hours", 1),
+                    oracle_address=oracle_address,
+                    client=alkahest_client,
+                )
+                escrow_uid = escrow_receipt.get("log", {}).get("uid")
+                if escrow_uid:
+                    logger.info("[ALKAHEST] Created escrow; uid=%s", escrow_uid)
+                    break
+                logger.warning("[ALKAHEST] Escrow receipt missing uid on attempt %d", attempt + 1)
+            except Exception as e:
+                logger.warning("[ALKAHEST] Failed to create escrow on attempt %d/%d: %s", attempt + 1, max_retries, e)
+                if attempt < max_retries - 1:
+                    await asyncio.sleep(base_delay * (2 ** attempt))
+                else:
+                    raise RuntimeError(f"Failed to create escrow after {max_retries} attempts: {e}") from e
+
+        if not escrow_uid:
+            if isinstance(escrow_receipt, dict):
+                escrow_uid = escrow_receipt.get("log", {}).get("uid")
+            if not escrow_uid:
+                raise RuntimeError("Failed to obtain escrow_uid from Alkahest response")
+    else:
+        raise RuntimeError("AlkahestClient is required for accept_offer. Cannot proceed without on-chain escrow.")
+
+    order_dict["order_taker"] = BASE_URL_OVERRIDE
+    order_dict["taker_attestation"] = escrow_uid
+    order_dict["oracle_address"] = oracle_address
+
+    # Echo the seller's order_id back so they can update their local DB without a lookup.
+    matched_order_id = parameters.get("matched_order_id")
+
+    event_payload = {
+        "event_type": EventType.ACCEPT_OFFER.value,
+        "source": BASE_URL_OVERRIDE,
+        "offer": order_dict,
+        "escrow_uid": escrow_uid,
+        "ssh_public_key": SSH_PUBLIC_KEY,
+        "matched_order_id": matched_order_id,
+    }
 
     try:
         sqlite_client = get_sqlite_client()
@@ -970,57 +1025,118 @@ async def accept_offer(
     except Exception as exc:
         logger.warning("[LOCAL DB] Failed to update order %s as accepted: %s", our_order_id, exc)
 
-    # Update registry if order exists there
-    # This updates the MAKER's order (the order we're accepting)
-    # The registry will also update the symmetric order (taker's order) automatically
     if CONFIG.enable_registry_discovery:
         try:
             registry_client = get_registry_client()
-            order_id = order_dict.get("order_id")
-            if order_id:
-                updates = {
-                    "status": "accepted",
-                    "order_taker": BASE_URL_OVERRIDE,
-                    "taker_attestation": escrow_uid,
-                }
-                result = await registry_client.update_order(order_id, updates)
+            their_id = order_dict.get("order_id")
+            if their_id:
+                updates = {"status": "accepted", "order_taker": BASE_URL_OVERRIDE, "taker_attestation": escrow_uid}
+                result = await registry_client.update_order(their_id, updates)
                 if result:
-                    logger.info(f"[REGISTRY] Updated maker's order {order_id} status to accepted")
-                    if result.get("symmetric_order_updated"):
-                        logger.info(f"[REGISTRY] Also updated symmetric order {result.get('symmetric_order_updated')}")
-                    else:
-                        logger.warning(f"[REGISTRY] No symmetric order found/updated for order {order_id}")
+                    logger.info("[REGISTRY] Updated maker's order %s to accepted", their_id)
                 else:
-                    logger.warning(f"[REGISTRY] Failed to update maker's order {order_id} - order may not exist in registry")
+                    logger.warning("[REGISTRY] Failed to update maker's order %s", their_id)
         except Exception as e:
-            logger.warning(f"[REGISTRY] Failed to update order in registry: {e}")
-            import traceback
-            logger.debug(f"[REGISTRY] Update order traceback: {traceback.format_exc()}")
+            logger.warning("[REGISTRY] Failed to update order in registry: %s", e)
 
-    # Counterparty to notify is the order maker (we are the taker accepting their offer).
     counterparty_ref = parameters.get("counterparty_url") or order_dict.get("order_maker")
     counterparty_url = _coerce_agent_reference_to_url(counterparty_ref)
     if not counterparty_url:
-        raise ValueError(
-            f"accept_offer: cannot send acceptance — unresolved counterparty={counterparty_ref!r}"
-        )
+        raise ValueError(f"accept_offer (buyer): cannot send acceptance — unresolved counterparty={counterparty_ref!r}")
+
+    if ctx is None:
+        logger.warning("[TOOL] No invocation context; acceptance not sent.")
+        return {**event_payload, "status": "pending", "message": "No invocation context available"}
+
+    event = Event(
+        author=AGENT_ID,
+        content=genai_types.Content(
+            role="model",
+            parts=[genai_types.Part.from_function_response(name="accept_offer", response=event_payload)],
+        ),
+        invocation_id=ctx.invocation_id,
+        branch=ctx.branch,
+    )
+    logger.info("[TOOL] Buyer accepting offer, notifying seller: %s", counterparty_url)
     try:
         result = await send_to_remote_agent(ctx, event, agent_url=counterparty_url)
         return {
             "status": "sent",
-            "message": "Offer accepted and forwarded to counterparty",
+            "message": "Offer matched.",
             "escrow_uid": escrow_uid,
             "offer": order_dict,
             "remote_response": getattr(result, "content", None),
         }
     except Exception as e:
         logger.error("[TOOL] Failed to send acceptance: %s", e)
+        return {"status": "error", "message": f"Failed to send acceptance: {e}", "escrow_uid": escrow_uid, "offer": order_dict}
+
+
+async def _accept_as_seller(
+    *,
+    ctx: InvocationContext | None,
+    parameters: dict[str, Any],
+    order_dict: dict[str, Any],
+    our_order_id: str | None,
+    their_order_id: str | None,
+) -> dict[str, Any]:
+    """Seller path: signal acceptance to the buyer without creating an escrow.
+
+    The buyer will receive this and create the escrow on their side, then send
+    back an AcceptOfferEvent with escrow_uid for the seller to fulfill.
+    """
+    # Include our order_id so the buyer can echo it back, letting us update our
+    # local DB directly when we receive the second AcceptOfferEvent.
+    event_payload = {
+        "event_type": EventType.ACCEPT_OFFER.value,
+        "source": BASE_URL_OVERRIDE,
+        "offer": order_dict,
+        "escrow_uid": None,
+        "ssh_public_key": None,
+        "matched_order_id": our_order_id,
+    }
+
+    try:
+        sqlite_client = get_sqlite_client()
+        if our_order_id:
+            await sqlite_client.update_order(
+                order_id=our_order_id,
+                status="matched",
+                matched_offer_id=their_order_id,
+            )
+    except Exception as exc:
+        logger.warning("[LOCAL DB] Failed to update order %s as matched: %s", our_order_id, exc)
+
+    counterparty_ref = parameters.get("counterparty_url") or order_dict.get("order_maker")
+    counterparty_url = _coerce_agent_reference_to_url(counterparty_ref)
+    if not counterparty_url:
+        raise ValueError(f"accept_offer (seller): cannot notify buyer — unresolved counterparty={counterparty_ref!r}")
+
+    if ctx is None:
+        logger.warning("[TOOL] No invocation context; seller acceptance not sent.")
+        return {**event_payload, "status": "pending", "message": "No invocation context available"}
+
+    event = Event(
+        author=AGENT_ID,
+        content=genai_types.Content(
+            role="model",
+            parts=[genai_types.Part.from_function_response(name="accept_offer", response=event_payload)],
+        ),
+        invocation_id=ctx.invocation_id,
+        branch=ctx.branch,
+    )
+    logger.info("[TOOL] Seller signalling acceptance to buyer (no escrow yet): %s", counterparty_url)
+    try:
+        result = await send_to_remote_agent(ctx, event, agent_url=counterparty_url)
         return {
-            "status": "error",
-            "message": f"Failed to send acceptance: {e}",
-            "escrow_uid": escrow_uid,
+            "status": "sent",
+            "message": "Order matched.",
             "offer": order_dict,
+            "remote_response": getattr(result, "content", None),
         }
+    except Exception as e:
+        logger.error("[TOOL] Failed to send seller acceptance: %s", e)
+        return {"status": "error", "message": f"Failed to send seller acceptance: {e}", "offer": order_dict}
 
 
 def create_order(
@@ -1789,7 +1905,7 @@ async def fulfill_compute_obligation(
         "fulfillment_uid": fulfillment_uid,
         "connection_details": connection_details,
         "ssh_public_key": ssh_public_key,
-        "fulfilling_party_url": (order_dict or {}).get("order_maker"),
+        "fulfilling_party_url": BASE_URL_OVERRIDE,
     }
 
 async def arbitrate_compute_fulfillment(

--- a/core/agent/app/utils/action_executor.py
+++ b/core/agent/app/utils/action_executor.py
@@ -36,16 +36,13 @@ from core.agent.app.schema.pydantic_models import (
     ActionType,
     ComputeResource,
     EventType,
-    GPUModel,
     MarketOrder,
-    Region,
     TokenResource,
 )
 from core.agent.app.resources import parse_resource_from_dict
 
 from core.agent.app.utils.config import CONFIG
 from service.clients.alkahest import get_trusted_oracle_arbiter
-from service.clients.token import TOKEN_REGISTRY
 from service.clients.indexer import get_registry_client
 from core.agent.app.utils.sqlite_client import get_sqlite_client
 from .provisioning import run_vm_provisioning_playbook, schedule_vm_shutdown
@@ -251,18 +248,7 @@ async def execute_action(
                     created_order_id = order.get("order_id")
                 gpu_model = getattr(offer_resource, "gpu_model", None) or getattr(demand_resource, "gpu_model", "unknown")
             else:
-                gpu_model = parameters.get("gpu_model", "unknown")
-                imbalance_type = parameters.get("imbalance_type", "surplus")
-                logger.info(f"[ACTION] Creating order for {gpu_model} with params: {parameters}")
-                order = create_order(
-                    gpu_model_str=parameters.get("gpu_model"),
-                    sla=parameters.get("sla"),
-                    region_str=parameters.get("region"),
-                    imbalance_type=imbalance_type,
-                    duration_hours=parameters.get("duration_hours", 1),
-                )
-                if isinstance(order, dict):
-                    created_order_id = order.get("order_id")
+                raise ValueError("MAKE_OFFER requires explicit 'offer' and 'demand' parameters")
             if created_order_id:
                 outcome["order_id"] = created_order_id
             if isinstance(order, dict) and order.get("order_id"):
@@ -1163,10 +1149,6 @@ async def _accept_as_seller(
 
 
 def create_order(
-    gpu_model_str: str = None,
-    sla: float = None,
-    region_str: str = None,
-    imbalance_type: str = "surplus",
     publish_to_registry: bool = True,
     offer_resource: ComputeResource | TokenResource = None,
     demand_resource: ComputeResource | TokenResource = None,
@@ -1180,57 +1162,23 @@ def create_order(
     Not to be confused with make_offer, which propagates the order to the market.
 
     Args:
-        gpu_model_str: The GPU model, one of: {"H200", "Tesla V100", "RTX 5080"} (required for surplus)
-        sla: SLA required for the order (required for surplus)
-        region_str: Geographic region, one of: {"California, US", "New York, US, "Tokyo, JP"} (required for surplus)
-        imbalance_type: "surplus" (offer compute, demand tokens) or "deficit" (offer tokens, demand compute)
         publish_to_registry: Whether to publish order to registry (default: True)
-        offer_resource: Pre-constructed offer resource (optional, overrides gpu_model_str/sla/region_str)
-        demand_resource: Pre-constructed demand resource (optional)
+        offer_resource: Offer resource (required)
+        demand_resource: Demand resource (required)
         duration_hours: Duration of the order in hours (default: 1); 1 if seller (rate), else total if buyer
 
     Returns:
         The created order as a dictionary if the order was successfully created, or None otherwise.
         This creates a UUID identifying the new order, and the details should match the provided arguments.
     """
-    settlement_token = TOKEN_REGISTRY.require("MOCK")
-    logger.info(f"[TOOL] Creating order for resource (imbalance_type: {imbalance_type}).")
-    
-    # Determine order direction based on imbalance_type
-    if imbalance_type == "deficit":
-        # Deficit: Offer tokens, demand compute
-        if not offer_resource:
-            offer_resource = TokenResource(
-                token=settlement_token,
-                amount=9 * 10**settlement_token.decimals,
-            )
-        if not demand_resource:
-            if not gpu_model_str or sla is None or not region_str:
-                logger.error("[TOOL] gpu_model_str, sla, and region_str required for deficit orders")
-                return None
-            demand_resource = ComputeResource(
-                gpu_model=GPUModel(gpu_model_str),
-                quantity=1,
-                sla=sla,
-                region=Region(region_str),
-            )
-    else:
-        # Surplus: Offer compute, demand tokens (default/current behavior)
-        if not offer_resource:
-            if not gpu_model_str or sla is None or not region_str:
-                logger.error("[TOOL] gpu_model_str, sla, and region_str required for surplus orders")
-                return None
-            offer_resource = ComputeResource(
-                gpu_model=GPUModel(gpu_model_str),
-                quantity=1,
-                sla=sla,
-                region=Region(region_str),
-            )
-        if not demand_resource:
-            demand_resource = TokenResource(
-                token=settlement_token,
-                amount=9 * 10**settlement_token.decimals,
-            )
+    logger.info("[TOOL] Creating order.")
+
+    if not offer_resource:
+        logger.error("[TOOL] offer_resource is required")
+        return None
+    if not demand_resource:
+        logger.error("[TOOL] demand_resource is required")
+        return None
     
     # The token-offering side is always the oracle/buyer.
     offering_tokens = isinstance(offer_resource, TokenResource) or (

--- a/core/agent/app/utils/action_executor.py
+++ b/core/agent/app/utils/action_executor.py
@@ -352,6 +352,20 @@ async def execute_action(
                 order=order,
             )
             if result.get("status") == "fulfilled":
+                # Update our own local order with fulfillment details.
+                # fulfill_compute_obligation uses order_dict["order_id"] (the buyer's ID) for its
+                # internal DB write, which doesn't exist in the seller's local DB.  We correct that
+                # here using matched_order_id (the seller's own order).
+                if matched_order_id:
+                    try:
+                        sqlite_client = get_sqlite_client()
+                        await sqlite_client.update_order(
+                            order_id=matched_order_id,
+                            maker_attestation=result.get("fulfillment_uid"),
+                            fulfillment_resource=result.get("connection_details"),
+                        )
+                    except Exception as exc:
+                        logger.warning("[LOCAL DB] Failed to update fulfillment for matched_order_id %s: %s", matched_order_id, exc)
                 # Include event_type for downstream parsing and propagate to remote agent.
                 result["event_type"] = EventType.RECEIVE_COMPUTE_OBLIGATION_FULFILLMENT.value
                 if ctx:
@@ -1028,14 +1042,23 @@ async def _accept_as_buyer(
     if CONFIG.enable_registry_discovery:
         try:
             registry_client = get_registry_client()
+            registry_updates = {"status": "accepted", "order_taker": BASE_URL_OVERRIDE, "taker_attestation": escrow_uid}
+            # Update the order that is in the registry (order_dict["order_id"] is the buyer's order
+            # in buyer-as-maker flow; matched_order_id is the seller's order in seller-as-maker flow).
             their_id = order_dict.get("order_id")
             if their_id:
-                updates = {"status": "accepted", "order_taker": BASE_URL_OVERRIDE, "taker_attestation": escrow_uid}
-                result = await registry_client.update_order(their_id, updates)
+                result = await registry_client.update_order(their_id, registry_updates)
                 if result:
-                    logger.info("[REGISTRY] Updated maker's order %s to accepted", their_id)
+                    logger.info("[REGISTRY] Updated order %s to accepted", their_id)
                 else:
-                    logger.warning("[REGISTRY] Failed to update maker's order %s", their_id)
+                    logger.warning("[REGISTRY] Failed to update order %s", their_id)
+            # In seller-as-maker flow, also update the seller's registry entry.
+            if matched_order_id and matched_order_id != their_id:
+                result = await registry_client.update_order(matched_order_id, registry_updates)
+                if result:
+                    logger.info("[REGISTRY] Updated seller's order %s to accepted", matched_order_id)
+                else:
+                    logger.warning("[REGISTRY] Failed to update seller's order %s", matched_order_id)
         except Exception as e:
             logger.warning("[REGISTRY] Failed to update order in registry: %s", e)
 

--- a/core/agent/app/utils/sqlite_client.py
+++ b/core/agent/app/utils/sqlite_client.py
@@ -139,6 +139,11 @@ class SQLiteClient:
                 )
                 """
             )
+            # Migrate orders table: add columns that may be missing from older DBs
+            try:
+                cur.execute("ALTER TABLE orders ADD COLUMN oracle_address TEXT")
+            except sqlite3.OperationalError:
+                pass  # Column already exists
             # Orders table (local source of truth)
             cur.execute(
                 """
@@ -1026,6 +1031,69 @@ class SQLiteClient:
                 conn.close()
 
         await asyncio.to_thread(_save)
+
+    async def load_order(self, *, order_id: str) -> dict[str, Any] | None:
+        """Return a single order by order_id, or None if not found."""
+        def _load() -> dict[str, Any] | None:
+            conn = sqlite3.connect(self.db_path)
+            try:
+                cur = conn.cursor()
+                cur.execute(
+                    """
+                    SELECT order_id, status, created_at, updated_at,
+                           offer_resource, demand_resource, fulfillment_resource,
+                           duration_hours, order_maker, order_taker,
+                           matched_offer_id, maker_attestation, taker_attestation,
+                           escrow_uid, oracle_address
+                    FROM orders WHERE order_id = ?
+                    """,
+                    (order_id,),
+                )
+                row = cur.fetchone()
+                if not row:
+                    return None
+                keys = [
+                    "order_id", "status", "created_at", "updated_at",
+                    "offer_resource", "demand_resource", "fulfillment_resource",
+                    "duration_hours", "order_maker", "order_taker",
+                    "matched_offer_id", "maker_attestation", "taker_attestation",
+                    "escrow_uid", "oracle_address",
+                ]
+                return dict(zip(keys, row))
+            finally:
+                conn.close()
+
+        return await asyncio.to_thread(_load)
+
+    async def load_orders_by_escrow_uid(self, *, escrow_uid: str) -> list[dict[str, Any]]:
+        """Return all orders that share the given escrow_uid."""
+        def _load() -> list[dict[str, Any]]:
+            conn = sqlite3.connect(self.db_path)
+            try:
+                cur = conn.cursor()
+                cur.execute(
+                    """
+                    SELECT order_id, status, created_at, updated_at,
+                           offer_resource, demand_resource, fulfillment_resource,
+                           duration_hours, order_maker, order_taker,
+                           matched_offer_id, maker_attestation, taker_attestation,
+                           escrow_uid, oracle_address
+                    FROM orders WHERE escrow_uid = ?
+                    """,
+                    (escrow_uid,),
+                )
+                keys = [
+                    "order_id", "status", "created_at", "updated_at",
+                    "offer_resource", "demand_resource", "fulfillment_resource",
+                    "duration_hours", "order_maker", "order_taker",
+                    "matched_offer_id", "maker_attestation", "taker_attestation",
+                    "escrow_uid", "oracle_address",
+                ]
+                return [dict(zip(keys, row)) for row in cur.fetchall()]
+            finally:
+                conn.close()
+
+        return await asyncio.to_thread(_load)
 
     async def save_policy(
         self,

--- a/domain/compute/agent/app/policy/arkhai_common.py
+++ b/domain/compute/agent/app/policy/arkhai_common.py
@@ -14,12 +14,12 @@ from pathlib import Path
 from typing import Any, Optional
 
 import gymnasium as gym
+from domain.compute.agent.app.policy.store import get_compute_resource_portfolio
 
 from core.agent.app.schema.pydantic_models import (
     Action as DomainAction,
     ActionType,
     ComputeResource,
-    ComputeResourcePortfolio,
     DecisionContext,
     GPUModel,
     TokenResource,
@@ -316,13 +316,9 @@ def build_arkhai_observation(
         # Portfolio extraction
         totals = [0.0] * node_types
         frees = [0.0] * node_types
-        portfolio_dict = context.available_resources
-        if portfolio_dict and "resources" in portfolio_dict:
-            try:
-                portfolio = ComputeResourcePortfolio.model_validate(portfolio_dict)
-                totals, frees = count_nodes_by_slot(portfolio, node_types, gpu_slot_map)
-            except Exception as exc:
-                logger.warning("[ARKHAI COMMON] Failed to validate portfolio: %s", exc)
+        portfolio = get_compute_resource_portfolio(context)
+        if portfolio is not None:
+            totals, frees = count_nodes_by_slot(portfolio, node_types, gpu_slot_map)
 
         # Cluster node totals and free amounts
         for slot in range(node_types):

--- a/domain/compute/agent/app/policy/store.py
+++ b/domain/compute/agent/app/policy/store.py
@@ -149,21 +149,71 @@ def ri_action_make_offer_from_resource(context: DecisionContext) -> DomainAction
 # Accept-offer -> fulfill flow
 @policy_callable("ao.action.fulfill_after_accept")
 def ao_action_fulfill_after_accept(context: DecisionContext) -> DomainAction | None:
-    """When we receive an AcceptOfferEvent, move directly to fulfill compute obligation."""
+    """Handle AcceptOfferEvent by role.
+
+    Two paths depending on who we are and what escrow state we're in:
+
+    - Compute buyer, no escrow_uid yet: the seller just signalled acceptance.
+      We create the escrow by dispatching ACCEPT_OFFER (which will send a second
+      AcceptOfferEvent back to the seller with escrow_uid).
+
+    - Compute seller, escrow_uid present: the buyer created the escrow and is
+      asking us to provision. We dispatch FULFILL_COMPUTE_OBLIGATION.
+
+    Role detection: we are the compute buyer if the maker offers compute and we
+    are the taker, OR the maker offers tokens and we are the maker (buyer-as-maker
+    dispatch where we're creating the escrow for our own buy order).
+    """
     if not isinstance(context.event, AcceptOfferEvent):
         return None
 
+    from core.agent.app.utils.config import CONFIG
+
+    order = context.event.order
     escrow_uid = context.event.escrow_uid
     ssh_key = context.event.ssh_public_key
+    matched_order_id = context.event.matched_order_id
+    # source is the URL of whoever sent us this event (set by the sender).
+    sender_url = context.event.source
 
+    maker_offers_compute = isinstance(order.offer_resource, ComputeResource)
+    our_url = (CONFIG.base_url_override or "").rstrip("/")
+    maker_url = (order.order_maker or "").rstrip("/")
+    we_are_maker = bool(our_url and maker_url and our_url == maker_url)
+
+    # We are the compute buyer if:
+    # - Maker offers compute and we're the taker (seller-as-maker, normal flow).
+    # - Maker offers tokens and we're the maker (buyer-as-maker, policy-triggered).
+    compute_buyer = (maker_offers_compute and not we_are_maker) or (not maker_offers_compute and we_are_maker)
+
+    if compute_buyer:
+        # Escrow not yet created — create it now.
+        if escrow_uid:
+            return None  # already processed
+        return DomainAction(
+            action_type=DomainActionType.ACCEPT_OFFER,
+            parameters={
+                "order": order.model_dump(mode="json"),
+                "order_id": order.order_id,
+                "our_order_id": order.order_id,
+                "their_order_id": matched_order_id,
+                "counterparty_url": sender_url,
+                "matched_order_id": matched_order_id,
+            },
+        )
+
+    # Compute seller: fulfill once buyer has supplied escrow_uid and ssh_key.
+    if not escrow_uid or not ssh_key:
+        return None
     return DomainAction(
         action_type=DomainActionType.FULFILL_COMPUTE_OBLIGATION,
         parameters={
-            "order": context.event.order.model_dump(mode="json"),
+            "order": order.model_dump(mode="json"),
             "escrow_uid": escrow_uid,
             "ssh_public_key": ssh_key,
-            "oracle_address": context.event.order.oracle_address,
-            "counterparty_url": context.event.order.order_taker,
+            "oracle_address": order.oracle_address,
+            "counterparty_url": sender_url,
+            "matched_order_id": matched_order_id,
         },
     )
 

--- a/domain/compute/agent/app/policy/store.py
+++ b/domain/compute/agent/app/policy/store.py
@@ -29,6 +29,39 @@ from core.agent.app.utils.action_executor import _extract_initial_price_from_ord
 logger = logging.getLogger(__name__)
 
 
+def get_compute_resource_portfolio(
+    context: DecisionContext,
+) -> ComputeResourcePortfolio | None:
+    """Build a compute-only portfolio view from generic available resources."""
+    available_resources = context.available_resources
+    if not isinstance(available_resources, dict):
+        return None
+
+    raw_resources = available_resources.get("resources")
+    if not isinstance(raw_resources, list):
+        return None
+
+    compute_resources: list[dict[str, Any]] = []
+    for resource in raw_resources:
+        if isinstance(resource, ComputeResource):
+            compute_resources.append(resource.model_dump(mode="json"))
+            continue
+        if not isinstance(resource, dict):
+            continue
+        if "gpu_model" not in resource:
+            continue
+        compute_resources.append(resource)
+
+    if not compute_resources:
+        return None
+
+    try:
+        return ComputeResourcePortfolio.model_validate({"resources": compute_resources})
+    except Exception as exc:
+        logger.warning("[COMPUTE POLICY] Failed to validate compute portfolio: %s", exc)
+        return None
+
+
 # ----- Negotiation policies -----
 
 @policy_callable("simple_negotiation_random")
@@ -553,24 +586,16 @@ def mo_action_accept_offer(context: DecisionContext) -> DomainAction | None:
     # Check agent capacity for demand resource if it's a ComputeResource
     if isinstance(demand_resource, ComputeResource):
         # Get portfolio from available_resources
-        portfolio_dict = context.available_resources
-        if portfolio_dict and "resources" in portfolio_dict:
-            try:
-                portfolio = ComputeResourcePortfolio.model_validate(portfolio_dict)
-                if not portfolio.has_capacity(demand_resource):
-                    # Agent doesn't have capacity - reject
-                    return DomainAction(
-                        action_type=ActionType.REJECT_OFFER,
-                        parameters={
-                            "reason": "insufficient_capacity",
-                            "demand_resource": demand_resource.model_dump(mode="json"),
-                        }
-                    )
-            except Exception as e:
-                # If portfolio validation fails, log and continue
-                import logging
-                logger = logging.getLogger(__name__)
-                logger.warning(f"[POLICY] Failed to validate portfolio: {e}")
+        portfolio = get_compute_resource_portfolio(context)
+        if portfolio and not portfolio.has_capacity(demand_resource):
+            # Agent doesn't have capacity - reject
+            return DomainAction(
+                action_type=ActionType.REJECT_OFFER,
+                parameters={
+                    "reason": "insufficient_capacity",
+                    "demand_resource": demand_resource.model_dump(mode="json"),
+                }
+            )
     elif isinstance(demand_resource, TokenResource):
         # If demand is a TokenResource, accept the offer
         # Simulated assumption: we have enough tokens in our wallet

--- a/domain/compute/agent/app/policy/torch_always_accept_offer.py
+++ b/domain/compute/agent/app/policy/torch_always_accept_offer.py
@@ -11,6 +11,7 @@ except Exception:  # pragma: no cover - environment-dependent
     torch = None
 
 from core.agent.app.policy.registry import policy_callable
+from domain.compute.agent.app.policy.store import get_compute_resource_portfolio
 from core.agent.app.schema.pydantic_models import (
     Action as DomainAction,
     ActionType,
@@ -18,7 +19,6 @@ from core.agent.app.schema.pydantic_models import (
     MakeOfferEvent,
     ComputeResource,
     TokenResource,
-    ComputeResourcePortfolio,
 )
 from core.agent.app.utils.validation import extract_resources_from_make_offer_event
 
@@ -134,25 +134,19 @@ def mo_action_torch_always_accept_offer(context: DecisionContext) -> DomainActio
     # Check agent capacity for demand resource if it's a ComputeResource
     # If insufficient capacity, reject immediately without running model
     if isinstance(demand_resource, ComputeResource):
-        portfolio_dict = context.available_resources
-        if portfolio_dict and "resources" in portfolio_dict:
-            try:
-                portfolio = ComputeResourcePortfolio.model_validate(portfolio_dict)
-                if not portfolio.has_capacity(demand_resource):
-                    # Agent doesn't have capacity - reject with resource details
-                    logger.info("[TORCH POLICY] Insufficient capacity, rejecting offer")
-                    return DomainAction(
-                        action_type=ActionType.REJECT_OFFER,
-                        parameters={
-                            "reason": "insufficient_capacity",
-                            "order_id": order.order_id,
-                            "demand_resource": demand_resource.model_dump(mode="json"),
-                            "offer_resource": offer_resource.model_dump(mode="json"),
-                        }
-                    )
-            except Exception as e:
-                # If portfolio validation fails, log and continue to model
-                logger.warning(f"[TORCH POLICY] Failed to validate portfolio: {e}")
+        portfolio = get_compute_resource_portfolio(context)
+        if portfolio and not portfolio.has_capacity(demand_resource):
+            # Agent doesn't have capacity - reject with resource details
+            logger.info("[TORCH POLICY] Insufficient capacity, rejecting offer")
+            return DomainAction(
+                action_type=ActionType.REJECT_OFFER,
+                parameters={
+                    "reason": "insufficient_capacity",
+                    "order_id": order.order_id,
+                    "demand_resource": demand_resource.model_dump(mode="json"),
+                    "offer_resource": offer_resource.model_dump(mode="json"),
+                }
+            )
     elif isinstance(demand_resource, TokenResource):
         # If demand is a TokenResource, accept the offer immediately
         # Simulated assumption: we have enough tokens in our wallet

--- a/domain/compute/agent/app/policy/torch_arkhai_buyer.py
+++ b/domain/compute/agent/app/policy/torch_arkhai_buyer.py
@@ -20,12 +20,12 @@ from domain.compute.agent.app.policy.arkhai_common import (
     parse_node_types,
     torch,
 )
+from domain.compute.agent.app.policy.store import get_compute_resource_portfolio
 from core.agent.app.policy.registry import policy_callable
 from core.agent.app.schema.pydantic_models import (
     Action as DomainAction,
     ActionType,
     ComputeResource,
-    ComputeResourcePortfolio,
     DecisionContext,
     MakeOfferEvent,
 )
@@ -53,22 +53,17 @@ async def mo_action_torch_arkhai_buyer(context: DecisionContext) -> DomainAction
         return None
 
     if isinstance(demand_resource, ComputeResource):
-        portfolio_dict = context.available_resources
-        if portfolio_dict and "resources" in portfolio_dict:
-            try:
-                portfolio = ComputeResourcePortfolio.model_validate(portfolio_dict)
-                if not portfolio.has_capacity(demand_resource):
-                    return DomainAction(
-                        action_type=ActionType.REJECT_OFFER,
-                        parameters={
-                            "reason": "insufficient_capacity",
-                            "order_id": order.order_id,
-                            "demand_resource": demand_resource.model_dump(mode="json"),
-                            "offer_resource": offer_resource.model_dump(mode="json"),
-                        },
-                    )
-            except Exception as exc:
-                logger.warning("[ARKHAI BUYER POLICY] Failed to validate portfolio: %s", exc)
+        portfolio = get_compute_resource_portfolio(context)
+        if portfolio and not portfolio.has_capacity(demand_resource):
+            return DomainAction(
+                action_type=ActionType.REJECT_OFFER,
+                parameters={
+                    "reason": "insufficient_capacity",
+                    "order_id": order.order_id,
+                    "demand_resource": demand_resource.model_dump(mode="json"),
+                    "offer_resource": offer_resource.model_dump(mode="json"),
+                },
+            )
 
     node_types = parse_node_types()
     model = _get_model(obs_dim(node_types))

--- a/domain/compute/agent/app/policy/torch_arkhai_seller.py
+++ b/domain/compute/agent/app/policy/torch_arkhai_seller.py
@@ -21,12 +21,12 @@ from domain.compute.agent.app.policy.arkhai_common import (
     parse_node_types,
     torch,
 )
+from domain.compute.agent.app.policy.store import get_compute_resource_portfolio
 from core.agent.app.policy.registry import policy_callable
 from core.agent.app.schema.pydantic_models import (
     Action as DomainAction,
     ActionType,
     ComputeResource,
-    ComputeResourcePortfolio,
     DecisionContext,
     MakeOfferEvent,
 )
@@ -54,22 +54,17 @@ async def mo_action_torch_arkhai_seller(context: DecisionContext) -> DomainActio
         return None
 
     if isinstance(demand_resource, ComputeResource):
-        portfolio_dict = context.available_resources
-        if portfolio_dict and "resources" in portfolio_dict:
-            try:
-                portfolio = ComputeResourcePortfolio.model_validate(portfolio_dict)
-                if not portfolio.has_capacity(demand_resource):
-                    return DomainAction(
-                        action_type=ActionType.REJECT_OFFER,
-                        parameters={
-                            "reason": "insufficient_capacity",
-                            "order_id": order.order_id,
-                            "demand_resource": demand_resource.model_dump(mode="json"),
-                            "offer_resource": offer_resource.model_dump(mode="json"),
-                        },
-                    )
-            except Exception as exc:
-                logger.warning("[ARKHAI SELLER POLICY] Failed to validate portfolio: %s", exc)
+        portfolio = get_compute_resource_portfolio(context)
+        if portfolio and not portfolio.has_capacity(demand_resource):
+            return DomainAction(
+                action_type=ActionType.REJECT_OFFER,
+                parameters={
+                    "reason": "insufficient_capacity",
+                    "order_id": order.order_id,
+                    "demand_resource": demand_resource.model_dump(mode="json"),
+                    "offer_resource": offer_resource.model_dump(mode="json"),
+                },
+            )
 
     node_types = parse_node_types()
     model = _get_model(obs_dim(node_types))

--- a/domain/compute/agent/app/policy/torch_market_seller.py
+++ b/domain/compute/agent/app/policy/torch_market_seller.py
@@ -11,6 +11,7 @@ except Exception:  # pragma: no cover - environment-dependent
     torch = None
 
 from core.agent.app.policy.registry import policy_callable
+from domain.compute.agent.app.policy.store import get_compute_resource_portfolio
 from core.agent.app.schema.pydantic_models import (
     Action as DomainAction,
     ActionType,
@@ -18,7 +19,6 @@ from core.agent.app.schema.pydantic_models import (
     MakeOfferEvent,
     ComputeResource,
     TokenResource,
-    ComputeResourcePortfolio,
 )
 from core.agent.app.utils.validation import extract_resources_from_make_offer_event
 from core.agent.app.utils.config import CONFIG
@@ -108,13 +108,7 @@ def _build_market_observation(
     
     try:
         # Get agent portfolio
-        portfolio_dict = context.available_resources
-        portfolio = None
-        if portfolio_dict and "resources" in portfolio_dict:
-            try:
-                portfolio = ComputeResourcePortfolio.model_validate(portfolio_dict)
-            except Exception as e:
-                logger.warning(f"[MARKET SELLER POLICY] Failed to validate portfolio: {e}")
+        portfolio = get_compute_resource_portfolio(context)
         
         # Initialize observation vector (all zeros as fallback)
         obs = torch.zeros((1, 14), dtype=torch.float32)
@@ -309,23 +303,18 @@ def mo_action_torch_market_seller(context: DecisionContext) -> DomainAction | No
     
     # Check agent capacity for demand resource if it's a ComputeResource
     if isinstance(demand_resource, ComputeResource):
-        portfolio_dict = context.available_resources
-        if portfolio_dict and "resources" in portfolio_dict:
-            try:
-                portfolio = ComputeResourcePortfolio.model_validate(portfolio_dict)
-                if not portfolio.has_capacity(demand_resource):
-                    logger.info("[MARKET SELLER POLICY] Insufficient capacity, rejecting offer")
-                    return DomainAction(
-                        action_type=ActionType.REJECT_OFFER,
-                        parameters={
-                            "reason": "insufficient_capacity",
-                            "order_id": order.order_id,
-                            "demand_resource": demand_resource.model_dump(mode="json"),
-                            "offer_resource": offer_resource.model_dump(mode="json"),
-                        }
-                    )
-            except Exception as e:
-                logger.warning(f"[MARKET SELLER POLICY] Failed to validate portfolio: {e}")
+        portfolio = get_compute_resource_portfolio(context)
+        if portfolio and not portfolio.has_capacity(demand_resource):
+            logger.info("[MARKET SELLER POLICY] Insufficient capacity, rejecting offer")
+            return DomainAction(
+                action_type=ActionType.REJECT_OFFER,
+                parameters={
+                    "reason": "insufficient_capacity",
+                    "order_id": order.order_id,
+                    "demand_resource": demand_resource.model_dump(mode="json"),
+                    "offer_resource": offer_resource.model_dump(mode="json"),
+                }
+            )
     
     # Load model
     model = _get_model()


### PR DESCRIPTION
# Changes Made
- **Logic now works where compute-seller first creates the order offering compute and demanding tokens, then compute-buyer creates their order demanding compute and offering tokens.**
- Split policy handling into compute-buyer vs compute-seller
- Agent queries adapters for supported (registered) resource types
- Moved ComputeResourcePortfolio out of `core/agent` logic into `domain/compute`
- Added `matched_order_id` to explicitly transmit which orders match each other, instead of inferring it
- Removed unnecessary infinite-loop guard ("Too many message parts. Aborting.")

# Testing
## Setup
Run chain, deploy contracts, registry index, register Agents, start Agents.

## Regression
Before every test, load the resource portfolio:
```
market portfolio import-csv app/data/resources.sample.csv -e .env.bob.local
```
Buyer-first:
```
market order create -d '{"gpu_model": "H200", "quantity": 1, "sla": 90.0, "region": "California, US"}' -o '{"token":"MOCK","amount":1.0}' -e .env.alice.local
```
Then seller:
```
market order create -o '{"gpu_model": "H200", "quantity": 1, "sla": 90.0, "region": "California, US"}' -d '{"token":"MOCK","amount":1.0}' -e .env.bob.local
```
Confirm that both sides have accepted orders and connection strings:
```
market order history -e .env.alice.local 
```
```
market order history -e .env.bob.local
```

## Feature Testing
Before every test, load the resource portfolio:
```
market portfolio import-csv app/data/resources.sample.csv -e .env.bob.local
```
Seller first:
```
market order create -o '{"gpu_model": "H200", "quantity": 1, "sla": 90.0, "region": "California, US"}' -d '{"token":"MOCK","amount":1.0}' -e .env.bob.local
```
Then buyer:
```
market order create -d '{"gpu_model": "H200", "quantity": 1, "sla": 90.0, "region": "California, US"}' -o '{"token":"MOCK","amount":1.0}' -e .env.alice.local
```
Confirm that both sides have accepted orders and connection strings:
```
market order history -e .env.alice.local 
```
```
market order history -e .env.bob.local
```