### PR TITLE
Feat: Add Agent Auth

### DIFF
--- a/cli/market/groups/order.py
+++ b/cli/market/groups/order.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import os
 import json
 import textwrap
+import time
 import urllib.parse
 import urllib.request
 import urllib.error
@@ -53,7 +54,8 @@ def order_create(
     ),
 ) -> None:
     """Create a new order via the Agent endpoint."""
-    env_base_url = _read_env_value(Path(env), "BASE_URL_OVERRIDE") if env else None
+    env_path = Path(env) if env else None
+    env_base_url = _read_env_value(env_path, "BASE_URL_OVERRIDE") if env_path else None
     base_url = agent_url or env_base_url or os.getenv("AGENT_URL") or os.getenv("BASE_URL_OVERRIDE") or "http://localhost:8000"
     base_url = _normalize_registry_url(base_url)
     duration = duration_hours if duration_hours is not None else 1
@@ -69,13 +71,17 @@ def order_create(
     if not isinstance(offer_data, dict) or not isinstance(demand_data, dict):
         raise typer.BadParameter("Offer and demand must be JSON objects")
 
+    private_key = (
+        (_read_env_value(env_path, "AGENT_PRIV_KEY") if env_path else None)
+        or os.getenv("AGENT_PRIV_KEY")
+    )
     payload = {
         "offer": offer_data,
         "demand": demand_data,
         "duration_hours": duration,
     }
     url = f"{base_url}/orders/create"
-    response = _post_json(url, payload)
+    response = _post_json(url, payload, _get_auth_headers("create_order", base_url, private_key))
 
     console = Console()
     table = Table.grid(padding=(0, 2))
@@ -114,16 +120,28 @@ def order_close(
         "-a",
         help="Agent base URL (env: AGENT_URL or BASE_URL_OVERRIDE).",
     ),
+    env: str | None = typer.Option(
+        None,
+        "--env",
+        "-e",
+        help="Path to env file used to read BASE_URL_OVERRIDE and AGENT_PRIV_KEY.",
+    ),
 ) -> None:
     """Close an order via the Agent endpoint."""
-    base_url = agent_url or os.getenv("AGENT_URL") or os.getenv("BASE_URL_OVERRIDE") or "http://localhost:8000"
+    env_path = Path(env) if env else None
+    env_base_url = _read_env_value(env_path, "BASE_URL_OVERRIDE") if env_path else None
+    base_url = agent_url or env_base_url or os.getenv("AGENT_URL") or os.getenv("BASE_URL_OVERRIDE") or "http://localhost:8000"
     base_url = _normalize_registry_url(base_url)
     if not order_id.strip():
         raise typer.BadParameter("order-id must be a non-empty string")
 
+    private_key = (
+        (_read_env_value(env_path, "AGENT_PRIV_KEY") if env_path else None)
+        or os.getenv("AGENT_PRIV_KEY")
+    )
     payload = {"order_id": order_id}
     url = f"{base_url}/orders/close"
-    response = _post_json(url, payload)
+    response = _post_json(url, payload, _get_auth_headers("close_order", order_id, private_key))
 
     console = Console()
     table = Table.grid(padding=(0, 2))
@@ -248,6 +266,12 @@ def order_match(
         "-t",
         help="Order duration in hours (default: from target order or 1).",
     ),
+    env: str | None = typer.Option(
+        None,
+        "--env",
+        "-e",
+        help="Path to env file used to read BASE_URL_OVERRIDE and AGENT_PRIV_KEY.",
+    ),
 ) -> None:
     """Match an existing order by flipping offer/demand and creating a new order."""
     if not order_id.strip():
@@ -281,10 +305,16 @@ def order_match(
         "duration_hours": duration,
     }
 
-    base_agent_url = agent_url or os.getenv("AGENT_URL") or os.getenv("BASE_URL_OVERRIDE") or "http://localhost:8000"
+    env_path = Path(env) if env else None
+    env_base_url = _read_env_value(env_path, "BASE_URL_OVERRIDE") if env_path else None
+    base_agent_url = agent_url or env_base_url or os.getenv("AGENT_URL") or os.getenv("BASE_URL_OVERRIDE") or "http://localhost:8000"
     base_agent_url = _normalize_registry_url(base_agent_url)
+    private_key = (
+        (_read_env_value(env_path, "AGENT_PRIV_KEY") if env_path else None)
+        or os.getenv("AGENT_PRIV_KEY")
+    )
     create_url = f"{base_agent_url}/orders/create"
-    response = _post_json(create_url, payload)
+    response = _post_json(create_url, payload, _get_auth_headers("create_order", base_agent_url, private_key))
 
     console = Console()
     table = Table.grid(padding=(0, 2))
@@ -436,6 +466,27 @@ def _format_resource_full(resource: dict | str | None) -> str:
         return str(resource)
 
 
+def _get_auth_headers(operation: str, resource_id: str, private_key: str | None) -> dict[str, str]:
+    """Build X-Signature / X-Timestamp headers for a CLI→agent request.
+
+    Returns an empty dict if no private_key is provided or if eth_account is
+    not installed (request is sent unsigned; the agent will reject it if it
+    requires auth).
+    """
+    if not private_key:
+        return {}
+    try:
+        from eth_account import Account
+        from eth_account.messages import encode_defunct
+    except ImportError:
+        return {}
+    ts = int(time.time())
+    message = f"{operation}:{resource_id}:{ts}"
+    msg_hash = encode_defunct(text=message)
+    sig = Account.sign_message(msg_hash, private_key).signature.hex()
+    return {"X-Signature": sig, "X-Timestamp": str(ts)}
+
+
 def _get_cli_http_timeout() -> float:
     raw = os.getenv("MARKET_CLI_HTTP_TIMEOUT", "120")
     default_value = 120.0
@@ -462,13 +513,16 @@ def _fetch_json(url: str) -> dict:
         raise typer.Exit(code=1)
 
 
-def _post_json(url: str, payload: dict) -> dict:
+def _post_json(url: str, payload: dict, extra_headers: dict[str, str] | None = None) -> dict:
     try:
         data = json.dumps(payload).encode("utf-8")
+        headers = {"Accept": "application/json", "Content-Type": "application/json"}
+        if extra_headers:
+            headers.update(extra_headers)
         request = urllib.request.Request(
             url,
             data=data,
-            headers={"Accept": "application/json", "Content-Type": "application/json"},
+            headers=headers,
             method="POST",
         )
         with urllib.request.urlopen(request, timeout=_get_cli_http_timeout()) as response:

--- a/cli/tests/test_order_auth.py
+++ b/cli/tests/test_order_auth.py
@@ -1,0 +1,57 @@
+"""Unit tests for CLI order auth header generation (_get_auth_headers)."""
+
+import pytest
+
+PRIVATE_KEY = "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a"
+OWNER_ADDRESS = "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"
+
+
+def test_no_private_key_returns_empty():
+    from market.groups.order import _get_auth_headers
+    assert _get_auth_headers("create_order", "http://localhost:8000", None) == {}
+
+
+def test_empty_private_key_returns_empty():
+    from market.groups.order import _get_auth_headers
+    assert _get_auth_headers("create_order", "http://localhost:8000", "") == {}
+
+
+def test_with_key_returns_headers():
+    pytest.importorskip("eth_account")
+    from market.groups.order import _get_auth_headers
+    headers = _get_auth_headers("create_order", "http://localhost:8000", PRIVATE_KEY)
+    assert "X-Signature" in headers
+    assert "X-Timestamp" in headers
+
+
+def test_timestamp_is_recent():
+    import time
+    pytest.importorskip("eth_account")
+    from market.groups.order import _get_auth_headers
+    before = int(time.time())
+    headers = _get_auth_headers("create_order", "http://localhost:8000", PRIVATE_KEY)
+    after = int(time.time())
+    ts = int(headers["X-Timestamp"])
+    assert before <= ts <= after
+
+
+def test_signature_is_recoverable_create_order():
+    eth_account = pytest.importorskip("eth_account")
+    messages_mod = pytest.importorskip("eth_account.messages")
+    from market.groups.order import _get_auth_headers
+    headers = _get_auth_headers("create_order", "http://localhost:8000", PRIVATE_KEY)
+    ts = headers["X-Timestamp"]
+    msg = messages_mod.encode_defunct(text=f"create_order:http://localhost:8000:{ts}")
+    recovered = eth_account.Account.recover_message(msg, signature=headers["X-Signature"])
+    assert recovered.lower() == OWNER_ADDRESS.lower()
+
+
+def test_signature_is_recoverable_close_order():
+    eth_account = pytest.importorskip("eth_account")
+    messages_mod = pytest.importorskip("eth_account.messages")
+    from market.groups.order import _get_auth_headers
+    headers = _get_auth_headers("close_order", "order-xyz-123", PRIVATE_KEY)
+    ts = headers["X-Timestamp"]
+    msg = messages_mod.encode_defunct(text=f"close_order:order-xyz-123:{ts}")
+    recovered = eth_account.Account.recover_message(msg, signature=headers["X-Signature"])
+    assert recovered.lower() == OWNER_ADDRESS.lower()

--- a/core/agent/app/agent.py
+++ b/core/agent/app/agent.py
@@ -998,6 +998,45 @@ alert_route = Route("/alerts/resource", handle_resource_alert, methods=["POST"])
 AGENT_REST_API_APP_NAME = "agent-rest-api"
 AGENT_REST_API_USER_ID = "agent-rest-api"
 
+_MAX_TIMESTAMP_SKEW = 300  # seconds
+
+
+def _check_agent_request_auth(request: Request, operation: str, resource_id: str) -> JSONResponse | None:
+    """Verify X-Signature / X-Timestamp headers against the agent's own wallet address.
+
+    Returns a JSONResponse (403) if auth fails, or None to allow the request through.
+    If AGENT_WALLET_ADDRESS is not configured the check is skipped (backward compat).
+    """
+    owner = CONFIG.agent_wallet_address
+    if not owner:
+        return None
+
+    from service.clients.erc8004.signing import verify_eip191
+
+    sig = request.headers.get("X-Signature")
+    ts_raw = request.headers.get("X-Timestamp")
+
+    if not sig or not ts_raw:
+        logger.warning("[AUTH] Missing X-Signature or X-Timestamp on %s request", operation)
+        return JSONResponse({"error": "Missing auth headers"}, status_code=403)
+
+    try:
+        ts = int(ts_raw)
+    except ValueError:
+        return JSONResponse({"error": "Invalid X-Timestamp"}, status_code=403)
+
+    import time as _time
+    if abs(_time.time() - ts) > _MAX_TIMESTAMP_SKEW:
+        logger.warning("[AUTH] Timestamp too old/future for %s", operation)
+        return JSONResponse({"error": "Timestamp out of range"}, status_code=403)
+
+    message = f"{operation}:{resource_id}:{ts}"
+    if not verify_eip191(message, sig, owner):
+        logger.warning("[AUTH] Invalid signature for %s resource=%s", operation, resource_id)
+        return JSONResponse({"error": "Invalid signature"}, status_code=403)
+
+    return None
+
 async def _run_create_order_flow(request: Request) -> dict:
     """
     Internal helper to run the create order flow.
@@ -1262,6 +1301,9 @@ async def create_market_order_endpoint(request: Request) -> JSONResponse:
     """
     Expose an endpoint to create market orders via the root agent.
     """
+    auth_error = _check_agent_request_auth(request, "create_order", BASE_URL_OVERRIDE)
+    if auth_error:
+        return auth_error
 
     try:
         response = await _run_create_order_flow(request)
@@ -1289,6 +1331,15 @@ async def close_market_order_endpoint(request: Request) -> JSONResponse:
     """
     Expose an endpoint to close market orders via the root agent.
     """
+    try:
+        body = await request.json()
+        order_id = body.get("order_id", "")
+    except Exception:
+        order_id = ""
+    auth_error = _check_agent_request_auth(request, "close_order", order_id)
+    if auth_error:
+        return auth_error
+
     try:
         response = await _run_close_order_flow(request)
         return JSONResponse(response)

--- a/erc-8004-registry-py/src/api/order_routes.py
+++ b/erc-8004-registry-py/src/api/order_routes.py
@@ -1,6 +1,7 @@
 """Market order-related API routes."""
 
 import logging
+import time
 from typing import Optional
 from datetime import datetime
 
@@ -16,7 +17,15 @@ from src.api.utils import (
     validate_order_status,
     matches_resource_filters,
     find_symmetric_order,
+    verify_order_signature,
 )
+
+_MAX_TIMESTAMP_SKEW = 300  # 5 minutes
+
+
+def _check_timestamp(timestamp: int) -> None:
+    if abs(int(time.time()) - timestamp) > _MAX_TIMESTAMP_SKEW:
+        raise HTTPException(status_code=401, detail="Timestamp too old or too far in future (max 5 minutes)")
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -32,10 +41,20 @@ async def publish_order(
     agent = find_agent_by_id(db, agent_id)
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
-    
+
+    # Verify signature if agent has an owner
+    signature = order_data.pop("signature", None)
+    timestamp = order_data.pop("timestamp", None)
+    if agent.owner:
+        if not signature or timestamp is None:
+            raise HTTPException(status_code=401, detail="Signature and timestamp required for authenticated agents")
+        _check_timestamp(timestamp)
+        if not verify_order_signature("create_order", agent.agent_id, timestamp, signature, agent.owner):
+            raise HTTPException(status_code=401, detail="Invalid signature")
+
     # Use canonical agent_id for FK in MarketOrder
     agent_id_for_order = agent.agent_id
-    
+
     # Extract order fields
     order_id = order_data.get("order_id")
     if not order_id:
@@ -173,10 +192,36 @@ async def update_order(
 ):
     """Update an order (e.g., mark as accepted). Also updates the corresponding symmetric order."""
     order = db.query(MarketOrder).filter(MarketOrder.order_id == order_id).first()
-    
+
     if not order:
         raise HTTPException(status_code=404, detail="Order not found")
-    
+
+    # Verify signature if the maker agent has an owner
+    signature = updates.pop("signature", None)
+    timestamp = updates.pop("timestamp", None)
+    signer_agent_id = updates.pop("signer_agent_id", None)
+
+    maker_agent = find_agent_by_id(db, order.agent_id)
+    if maker_agent and maker_agent.owner:
+        if not signature or timestamp is None or not signer_agent_id:
+            raise HTTPException(
+                status_code=401,
+                detail="signature, timestamp, and signer_agent_id required for authenticated orders"
+            )
+        _check_timestamp(timestamp)
+
+        signer_agent = find_agent_by_id(db, signer_agent_id)
+        if not signer_agent or not signer_agent.owner:
+            raise HTTPException(status_code=403, detail="Signer agent not registered or has no owner")
+
+        is_maker = (signer_agent.agent_id == order.agent_id)
+        # A new taker can claim an unmatched order; once a taker is set only the maker can update
+        if not is_maker and order.order_taker is not None:
+            raise HTTPException(status_code=403, detail="Only the order maker can update after a taker is assigned")
+
+        if not verify_order_signature("update_order", order_id, timestamp, signature, signer_agent.owner):
+            raise HTTPException(status_code=401, detail="Invalid signature")
+
     original_order_maker = order.order_maker
     original_offer_resource = order.offer_resource
     original_demand_resource = order.demand_resource
@@ -251,15 +296,25 @@ async def get_order(
 @router.delete("/orders/{order_id}", status_code=204)
 async def delete_order(
     order_id: str = Path(..., description="Order ID"),
+    signature: Optional[str] = Query(None, description="EIP-191 signature"),
+    timestamp: Optional[int] = Query(None, description="Unix timestamp of signature"),
     db: Session = Depends(get_db),
 ):
-    """Remove an order from the registry"""
+    """Remove an order from the registry. Requires signature from the order maker's owner."""
     order = db.query(MarketOrder).filter(MarketOrder.order_id == order_id).first()
-    
+
     if not order:
         raise HTTPException(status_code=404, detail="Order not found")
-    
+
+    maker_agent = find_agent_by_id(db, order.agent_id)
+    if maker_agent and maker_agent.owner:
+        if not signature or timestamp is None:
+            raise HTTPException(status_code=401, detail="Signature and timestamp required for authenticated orders")
+        _check_timestamp(timestamp)
+        if not verify_order_signature("delete_order", order_id, timestamp, signature, maker_agent.owner):
+            raise HTTPException(status_code=401, detail="Invalid signature")
+
     db.delete(order)
     db.commit()
-    
+
     return None

--- a/erc-8004-registry-py/src/api/utils.py
+++ b/erc-8004-registry-py/src/api/utils.py
@@ -135,34 +135,46 @@ def convert_agent_card_to_registration_file(
     )
 
 
+def _verify_eip191_signature(message: str, signature: str, expected_owner: str) -> bool:
+    """Low-level EIP-191 signature verification. Recovers signer and checks against expected_owner."""
+    if not HAS_ETH_ACCOUNT:
+        return False
+    try:
+        message_hash = encode_defunct(text=message)
+        recovered = Account.recover_message(message_hash, signature=signature)
+        return recovered.lower() == expected_owner.lower()
+    except Exception as e:
+        logger.error(f"[VERIFY] EIP-191 verification error: {e}")
+        return False
+
+
 def verify_heartbeat_signature(agent_id: str, timestamp: int, signature: str, owner_address: str) -> bool:
-    """Verify heartbeat signature using EIP-191 personal sign format"""
+    """Verify heartbeat signature. Message format: 'heartbeat:{agent_id}:{timestamp}'"""
     if not HAS_ETH_ACCOUNT:
         logger.warning("[Heartbeat] eth_account not available, signature verification disabled")
         return False
+    message = f"heartbeat:{agent_id}:{timestamp}"
+    logger.info(f"[Heartbeat] Verifying for agent={agent_id} owner={owner_address}")
+    is_valid = _verify_eip191_signature(message, signature, owner_address)
+    logger.info(f"[Heartbeat] Signature valid: {is_valid}")
+    return is_valid
 
-    try:
-        # Construct the message that should have been signed
-        message = f"heartbeat:{agent_id}:{timestamp}"
-        logger.info(f"[Heartbeat] Verifying signature for agent: {agent_id}")
-        logger.info(f"[Heartbeat] Expected message: {message}")
-        logger.info(f"[Heartbeat] Expected owner: {owner_address}")
-        logger.info(f"[Heartbeat] Received signature: {signature}")
 
-        # Encode message in EIP-191 format
-        message_hash = encode_defunct(text=message)
+def verify_order_signature(operation: str, resource_id: str, timestamp: int, signature: str, owner_address: str) -> bool:
+    """Verify an order mutation signature.
 
-        # Recover the signer address from the signature
-        recovered_address = Account.recover_message(message_hash, signature=signature)
-        logger.info(f"[Heartbeat] Recovered address: {recovered_address}")
-
-        # Verify it matches the agent's owner address
-        is_valid = recovered_address.lower() == owner_address.lower()
-        logger.info(f"[Heartbeat] Signature valid: {is_valid}")
-        return is_valid
-    except Exception as e:
-        logger.error(f"[Heartbeat] Signature verification error: {e}")
+    Message format: '{operation}:{resource_id}:{timestamp}'
+    operation: 'create_order', 'update_order', or 'delete_order'
+    resource_id: agent_id for create_order, order_id for update/delete
+    """
+    if not HAS_ETH_ACCOUNT:
+        logger.warning("[Order] eth_account not available, signature verification disabled")
         return False
+    message = f"{operation}:{resource_id}:{timestamp}"
+    logger.info(f"[Order] Verifying {operation} for resource={resource_id} owner={owner_address}")
+    is_valid = _verify_eip191_signature(message, signature, owner_address)
+    logger.info(f"[Order] Signature valid: {is_valid}")
+    return is_valid
 
 
 def verify_registration_signature(
@@ -186,8 +198,6 @@ def verify_registration_signature(
         True if signature is valid, False otherwise
     """
     try:
-        from eth_account import Account
-        from eth_account.messages import encode_defunct
         import hashlib
         import json
 
@@ -221,27 +231,21 @@ def verify_registration_signature(
         data_str = json.dumps(serializable_data, sort_keys=True, separators=(',', ':'))
         data_hash = hashlib.sha256(data_str.encode()).hexdigest()[:16]
 
-        # Verify signature
         message = f"register:{owner}:{timestamp}:{data_hash}"
-        message_hash = encode_defunct(text=message)
 
-        # Ensure signature has 0x prefix and is proper format
+        # Ensure signature has 0x prefix
         if not signature.startswith('0x'):
             signature = '0x' + signature
-
-        recovered_address = Account.recover_message(message_hash, signature=signature)
-        logger.info(f"[Registration] Signature format check: original={len(signature)} chars, with prefix={signature[:10]}...")
 
         logger.info(f"[Registration] Verifying signature for owner {owner}")
         logger.info(f"[Registration] Expected message: {message}")
         logger.info(f"[Registration] Data to hash: {data_str}")
         logger.info(f"[Registration] Data hash: {data_hash}")
         logger.info(f"[Registration] Received signature: {signature}")
-        logger.info(f"[Registration] Recovered address: {recovered_address}")
-        logger.info(f"[Registration] Expected owner: {owner}")
-        logger.info(f"[Registration] Address match: {recovered_address.lower() == owner.lower()}")
 
-        return recovered_address.lower() == owner.lower()
+        is_valid = _verify_eip191_signature(message, signature, owner)
+        logger.info(f"[Registration] Address match: {is_valid}")
+        return is_valid
     except Exception as e:
         logger.error(f"[Registration] Signature verification error: {e}")
         return False

--- a/erc-8004-registry-py/tests/conftest.py
+++ b/erc-8004-registry-py/tests/conftest.py
@@ -1,5 +1,6 @@
 """Pytest configuration and fixtures."""
 
+import time
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -7,6 +8,24 @@ from sqlalchemy.pool import StaticPool
 
 from src.db.database import Base
 from src.db.models import Agent, MarketOrder, OrderStatusEnum
+
+
+@pytest.fixture(scope="session")
+def sign_order_auth():
+    """Return a helper that builds EIP-191 auth fields for order mutations.
+
+    Skips the calling test automatically if eth_account is not installed.
+    """
+    Account = pytest.importorskip("eth_account").Account
+    encode_defunct = pytest.importorskip("eth_account.messages").encode_defunct
+
+    def _sign(private_key: str, operation: str, resource_id: str) -> dict:
+        ts = int(time.time())
+        msg = encode_defunct(text=f"{operation}:{resource_id}:{ts}")
+        sig = Account.sign_message(msg, private_key).signature.hex()
+        return {"signature": sig, "timestamp": ts}
+
+    return _sign
 
 
 @pytest.fixture
@@ -48,11 +67,48 @@ def sample_agent(db_session):
 
 @pytest.fixture
 def sample_order(db_session, sample_agent):
-    """Create a sample order for testing."""
+    """Create a sample order for testing (agent has owner — auth required)."""
     order = MarketOrder(
         order_id="test-order-1",
         agent_id=sample_agent.agent_id,
         order_maker="http://localhost:8001/.well-known/agent-card.json",
+        offer_resource={"gpu_model": "A100", "region": "us-west"},
+        demand_resource={"token": "USDC"},
+        duration_hours=3600,
+        status=OrderStatusEnum.open,
+    )
+    db_session.add(order)
+    db_session.commit()
+    db_session.refresh(order)
+    return order
+
+
+@pytest.fixture
+def sample_agent_no_owner(db_session):
+    """Create a sample agent with no owner (auth not required)."""
+    agent = Agent(
+        id=2,
+        agent_id="eip155:31337:0x21df544947ba3e8b3c32561399e88b52dc8b2823:2",
+        chain_id=31337,
+        identity_registry="0x21df544947ba3e8b3c32561399e88b52dc8b2823",
+        onchain_agent_id=2,
+        registry_address="0x21df544947ba3e8b3c32561399e88b52dc8b2823",
+        owner=None,
+        token_uri="http://localhost:8002/.well-known/agent-card.json",
+    )
+    db_session.add(agent)
+    db_session.commit()
+    db_session.refresh(agent)
+    return agent
+
+
+@pytest.fixture
+def sample_order_no_owner(db_session, sample_agent_no_owner):
+    """Create a sample order for an agent with no owner (auth not required)."""
+    order = MarketOrder(
+        order_id="test-order-no-owner",
+        agent_id=sample_agent_no_owner.agent_id,
+        order_maker="http://localhost:8002/.well-known/agent-card.json",
         offer_resource={"gpu_model": "A100", "region": "us-west"},
         demand_resource={"token": "USDC"},
         duration_hours=3600,

--- a/erc-8004-registry-py/tests/unit/test_order_auth_utils.py
+++ b/erc-8004-registry-py/tests/unit/test_order_auth_utils.py
@@ -1,0 +1,92 @@
+"""Unit tests for verify_order_signature and _verify_eip191_signature in utils.py."""
+
+import time
+import pytest
+
+
+OWNER_PRIVATE_KEY = "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a"
+OWNER_ADDRESS = "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"
+OTHER_PRIVATE_KEY = "0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6"
+
+
+@pytest.fixture(scope="module")
+def eth_account():
+    return pytest.importorskip("eth_account")
+
+
+@pytest.fixture(scope="module")
+def encode_defunct():
+    return pytest.importorskip("eth_account.messages").encode_defunct
+
+
+def _make_sig(eth_account, encode_defunct, private_key: str, message: str) -> str:
+    msg_hash = encode_defunct(text=message)
+    return eth_account.Account.sign_message(msg_hash, private_key).signature.hex()
+
+
+# --- verify_order_signature ---
+
+def test_verify_order_signature_valid_create(eth_account, encode_defunct):
+    from src.api.utils import verify_order_signature
+    ts = int(time.time())
+    sig = _make_sig(eth_account, encode_defunct, OWNER_PRIVATE_KEY, f"create_order:agent-1:{ts}")
+    assert verify_order_signature("create_order", "agent-1", ts, sig, OWNER_ADDRESS) is True
+
+
+def test_verify_order_signature_valid_update(eth_account, encode_defunct):
+    from src.api.utils import verify_order_signature
+    ts = int(time.time())
+    sig = _make_sig(eth_account, encode_defunct, OWNER_PRIVATE_KEY, f"update_order:order-42:{ts}")
+    assert verify_order_signature("update_order", "order-42", ts, sig, OWNER_ADDRESS) is True
+
+
+def test_verify_order_signature_valid_delete(eth_account, encode_defunct):
+    from src.api.utils import verify_order_signature
+    ts = int(time.time())
+    sig = _make_sig(eth_account, encode_defunct, OWNER_PRIVATE_KEY, f"delete_order:order-42:{ts}")
+    assert verify_order_signature("delete_order", "order-42", ts, sig, OWNER_ADDRESS) is True
+
+
+def test_verify_order_signature_wrong_key(eth_account, encode_defunct):
+    from src.api.utils import verify_order_signature
+    ts = int(time.time())
+    sig = _make_sig(eth_account, encode_defunct, OTHER_PRIVATE_KEY, f"create_order:agent-1:{ts}")
+    assert verify_order_signature("create_order", "agent-1", ts, sig, OWNER_ADDRESS) is False
+
+
+def test_verify_order_signature_wrong_operation(eth_account, encode_defunct):
+    from src.api.utils import verify_order_signature
+    ts = int(time.time())
+    # Signed for "update_order" but verified as "create_order"
+    sig = _make_sig(eth_account, encode_defunct, OWNER_PRIVATE_KEY, f"update_order:agent-1:{ts}")
+    assert verify_order_signature("create_order", "agent-1", ts, sig, OWNER_ADDRESS) is False
+
+
+def test_verify_order_signature_wrong_resource_id(eth_account, encode_defunct):
+    from src.api.utils import verify_order_signature
+    ts = int(time.time())
+    sig = _make_sig(eth_account, encode_defunct, OWNER_PRIVATE_KEY, f"create_order:agent-1:{ts}")
+    assert verify_order_signature("create_order", "agent-999", ts, sig, OWNER_ADDRESS) is False
+
+
+def test_verify_order_signature_no_eth_account(monkeypatch):
+    import src.api.utils as utils_module
+    monkeypatch.setattr(utils_module, "HAS_ETH_ACCOUNT", False)
+    from src.api.utils import verify_order_signature
+    assert verify_order_signature("create_order", "agent-1", int(time.time()), "0xdeadbeef", OWNER_ADDRESS) is False
+
+
+# --- verify_heartbeat_signature (ensure refactor didn't break it) ---
+
+def test_verify_heartbeat_signature_still_works(eth_account, encode_defunct):
+    from src.api.utils import verify_heartbeat_signature
+    ts = int(time.time())
+    sig = _make_sig(eth_account, encode_defunct, OWNER_PRIVATE_KEY, f"heartbeat:agent-1:{ts}")
+    assert verify_heartbeat_signature("agent-1", ts, sig, OWNER_ADDRESS) is True
+
+
+def test_verify_heartbeat_signature_wrong_key(eth_account, encode_defunct):
+    from src.api.utils import verify_heartbeat_signature
+    ts = int(time.time())
+    sig = _make_sig(eth_account, encode_defunct, OTHER_PRIVATE_KEY, f"heartbeat:agent-1:{ts}")
+    assert verify_heartbeat_signature("agent-1", ts, sig, OWNER_ADDRESS) is False

--- a/erc-8004-registry-py/tests/unit/test_order_routes.py
+++ b/erc-8004-registry-py/tests/unit/test_order_routes.py
@@ -22,10 +22,10 @@ def client(db_session):
     app.dependency_overrides.clear()
 
 
-def test_create_order(client, sample_agent):
-    """Test creating a new order."""
+def test_create_order(client, sample_agent_no_owner):
+    """Test creating a new order (agent has no owner, no auth required)."""
     response = client.post(
-        f"/agents/{sample_agent.agent_id}/orders",
+        f"/agents/{sample_agent_no_owner.agent_id}/orders",
         json={
             "order_id": "test-order-create",
             "order_maker": "http://localhost:8001/.well-known/agent-card.json",
@@ -41,12 +41,12 @@ def test_create_order(client, sample_agent):
     assert data["status"] == "open"
 
 
-def test_create_order_duplicate(client, sample_agent, sample_order):
-    """Test creating order with existing order_id updates it."""
+def test_create_order_duplicate(client, sample_agent_no_owner, sample_order_no_owner):
+    """Test creating order with existing order_id updates it (no auth required)."""
     response = client.post(
-        f"/agents/{sample_agent.agent_id}/orders",
+        f"/agents/{sample_agent_no_owner.agent_id}/orders",
         json={
-            "order_id": sample_order.order_id,
+            "order_id": sample_order_no_owner.order_id,
             "order_maker": "http://localhost:8001/.well-known/agent-card.json",
             "offer_resource": {"gpu_model": "H100", "region": "us-east"},
             "demand_resource": {"token": "USDC"},
@@ -56,7 +56,7 @@ def test_create_order_duplicate(client, sample_agent, sample_order):
     )
     assert response.status_code == 201
     data = response.json()
-    assert data["order_id"] == sample_order.order_id
+    assert data["order_id"] == sample_order_no_owner.order_id
     assert data["status"] == "closed"
 
 
@@ -74,10 +74,10 @@ def test_create_order_invalid_agent(client):
     assert "Agent not found" in response.json()["detail"]
 
 
-def test_create_order_missing_order_id(client, sample_agent):
-    """Test creating order with missing order_id."""
+def test_create_order_missing_order_id(client, sample_agent_no_owner):
+    """Test creating order with missing order_id (no auth required)."""
     response = client.post(
-        f"/agents/{sample_agent.agent_id}/orders",
+        f"/agents/{sample_agent_no_owner.agent_id}/orders",
         json={
             "offer_resource": {"gpu_model": "A100"},
             "demand_resource": {"token": "USDC"},
@@ -196,10 +196,10 @@ def test_query_orders_bidirectional(client, db_session, sample_agent):
     assert len(data["items"]) >= 2
 
 
-def test_update_order(client, sample_order):
-    """Test updating an order."""
+def test_update_order(client, sample_order_no_owner):
+    """Test updating an order (agent has no owner, no auth required)."""
     response = client.put(
-        f"/orders/{sample_order.order_id}",
+        f"/orders/{sample_order_no_owner.order_id}",
         json={"status": "accepted"},
     )
     assert response.status_code == 200
@@ -207,12 +207,12 @@ def test_update_order(client, sample_order):
     assert data["status"] == "accepted"
 
 
-def test_update_order_symmetric(client, db_session, sample_agent):
-    """Test updating order updates symmetric order."""
+def test_update_order_symmetric(client, db_session, sample_agent_no_owner):
+    """Test updating order updates symmetric order (no auth required)."""
     # Create order A: offer GPU, demand token
     order_a = MarketOrder(
         order_id="order-a-symmetric",
-        agent_id=sample_agent.agent_id,
+        agent_id=sample_agent_no_owner.agent_id,
         order_maker="http://localhost:8001/.well-known/agent-card.json",
         order_taker="http://localhost:8002/.well-known/agent-card.json",
         offer_resource={"gpu_model": "A100"},
@@ -223,7 +223,7 @@ def test_update_order_symmetric(client, db_session, sample_agent):
     # Create order B: offer token, demand GPU (symmetric)
     order_b = MarketOrder(
         order_id="order-b-symmetric",
-        agent_id=sample_agent.agent_id,
+        agent_id=sample_agent_no_owner.agent_id,
         order_maker="http://localhost:8002/.well-known/agent-card.json",
         offer_resource={"token": "USDC"},
         demand_resource={"gpu_model": "A100"},
@@ -236,7 +236,8 @@ def test_update_order_symmetric(client, db_session, sample_agent):
     
     response = client.put(
         f"/orders/{order_a.order_id}",
-        json={"status": "accepted"},
+        # Include order_taker so the route triggers symmetric order lookup
+        json={"status": "accepted", "order_taker": "http://localhost:8002/.well-known/agent-card.json"},
     )
     assert response.status_code == 200
     data = response.json()
@@ -244,9 +245,9 @@ def test_update_order_symmetric(client, db_session, sample_agent):
     assert data.get("symmetric_order_updated") is not None
 
 
-def test_delete_order(client, sample_order):
-    """Test deleting an order."""
-    response = client.delete(f"/orders/{sample_order.order_id}")
+def test_delete_order(client, sample_order_no_owner):
+    """Test deleting an order (agent has no owner, no auth required)."""
+    response = client.delete(f"/orders/{sample_order_no_owner.order_id}")
     assert response.status_code == 204
 
 
@@ -254,4 +255,195 @@ def test_delete_order_not_found(client):
     """Test deleting non-existent order."""
     response = client.delete("/orders/nonexistent")
     assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Auth tests — sample_agent has owner set (0x3C44...293BC, Hardhat account #2)
+# Private key: 0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a
+# Taker agent uses Hardhat account #3: 0x90F79bf6EB2c4f870365E785982E1f101E93b906
+# ---------------------------------------------------------------------------
+
+MAKER_PRIVATE_KEY = "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a"
+TAKER_PRIVATE_KEY = "0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6"
+TAKER_ADDRESS = "0x90F79bf6EB2c4f870365E785982E1f101E93b906"
+
+
+# --- publish (POST /agents/{agent_id}/orders) ---
+
+def test_publish_order_authenticated_no_auth_returns_401(client, sample_agent):
+    """Agents with an owner reject unsigned publish requests."""
+    response = client.post(
+        f"/agents/{sample_agent.agent_id}/orders",
+        json={"order_id": "ord-auth-1", "offer_resource": {}, "demand_resource": {}},
+    )
+    assert response.status_code == 401
+
+
+def test_publish_order_authenticated_valid_signature(client, sample_agent, sign_order_auth):
+    """Valid signature from the agent owner allows publish."""
+    auth = sign_order_auth(MAKER_PRIVATE_KEY, "create_order", sample_agent.agent_id)
+    response = client.post(
+        f"/agents/{sample_agent.agent_id}/orders",
+        json={
+            "order_id": "ord-auth-valid",
+            "order_maker": "http://localhost:8001/",
+            "offer_resource": {"gpu_model": "A100"},
+            "demand_resource": {"token": "USDC"},
+            "duration_hours": 1,
+            **auth,
+        },
+    )
+    assert response.status_code == 201
+
+
+def test_publish_order_authenticated_wrong_signature_returns_401(client, sample_agent, sign_order_auth):
+    """Signature from a different key is rejected."""
+    auth = sign_order_auth(TAKER_PRIVATE_KEY, "create_order", sample_agent.agent_id)
+    response = client.post(
+        f"/agents/{sample_agent.agent_id}/orders",
+        json={
+            "order_id": "ord-auth-wrong",
+            "offer_resource": {},
+            "demand_resource": {},
+            **auth,
+        },
+    )
+    assert response.status_code == 401
+
+
+def test_publish_order_authenticated_stale_timestamp_returns_401(client, sample_agent, sign_order_auth):
+    """Timestamp older than 5 minutes is rejected."""
+    import time
+    # Build a valid signature but manually set a stale timestamp
+    auth = sign_order_auth(MAKER_PRIVATE_KEY, "create_order", sample_agent.agent_id)
+    auth["timestamp"] = int(time.time()) - 400  # backdate to 400s ago
+    response = client.post(
+        f"/agents/{sample_agent.agent_id}/orders",
+        json={"order_id": "ord-stale", "offer_resource": {}, "demand_resource": {}, **auth},
+    )
+    assert response.status_code == 401
+
+
+# --- update (PUT /orders/{order_id}) ---
+
+def test_update_order_authenticated_no_auth_returns_401(client, sample_order):
+    """Updating an owned order without auth is rejected."""
+    response = client.put(f"/orders/{sample_order.order_id}", json={"status": "closed"})
+    assert response.status_code == 401
+
+
+def test_update_order_authenticated_as_maker(client, sample_order, sample_agent, sign_order_auth):
+    """Maker can update their own order with a valid signature."""
+    auth = sign_order_auth(MAKER_PRIVATE_KEY, "update_order", sample_order.order_id)
+    response = client.put(
+        f"/orders/{sample_order.order_id}",
+        json={"status": "closed", "signer_agent_id": sample_agent.agent_id, **auth},
+    )
+    assert response.status_code == 200
+    assert response.json()["status"] == "closed"
+
+
+def test_update_order_authenticated_wrong_signature_returns_401(client, sample_order, sample_agent, sign_order_auth):
+    """Wrong signature on update is rejected."""
+    auth = sign_order_auth(TAKER_PRIVATE_KEY, "update_order", sample_order.order_id)
+    # signer_agent_id points to the maker's agent, but signature is from taker key — mismatch
+    response = client.put(
+        f"/orders/{sample_order.order_id}",
+        json={"status": "closed", "signer_agent_id": sample_agent.agent_id, **auth},
+    )
+    assert response.status_code == 401
+
+
+def test_update_order_as_new_taker(client, db_session, sample_order, sample_agent, sign_order_auth):
+    """A registered taker agent can claim an unmatched order."""
+    from src.db.models import Agent
+    taker_agent = Agent(
+        id=3,
+        agent_id="eip155:31337:0x21df544947ba3e8b3c32561399e88b52dc8b2823:3",
+        chain_id=31337,
+        identity_registry="0x21df544947ba3e8b3c32561399e88b52dc8b2823",
+        onchain_agent_id=3,
+        registry_address="0x21df544947ba3e8b3c32561399e88b52dc8b2823",
+        owner=TAKER_ADDRESS,
+        token_uri="http://localhost:8003/.well-known/agent-card.json",
+    )
+    db_session.add(taker_agent)
+    db_session.commit()
+
+    auth = sign_order_auth(TAKER_PRIVATE_KEY, "update_order", sample_order.order_id)
+    response = client.put(
+        f"/orders/{sample_order.order_id}",
+        json={
+            "status": "accepted",
+            "order_taker": "http://localhost:8003/",
+            "signer_agent_id": taker_agent.agent_id,
+            **auth,
+        },
+    )
+    assert response.status_code == 200
+
+
+def test_update_order_blocked_after_taker_assigned(client, db_session, sample_agent, sign_order_auth):
+    """After a taker is assigned, a third party cannot update the order."""
+    from src.db.models import Agent, MarketOrder
+    # Order already has a taker
+    order = MarketOrder(
+        order_id="ord-with-taker",
+        agent_id=sample_agent.agent_id,
+        order_maker="http://localhost:8001/",
+        order_taker="http://localhost:8003/",  # taker already set
+        offer_resource={"gpu_model": "A100"},
+        demand_resource={"token": "USDC"},
+        duration_hours=1,
+        status=OrderStatusEnum.accepted,
+    )
+    db_session.add(order)
+
+    interloper = Agent(
+        id=4,
+        agent_id="eip155:31337:0x21df544947ba3e8b3c32561399e88b52dc8b2823:4",
+        chain_id=31337,
+        identity_registry="0x21df544947ba3e8b3c32561399e88b52dc8b2823",
+        onchain_agent_id=4,
+        registry_address="0x21df544947ba3e8b3c32561399e88b52dc8b2823",
+        owner=TAKER_ADDRESS,
+        token_uri="http://localhost:8004/.well-known/agent-card.json",
+    )
+    db_session.add(interloper)
+    db_session.commit()
+
+    auth = sign_order_auth(TAKER_PRIVATE_KEY, "update_order", order.order_id)
+    response = client.put(
+        f"/orders/{order.order_id}",
+        json={"status": "closed", "signer_agent_id": interloper.agent_id, **auth},
+    )
+    assert response.status_code == 403
+
+
+# --- delete (DELETE /orders/{order_id}) ---
+
+def test_delete_order_authenticated_no_auth_returns_401(client, sample_order):
+    """Deleting an owned order without a signature is rejected."""
+    response = client.delete(f"/orders/{sample_order.order_id}")
+    assert response.status_code == 401
+
+
+def test_delete_order_authenticated_valid_signature(client, sample_order, sign_order_auth):
+    """Maker can delete their own order with a valid signature."""
+    auth = sign_order_auth(MAKER_PRIVATE_KEY, "delete_order", sample_order.order_id)
+    response = client.delete(
+        f"/orders/{sample_order.order_id}",
+        params={"signature": auth["signature"], "timestamp": auth["timestamp"]},
+    )
+    assert response.status_code == 204
+
+
+def test_delete_order_authenticated_wrong_signature_returns_401(client, sample_order, sign_order_auth):
+    """Wrong key on delete is rejected."""
+    auth = sign_order_auth(TAKER_PRIVATE_KEY, "delete_order", sample_order.order_id)
+    response = client.delete(
+        f"/orders/{sample_order.order_id}",
+        params={"signature": auth["signature"], "timestamp": auth["timestamp"]},
+    )
+    assert response.status_code == 401
 

--- a/service/src/service/clients/erc8004/heartbeat.py
+++ b/service/src/service/clients/erc8004/heartbeat.py
@@ -30,7 +30,6 @@ async def send_heartbeat(
     agent_id: str,
     indexer_url: str,
     private_key: Optional[str] = None,
-    owner_address: Optional[str] = None
 ) -> bool:
     """
     Send heartbeat to Indexer to indicate agent is alive.
@@ -41,7 +40,6 @@ async def send_heartbeat(
         agent_id: Agent ID (from Indexer registration)
         indexer_url: Indexer API URL
         private_key: Private key for signing heartbeat (optional if agent has no owner)
-        owner_address: Owner wallet address (optional, used for logging)
 
     Returns:
         True if successful, False otherwise
@@ -129,7 +127,6 @@ async def heartbeat_loop(
     agent_id: Optional[str],
     indexer_url: str,
     private_key: Optional[str] = None,
-    owner_address: Optional[str] = None
 ):
     """
     Background task to periodically send heartbeats to Indexer.
@@ -138,7 +135,6 @@ async def heartbeat_loop(
         agent_id: Agent ID from registration (None if not registered)
         indexer_url: Indexer API URL
         private_key: Private key for signing heartbeats (optional)
-        owner_address: Owner wallet address (optional, for logging)
     """
     if agent_id is None:
         logger.debug("[HEARTBEAT] No agent ID, skipping heartbeat loop")
@@ -153,7 +149,7 @@ async def heartbeat_loop(
     while True:
         try:
             await asyncio.sleep(HEARTBEAT_INTERVAL)
-            success = await send_heartbeat(agent_id, indexer_url, private_key, owner_address)
+            success = await send_heartbeat(agent_id, indexer_url, private_key)
             if success:
                 logger.debug(f"[HEARTBEAT] Heartbeat sent successfully")
         except asyncio.CancelledError:
@@ -217,6 +213,6 @@ async def start_agent_heartbeat(config: dict) -> Optional[str]:
         agent_id=agent_id,
     )
 
-    asyncio.create_task(heartbeat_loop(canonical_id, indexer_url, agent_priv_key, agent_wallet_address))
+    asyncio.create_task(heartbeat_loop(canonical_id, indexer_url, agent_priv_key))
     logger.info(f"[HEARTBEAT] Started heartbeat for {canonical_id}")
     return agent_wallet_address

--- a/service/src/service/clients/erc8004/heartbeat.py
+++ b/service/src/service/clients/erc8004/heartbeat.py
@@ -10,12 +10,7 @@ import urllib.parse
 import urllib.request
 from typing import Optional
 
-try:
-    from eth_account import Account
-    from eth_account.messages import encode_defunct
-    HAS_ETH_ACCOUNT = True
-except ImportError:
-    HAS_ETH_ACCOUNT = False
+from .signing import sign_eip191
 
 # Try to use aiohttp for async HTTP, fallback to urllib
 try:
@@ -57,24 +52,12 @@ async def send_heartbeat(
         # Prepare request body with signature if private key is available
         body = {}
         if private_key:
-            if not HAS_ETH_ACCOUNT:
-                logger.warning("[HEARTBEAT] eth_account not available, sending heartbeat without signature")
+            message = f"heartbeat:{agent_id}:{timestamp}"
+            signature = sign_eip191(private_key, message)
+            if signature:
+                body = {"signature": signature, "timestamp": timestamp}
             else:
-                try:
-                    # Construct message to sign
-                    message = f"heartbeat:{agent_id}:{timestamp}"
-
-                    # Sign message using EIP-191 personal sign format
-                    message_hash = encode_defunct(text=message)
-                    signed_message = Account.sign_message(message_hash, private_key)
-                    signature = signed_message.signature.hex()
-
-                    body = {
-                        "signature": signature,
-                        "timestamp": timestamp
-                    }
-                except Exception as e:
-                    logger.warning(f"[HEARTBEAT] Failed to sign heartbeat: {e}")
+                logger.warning("[HEARTBEAT] Signing unavailable, sending heartbeat without signature")
 
         # URL-encode the agent_id for use in path parameter (handles canonical IDs with colons)
         encoded_agent_id = urllib.parse.quote(agent_id, safe='')

--- a/service/src/service/clients/erc8004/signing.py
+++ b/service/src/service/clients/erc8004/signing.py
@@ -28,6 +28,19 @@ def sign_eip191(private_key: str, message: str) -> Optional[str]:
         return None
 
 
+def verify_eip191(message: str, signature: str, expected_address: str) -> bool:
+    """Verify an EIP-191 signature. Returns True if the signer matches expected_address."""
+    if not HAS_ETH_ACCOUNT:
+        return False
+    try:
+        message_hash = encode_defunct(text=message)
+        recovered = Account.recover_message(message_hash, signature=signature)
+        return recovered.lower() == expected_address.lower()
+    except Exception as e:
+        logger.error(f"[SIGNING] Failed to verify signature: {e}")
+        return False
+
+
 def build_order_auth(private_key: str, operation: str, resource_id: str) -> dict:
     """Build auth fields for an order mutation request.
 

--- a/service/src/service/clients/erc8004/signing.py
+++ b/service/src/service/clients/erc8004/signing.py
@@ -1,0 +1,48 @@
+"""Shared EIP-191 signing utilities for order and heartbeat auth."""
+
+import time
+import logging
+from typing import Optional
+
+try:
+    from eth_account import Account
+    from eth_account.messages import encode_defunct
+    HAS_ETH_ACCOUNT = True
+except ImportError:
+    HAS_ETH_ACCOUNT = False
+
+logger = logging.getLogger(__name__)
+
+
+def sign_eip191(private_key: str, message: str) -> Optional[str]:
+    """Sign a message with EIP-191 personal sign. Returns hex signature or None."""
+    if not HAS_ETH_ACCOUNT:
+        logger.warning("[SIGNING] eth_account not available, cannot sign message")
+        return None
+    try:
+        message_hash = encode_defunct(text=message)
+        signed = Account.sign_message(message_hash, private_key)
+        return signed.signature.hex()
+    except Exception as e:
+        logger.error(f"[SIGNING] Failed to sign message: {e}")
+        return None
+
+
+def build_order_auth(private_key: str, operation: str, resource_id: str) -> dict:
+    """Build auth fields for an order mutation request.
+
+    Args:
+        private_key: Hex private key of the signer
+        operation: One of 'create_order', 'update_order', 'delete_order'
+        resource_id: agent_id for create_order, order_id for update/delete
+
+    Returns:
+        Dict with 'signature' and 'timestamp' to merge into the request body/params.
+        Empty dict if signing is unavailable.
+    """
+    timestamp = int(time.time())
+    message = f"{operation}:{resource_id}:{timestamp}"
+    sig = sign_eip191(private_key, message)
+    if sig is None:
+        return {}
+    return {"signature": sig, "timestamp": timestamp}

--- a/service/src/service/clients/indexer.py
+++ b/service/src/service/clients/indexer.py
@@ -337,6 +337,78 @@ class RegistryClient:
 _registry_client: Optional[RegistryClient] = None
 
 
+_ALKAHEST_NETWORK_CHAIN_IDS: dict[str, int] = {
+    "anvil": 31337,
+    "base_sepolia": 84532,
+    "ethereum_sepolia": 11155111,
+    "ethereum_mainnet": 1,
+}
+
+
+def _resolve_canonical_agent_id() -> str | None:
+    """Resolve the full canonical agent ID (eip155:...) for registry signing.
+
+    Resolution order:
+    1. ONCHAIN_AGENT_ID already in canonical format → use as-is.
+    2. Build from ONCHAIN_AGENT_ID + IDENTITY_REGISTRY_ADDRESS + chain ID
+       (chain ID sourced from: CHAIN_ID env → ALKAHEST_NETWORK map → web3 call).
+    3. Fall back to AGENT_ID.
+    """
+    onchain_agent_id = os.getenv("ONCHAIN_AGENT_ID")
+    if not onchain_agent_id:
+        return os.getenv("AGENT_ID")
+
+    if onchain_agent_id.startswith("eip155:"):
+        return onchain_agent_id
+
+    identity_registry = os.getenv("IDENTITY_REGISTRY_ADDRESS")
+    if not identity_registry:
+        logger.warning(
+            "[REGISTRY] IDENTITY_REGISTRY_ADDRESS not set; using raw ONCHAIN_AGENT_ID=%s as signer_agent_id",
+            onchain_agent_id,
+        )
+        return onchain_agent_id
+
+    try:
+        numeric_id = int(onchain_agent_id)
+    except ValueError:
+        return onchain_agent_id
+
+    # Resolve chain ID.
+    chain_id: int | None = None
+    chain_id_env = os.getenv("CHAIN_ID")
+    if chain_id_env:
+        try:
+            chain_id = int(chain_id_env)
+        except ValueError:
+            pass
+    if chain_id is None:
+        chain_id = _ALKAHEST_NETWORK_CHAIN_IDS.get(os.getenv("ALKAHEST_NETWORK", "").lower())
+    if chain_id is None:
+        chain_rpc_url = os.getenv("CHAIN_RPC_URL")
+        if chain_rpc_url:
+            try:
+                from web3 import Web3
+                from web3.providers import HTTPProvider
+                from service.clients.erc8004.blockchain import rpc_url_for_http_provider
+                w3 = Web3(HTTPProvider(rpc_url_for_http_provider(chain_rpc_url), request_kwargs={"timeout": 5}))
+                chain_id = w3.eth.chain_id
+            except Exception as exc:
+                logger.warning("[REGISTRY] Could not resolve chain ID from RPC: %s", exc)
+    if chain_id is None:
+        logger.warning("[REGISTRY] Cannot resolve chain ID; using raw ONCHAIN_AGENT_ID=%s", onchain_agent_id)
+        return onchain_agent_id
+
+    try:
+        from service.clients.erc8004.blockchain import build_erc8004_canonical_id
+        canonical = build_erc8004_canonical_id(chain_id, identity_registry, numeric_id)
+        logger.debug("[REGISTRY] Resolved canonical agent ID: %s", canonical)
+        return canonical
+    except Exception as exc:
+        logger.warning("[REGISTRY] Failed to build canonical ID: %s", exc)
+        return onchain_agent_id
+
+
 def get_registry_client() -> RegistryClient:
     """Get or create global registry client instance."""
     global _registry_client
@@ -345,6 +417,6 @@ def get_registry_client() -> RegistryClient:
         _registry_client = RegistryClient(
             timeout=timeout,
             private_key=os.getenv("AGENT_PRIV_KEY"),
-            agent_id=os.getenv("AGENT_ID"),
+            agent_id=_resolve_canonical_agent_id(),
         )
     return _registry_client

--- a/service/src/service/clients/indexer.py
+++ b/service/src/service/clients/indexer.py
@@ -6,7 +6,8 @@ import logging
 import os
 import aiohttp
 from typing import Any, Dict, List, Optional
-from datetime import datetime, timedelta
+
+from service.clients.erc8004.signing import build_order_auth
 
 logger = logging.getLogger(__name__)
 
@@ -14,16 +15,26 @@ logger = logging.getLogger(__name__)
 class RegistryClient:
     """Client for interacting with the ERC-8004 registry API."""
 
-    def __init__(self, base_url: str | None = None, timeout: int = 30):
+    def __init__(
+        self,
+        base_url: str | None = None,
+        timeout: int = 30,
+        private_key: str | None = None,
+        agent_id: str | None = None,
+    ):
         """Initialize registry client.
 
         Args:
             base_url: Base URL of the registry API (defaults to INDEXER_URL env var)
             timeout: Request timeout in seconds
+            private_key: Agent private key for signing mutations (optional)
+            agent_id: Canonical agent ID used as signer_agent_id on updates (optional)
         """
         self.base_url = (base_url or os.getenv("INDEXER_URL", os.getenv("REGISTRY_URL", "http://localhost:8080"))).rstrip('/')
         self.timeout = aiohttp.ClientTimeout(total=timeout)
         self._session: Optional[aiohttp.ClientSession] = None
+        self._private_key = private_key or os.getenv("AGENT_PRIV_KEY")
+        self._agent_id = agent_id or os.getenv("AGENT_ID")
 
     async def _get_session(self) -> aiohttp.ClientSession:
         """Get or create aiohttp session."""
@@ -186,9 +197,12 @@ class RegistryClient:
         """
         try:
             session = await self._get_session()
+            payload = dict(order)
+            if self._private_key:
+                payload.update(build_order_auth(self._private_key, "create_order", agent_id))
             async with session.post(
                 f"{self.base_url}/agents/{agent_id}/orders",
-                json=order
+                json=payload
             ) as response:
                 if response.status == 201:
                     return await response.json()
@@ -216,9 +230,13 @@ class RegistryClient:
         """
         try:
             session = await self._get_session()
+            payload = dict(updates)
+            if self._private_key and self._agent_id:
+                payload.update(build_order_auth(self._private_key, "update_order", order_id))
+                payload["signer_agent_id"] = self._agent_id
             async with session.put(
                 f"{self.base_url}/orders/{order_id}",
-                json=updates
+                json=payload
             ) as response:
                 if response.status == 200:
                     return await response.json()
@@ -244,7 +262,14 @@ class RegistryClient:
         """
         try:
             session = await self._get_session()
-            async with session.delete(f"{self.base_url}/orders/{order_id}") as response:
+            params = {}
+            if self._private_key:
+                auth = build_order_auth(self._private_key, "delete_order", order_id)
+                params = {"signature": auth["signature"], "timestamp": auth["timestamp"]} if auth else {}
+            async with session.delete(
+                f"{self.base_url}/orders/{order_id}",
+                params=params
+            ) as response:
                 if response.status == 204:
                     return True
                 else:
@@ -317,5 +342,9 @@ def get_registry_client() -> RegistryClient:
     global _registry_client
     if _registry_client is None:
         timeout = int(os.getenv("REGISTRY_ORDER_TIMEOUT", "30"))
-        _registry_client = RegistryClient(timeout=timeout)
+        _registry_client = RegistryClient(
+            timeout=timeout,
+            private_key=os.getenv("AGENT_PRIV_KEY"),
+            agent_id=os.getenv("AGENT_ID"),
+        )
     return _registry_client

--- a/service/tests/unit/test_indexer.py
+++ b/service/tests/unit/test_indexer.py
@@ -4,10 +4,26 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import aiohttp
 
 
+PRIVATE_KEY = "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a"
+AGENT_ID = "eip155:31337:0xregistry:1"
+
+
 @pytest.fixture
 def client():
     from service.clients.indexer import RegistryClient
     return RegistryClient(base_url="http://test-indexer:8080", timeout=5)
+
+
+@pytest.fixture
+def auth_client():
+    """RegistryClient configured with a private key and agent_id for signing."""
+    from service.clients.indexer import RegistryClient
+    return RegistryClient(
+        base_url="http://test-indexer:8080",
+        timeout=5,
+        private_key=PRIVATE_KEY,
+        agent_id=AGENT_ID,
+    )
 
 
 @pytest.mark.asyncio
@@ -66,6 +82,127 @@ async def test_delete_order_success(client):
     with patch.object(client, "_get_session", return_value=mock_session):
         result = await client.delete_order("ord1")
     assert result is True
+
+
+@pytest.mark.asyncio
+async def test_publish_order_attaches_signature(auth_client):
+    """When private_key is set, publish_order adds signature+timestamp to the payload."""
+    pytest.importorskip("eth_account")
+    captured = {}
+    mock_response = AsyncMock()
+    mock_response.status = 201
+    mock_response.json = AsyncMock(return_value={"order_id": "ord1"})
+    mock_session = AsyncMock()
+
+    def capture_post(url, json=None, **kwargs):
+        captured["payload"] = json
+        cm = AsyncMock()
+        cm.__aenter__ = AsyncMock(return_value=mock_response)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        return cm
+
+    mock_session.post = MagicMock(side_effect=capture_post)
+    with patch.object(auth_client, "_get_session", return_value=mock_session):
+        await auth_client.publish_order(AGENT_ID, {"order_id": "ord1"})
+
+    assert "signature" in captured["payload"]
+    assert "timestamp" in captured["payload"]
+
+
+@pytest.mark.asyncio
+async def test_publish_order_no_private_key_no_signature(client):
+    """Without a private key, no auth fields are added to the payload."""
+    captured = {}
+    mock_response = AsyncMock()
+    mock_response.status = 201
+    mock_response.json = AsyncMock(return_value={"order_id": "ord1"})
+    mock_session = AsyncMock()
+
+    def capture_post(url, json=None, **kwargs):
+        captured["payload"] = json
+        cm = AsyncMock()
+        cm.__aenter__ = AsyncMock(return_value=mock_response)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        return cm
+
+    mock_session.post = MagicMock(side_effect=capture_post)
+    with patch.object(client, "_get_session", return_value=mock_session):
+        await client.publish_order("agent1", {"order_id": "ord1"})
+
+    assert "signature" not in captured["payload"]
+    assert "timestamp" not in captured["payload"]
+
+
+@pytest.mark.asyncio
+async def test_update_order_attaches_signature_and_signer_id(auth_client):
+    """update_order includes signature, timestamp, and signer_agent_id when credentialed."""
+    pytest.importorskip("eth_account")
+    captured = {}
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.json = AsyncMock(return_value={"order_id": "ord1", "status": "closed"})
+    mock_session = AsyncMock()
+
+    def capture_put(url, json=None, **kwargs):
+        captured["payload"] = json
+        cm = AsyncMock()
+        cm.__aenter__ = AsyncMock(return_value=mock_response)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        return cm
+
+    mock_session.put = MagicMock(side_effect=capture_put)
+    with patch.object(auth_client, "_get_session", return_value=mock_session):
+        await auth_client.update_order("ord1", {"status": "closed"})
+
+    assert "signature" in captured["payload"]
+    assert "timestamp" in captured["payload"]
+    assert captured["payload"]["signer_agent_id"] == AGENT_ID
+
+
+@pytest.mark.asyncio
+async def test_delete_order_attaches_signature_as_query_params(auth_client):
+    """delete_order passes signature and timestamp as query params when credentialed."""
+    pytest.importorskip("eth_account")
+    captured = {}
+    mock_response = AsyncMock()
+    mock_response.status = 204
+    mock_session = AsyncMock()
+
+    def capture_delete(url, params=None, **kwargs):
+        captured["params"] = params
+        cm = AsyncMock()
+        cm.__aenter__ = AsyncMock(return_value=mock_response)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        return cm
+
+    mock_session.delete = MagicMock(side_effect=capture_delete)
+    with patch.object(auth_client, "_get_session", return_value=mock_session):
+        await auth_client.delete_order("ord1")
+
+    assert "signature" in captured["params"]
+    assert "timestamp" in captured["params"]
+
+
+@pytest.mark.asyncio
+async def test_delete_order_no_private_key_empty_params(client):
+    """Without a private key, delete_order sends no query params."""
+    captured = {}
+    mock_response = AsyncMock()
+    mock_response.status = 204
+    mock_session = AsyncMock()
+
+    def capture_delete(url, params=None, **kwargs):
+        captured["params"] = params
+        cm = AsyncMock()
+        cm.__aenter__ = AsyncMock(return_value=mock_response)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        return cm
+
+    mock_session.delete = MagicMock(side_effect=capture_delete)
+    with patch.object(client, "_get_session", return_value=mock_session):
+        await client.delete_order("ord1")
+
+    assert captured["params"] == {}
 
 
 def test_get_registry_client_singleton(monkeypatch):

--- a/service/tests/unit/test_signing.py
+++ b/service/tests/unit/test_signing.py
@@ -65,3 +65,31 @@ def test_build_order_auth_no_eth_account(monkeypatch):
     monkeypatch.setattr(mod, "HAS_ETH_ACCOUNT", False)
     from service.clients.erc8004.signing import build_order_auth
     assert build_order_auth(PRIVATE_KEY, "create_order", "agent-id") == {}
+
+
+def test_verify_eip191_valid():
+    pytest.importorskip("eth_account")
+    from service.clients.erc8004.signing import sign_eip191, verify_eip191
+    sig = sign_eip191(PRIVATE_KEY, "hello")
+    assert verify_eip191("hello", sig, OWNER_ADDRESS) is True
+
+
+def test_verify_eip191_wrong_address():
+    pytest.importorskip("eth_account")
+    from service.clients.erc8004.signing import sign_eip191, verify_eip191
+    sig = sign_eip191(PRIVATE_KEY, "hello")
+    assert verify_eip191("hello", sig, "0x000000000000000000000000000000000000dead") is False
+
+
+def test_verify_eip191_wrong_message():
+    pytest.importorskip("eth_account")
+    from service.clients.erc8004.signing import sign_eip191, verify_eip191
+    sig = sign_eip191(PRIVATE_KEY, "hello")
+    assert verify_eip191("wrong message", sig, OWNER_ADDRESS) is False
+
+
+def test_verify_eip191_no_eth_account(monkeypatch):
+    import service.clients.erc8004.signing as mod
+    monkeypatch.setattr(mod, "HAS_ETH_ACCOUNT", False)
+    from service.clients.erc8004.signing import verify_eip191
+    assert verify_eip191("hello", "0xdeadbeef", OWNER_ADDRESS) is False

--- a/service/tests/unit/test_signing.py
+++ b/service/tests/unit/test_signing.py
@@ -1,0 +1,67 @@
+"""Unit tests for service.clients.erc8004.signing."""
+
+import time
+import pytest
+
+PRIVATE_KEY = "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a"
+OWNER_ADDRESS = "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"
+
+
+def test_sign_eip191_returns_hex_string():
+    pytest.importorskip("eth_account")
+    from service.clients.erc8004.signing import sign_eip191
+    sig = sign_eip191(PRIVATE_KEY, "hello world")
+    assert sig is not None
+    assert isinstance(sig, str)
+    assert len(sig) == 130  # 65 bytes, no 0x prefix
+
+
+def test_sign_eip191_is_recoverable():
+    """The signature produced can be recovered back to the expected address."""
+    eth_account = pytest.importorskip("eth_account")
+    encode_defunct = pytest.importorskip("eth_account.messages").encode_defunct
+    from service.clients.erc8004.signing import sign_eip191
+    message = "test-recovery"
+    sig = sign_eip191(PRIVATE_KEY, message)
+    recovered = eth_account.Account.recover_message(encode_defunct(text=message), signature=sig)
+    assert recovered.lower() == OWNER_ADDRESS.lower()
+
+
+def test_sign_eip191_no_eth_account(monkeypatch):
+    import service.clients.erc8004.signing as mod
+    monkeypatch.setattr(mod, "HAS_ETH_ACCOUNT", False)
+    from service.clients.erc8004.signing import sign_eip191
+    assert sign_eip191(PRIVATE_KEY, "hello") is None
+
+
+def test_build_order_auth_has_required_fields():
+    pytest.importorskip("eth_account")
+    from service.clients.erc8004.signing import build_order_auth
+    before = int(time.time())
+    auth = build_order_auth(PRIVATE_KEY, "create_order", "agent-id-123")
+    after = int(time.time())
+    assert "signature" in auth
+    assert "timestamp" in auth
+    assert before <= auth["timestamp"] <= after
+    assert isinstance(auth["signature"], str)
+    assert len(auth["signature"]) == 130
+
+
+def test_build_order_auth_message_format():
+    """The message embedded in the signature matches the expected format."""
+    eth_account = pytest.importorskip("eth_account")
+    encode_defunct = pytest.importorskip("eth_account.messages").encode_defunct
+    from service.clients.erc8004.signing import build_order_auth
+    auth = build_order_auth(PRIVATE_KEY, "update_order", "order-xyz")
+    expected_msg = f"update_order:order-xyz:{auth['timestamp']}"
+    recovered = eth_account.Account.recover_message(
+        encode_defunct(text=expected_msg), signature=auth["signature"]
+    )
+    assert recovered.lower() == OWNER_ADDRESS.lower()
+
+
+def test_build_order_auth_no_eth_account(monkeypatch):
+    import service.clients.erc8004.signing as mod
+    monkeypatch.setattr(mod, "HAS_ETH_ACCOUNT", False)
+    from service.clients.erc8004.signing import build_order_auth
+    assert build_order_auth(PRIVATE_KEY, "create_order", "agent-id") == {}


### PR DESCRIPTION
# Changes Made

## CLI → Agent auth (X-Signature / X-Timestamp headers)
All three mutating CLI commands now sign requests with EIP-191 before sending them to the agent. The agent verifies the signature before processing.

Message formats:

`order create / order match: create_order:{agent_base_url}:{unix_timestamp}`
`order close: close_order:{order_id}:{unix_timestamp}`

- Added _get_auth_headers(operation, resource_id, private_key) — signs with eth_account (graceful ImportError fallback)
- Updated _post_json to accept and merge extra_headers
- order create, order close, order match all pass _get_auth_headers(...) on each request
- Added --env / -e to order close and order match (already present on order create) so AGENT_PRIV_KEY can be read from an env file
- Added _check_agent_request_auth(request, operation, resource_id) — reads X-Signature / X-Timestamp headers, verifies EIP-191 signature against AGENT_WALLET_ADDRESS

## Agent → Registry Auth

RegistryClient.update_order was signing registry updates with AGENT_ID (e.g. "bob_agent") as signer_agent_id, but the registry stores agents under their full ERC-8004 canonical ID (eip155:{chainId}:{registryAddress}:{onchainAgentId}). This caused 403 on every close_order and accept_offer registry update.

- Added _resolve_canonical_agent_id() — builds the full canonical ID from ONCHAIN_AGENT_ID + IDENTITY_REGISTRY_ADDRESS + chain ID (resolved via CHAIN_ID env → ALKAHEST_NETWORK map → web3 RPC call)
- get_registry_client() now passes the canonical ID as agent_id
- Added EIP-191 verify utility

## Other
- Heartbeat cleanup: Removed unused owner_address parameter from send_heartbeat and heartbeat_loop and their call sites

# Testing

## Unit tests

```
cd service && python -m pytest tests/unit/test_signing.py -v
```

```
cd cli && python -m pytest tests/test_order_auth.py -v
```


## End-to-End
Set up chain, contracts, registry indexer. Register Agents.

Import resources:

   ```
   market portfolio import-csv app/data/resources.sample.csv -e .env.bob.local
   ```

Seller first (Bob's agent):
   ```
   market order create -o '{"gpu_model": "H200", "quantity": 1, "sla": 90.0, "region": "California, US"}' -d '{"token":"MOCK","amount":1.0}' -e .env.bob.local
   ```
Then buyer (Alice's agent):
   ```
   market order create -d '{"gpu_model": "H200", "quantity": 1, "sla": 90.0, "region": "California, US"}' -o '{"token":"MOCK","amount":1.0}' -e .env.alice.local
   ```

Confirm that both sides have accepted orders and connection strings:
   ```
   market order history -e .env.alice.local
   market order history -e .env.bob.local
   ```

Confirm that unsigned requests are rejected (without -e):

   ```
   market order create -o '{"gpu_model": "H200", "quantity": 1, "sla": 90.0, "region": "California, US"}' -d '{"token":"MOCK","amount":1.0}'
   # → Agent error (403): {"error":"Missing auth headers"}
   ```