### PR TITLE
Feature: Update Install Script to Installs Dependencies

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -116,46 +116,7 @@ resolve_command() {
 install_gcloud() {
     info "Installing Google Cloud SDK..."
 
-    local file_name checksum
-    case "${OS}-${ARCH}" in
-        macos-x86_64)
-            file_name="google-cloud-cli-darwin-x86_64.tar.gz"
-            checksum="46d255163f034666940549aace9452d300fce11ca41b6c8a953d50af4301f5fb"
-            ;;
-        macos-arm64)
-            file_name="google-cloud-cli-darwin-arm.tar.gz"
-            checksum="7aec01fcba56ae6d0590ac0ee135401a2f679136d4e11cc6137415e69aa7536a"
-            ;;
-        *)
-            error "No Google Cloud SDK package available for ${OS}-${ARCH}."
-            error "Please install it manually: https://cloud.google.com/sdk/docs/install"
-            exit 1
-            ;;
-    esac
-
-    local tmp_dir
-    tmp_dir="$(mktemp -d)"
-    local archive="$tmp_dir/$file_name"
-
-    curl -#fL "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/$file_name" -o "$archive"
-
-    # Verify checksum
-    local actual_checksum
-    actual_checksum="$(shasum -a 256 "$archive" | awk '{print $1}')"
-    if [ "$actual_checksum" != "$checksum" ]; then
-        error "Checksum verification failed for $file_name"
-        error "Expected: $checksum"
-        error "Got:      $actual_checksum"
-        rm -rf "$tmp_dir"
-        exit 1
-    fi
-    ok "Checksum verified"
-
-    tar -xzf "$archive" -C "$HOME"
-    rm -rf "$tmp_dir"
-
-    # Run the SDK install script (non-interactive)
-    "$HOME/google-cloud-sdk/install.sh" --quiet --path-update=true
+    curl -sSL https://sdk.cloud.google.com | bash -s -- --disable-prompts --install-dir="$HOME"
 
     export PATH="$HOME/google-cloud-sdk/bin:$PATH"
 

--- a/install.sh
+++ b/install.sh
@@ -150,16 +150,6 @@ install_gcloud() {
     ok "Google Cloud SDK installed ($(gcloud --version 2>&1 | head -1))"
 }
 
-install_zerotier() {
-    info "Installing ZeroTier..."
-    curl -s https://install.zerotier.com | sudo bash
-    if ! command -v zerotier-cli &>/dev/null; then
-        error "ZeroTier installation failed. Please install manually."
-        exit 1
-    fi
-    ok "ZeroTier installed"
-}
-
 check_and_install_dependencies() {
     # ── Collect everything that's missing ──
     local display_items=()        # human-readable list for the prompt
@@ -167,7 +157,6 @@ check_and_install_dependencies() {
     local missing_apt_pkgs=()     # deduplicated apt packages
     local need_python312=false
     local need_gcloud=false
-    local need_zerotier=false
     local has_apt=false
     ZEROTIER_ALREADY_INSTALLED=true
 
@@ -248,11 +237,9 @@ check_and_install_dependencies() {
         ok "gcloud found ($(command -v gcloud))"
     fi
 
-    # -- zerotier --
+    # -- zerotier (detection only; market install --with-zerotier handles installation) --
     if ! resolve_command zerotier-cli "${ZEROTIER_SEARCH_PATHS[@]}"; then
-        need_zerotier=true
         ZEROTIER_ALREADY_INSTALLED=false
-        display_items+=("ZeroTier (zerotier-cli)")
     else
         ok "zerotier-cli found ($(command -v zerotier-cli))"
     fi
@@ -325,9 +312,8 @@ check_and_install_dependencies() {
         ok "System packages installed successfully."
     fi
 
-    # ── Install gcloud & zerotier ──
-    [ "$need_gcloud" = true ]   && install_gcloud
-    [ "$need_zerotier" = true ] && install_zerotier
+    # ── Install gcloud ──
+    [ "$need_gcloud" = true ] && install_gcloud
 }
 
 # ── Install uv ────────────────────────────────────────────────
@@ -492,8 +478,8 @@ main() {
     echo ""
 
     detect_platform
-    check_and_install_dependencies
     check_docker_running
+    check_and_install_dependencies
     check_python_version
     install_uv
     install_repo

--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,21 @@ GCP_SA_KEY_URL="https://us-central1-ww-migration-arkhai.cloudfunctions.net/getSe
 DOCKER_IMAGE="us-east4-docker.pkg.dev/ww-migration-arkhai/a2a-agent/a2a-agent:v0.0.1"
 GCP_DOCKER_REGISTRY="$(echo "$DOCKER_IMAGE" | cut -d'/' -f1)"
 
+# ── System dependency mapping ─────────────────────────────────
+# Format: "command:apt-package"
+LINUX_SYSTEM_DEPS=(
+    "curl:curl"
+    "rsync:rsync"
+    "git:git"
+    "gcc:build-essential"
+    "g++:build-essential"
+    "make:build-essential"
+    "npm:npm"
+    "docker:docker.io"
+    "python3.12:python3.12"
+)
+LINUX_PYTHON_DEV_PKGS=("python3.12-dev" "software-properties-common")
+
 # ── Color helpers ──────────────────────────────────────────────
 info()  { printf '\033[1;34m[info]\033[0m %s\n' "$*"; }
 warn()  { printf '\033[1;33m[warn]\033[0m %s\n' "$*"; }
@@ -73,7 +88,7 @@ detect_platform() {
     esac
 }
 
-# ── Dependency resolution (gcloud & zerotier) ────────────────
+# ── Dependency detection & installation ───────────────────────
 
 # Known install locations to check when a command is not on PATH
 GCLOUD_SEARCH_PATHS=(
@@ -139,30 +154,125 @@ install_zerotier() {
 }
 
 check_and_install_dependencies() {
-    local missing=()
+    # ── Collect everything that's missing ──
+    local display_items=()        # human-readable list for the prompt
+    local missing_apt_cmds=()     # commands to verify after apt install
+    local missing_apt_pkgs=()     # deduplicated apt packages
+    local need_python312=false
+    local need_gcloud=false
+    local need_zerotier=false
+    local has_apt=false
     ZEROTIER_ALREADY_INSTALLED=true
 
+    # -- System packages (Linux only) --
+    if [ "$OS" = "linux" ]; then
+        if command -v apt-get &>/dev/null; then
+            has_apt=true
+        else
+            warn "apt-get not found -- cannot auto-install system packages on this distro."
+        fi
+
+        if [ "$has_apt" = true ]; then
+            for entry in "${LINUX_SYSTEM_DEPS[@]}"; do
+                local cmd="${entry%%:*}"
+                local pkg="${entry##*:}"
+
+                if ! command -v "$cmd" &>/dev/null; then
+                    missing_apt_cmds+=("$cmd")
+                    # Deduplicate packages
+                    local already=false
+                    for p in "${missing_apt_pkgs[@]+"${missing_apt_pkgs[@]}"}"; do
+                        [ "$p" = "$pkg" ] && already=true && break
+                    done
+                    if [ "$already" = false ]; then
+                        missing_apt_pkgs+=("$pkg")
+                        display_items+=("$pkg (apt)")
+                    fi
+                    [ "$cmd" = "python3.12" ] && need_python312=true
+                fi
+            done
+
+            # Extra packages for python3.12
+            if [ "$need_python312" = true ]; then
+                for extra in "${LINUX_PYTHON_DEV_PKGS[@]}"; do
+                    local already=false
+                    for p in "${missing_apt_pkgs[@]+"${missing_apt_pkgs[@]}"}"; do
+                        [ "$p" = "$extra" ] && already=true && break
+                    done
+                    if [ "$already" = false ]; then
+                        missing_apt_pkgs+=("$extra")
+                        display_items+=("$extra (apt)")
+                    fi
+                done
+            fi
+        fi
+
+    elif [ "$OS" = "macos" ]; then
+        local mac_missing=()
+        for entry in "${LINUX_SYSTEM_DEPS[@]}"; do
+            local cmd="${entry%%:*}"
+            if ! command -v "$cmd" &>/dev/null; then
+                mac_missing+=("$cmd")
+            fi
+        done
+
+        if [ ${#mac_missing[@]} -gt 0 ]; then
+            echo ""
+            error "The following required commands are missing:"
+            for cmd in "${mac_missing[@]}"; do
+                echo "  - $cmd"
+            done
+            echo ""
+            if command -v brew &>/dev/null; then
+                info "You can install them with Homebrew, e.g.:"
+                echo "    brew install ${mac_missing[*]}"
+            else
+                info "Install Homebrew (https://brew.sh) and then install the missing commands."
+            fi
+            exit 1
+        fi
+    fi
+
+    # -- gcloud --
     if ! resolve_command gcloud "${GCLOUD_SEARCH_PATHS[@]}"; then
-        missing+=("Google Cloud SDK (gcloud)")
+        need_gcloud=true
+        display_items+=("Google Cloud SDK (gcloud)")
     else
         ok "gcloud found ($(command -v gcloud))"
     fi
 
+    # -- zerotier --
     if ! resolve_command zerotier-cli "${ZEROTIER_SEARCH_PATHS[@]}"; then
-        missing+=("ZeroTier (zerotier-cli)")
+        need_zerotier=true
         ZEROTIER_ALREADY_INSTALLED=false
+        display_items+=("ZeroTier (zerotier-cli)")
     else
         ok "zerotier-cli found ($(command -v zerotier-cli))"
     fi
 
-    if [ ${#missing[@]} -eq 0 ]; then
+    # ── Nothing missing → done ──
+    if [ ${#display_items[@]} -eq 0 ]; then
+        ok "All dependencies are present."
         return
     fi
 
+    # ── Sudo check (Linux, before prompting) ──
+    if [ "$OS" = "linux" ] && [ ${#missing_apt_pkgs[@]} -gt 0 ]; then
+        if ! command -v sudo &>/dev/null; then
+            if [ "$(id -u)" -ne 0 ]; then
+                error "'sudo' is not installed and you are not root."
+                error "Please run this script as root or install sudo first: apt-get install sudo"
+                exit 1
+            fi
+            sudo() { "$@"; }
+        fi
+    fi
+
+    # ── Single prompt for everything ──
     echo ""
-    warn "The following required dependencies are not found:"
-    for dep in "${missing[@]}"; do
-        echo "  - $dep"
+    warn "The following dependencies need to be installed:"
+    for item in "${display_items[@]}"; do
+        echo "  - $item"
     done
     echo ""
 
@@ -176,12 +286,41 @@ check_and_install_dependencies() {
     esac
     echo ""
 
-    for dep in "${missing[@]}"; do
-        case "$dep" in
-            *gcloud*)    install_gcloud ;;
-            *zerotier*)  install_zerotier ;;
-        esac
-    done
+    # ── Install system packages via apt ──
+    if [ ${#missing_apt_pkgs[@]} -gt 0 ]; then
+        info "Updating package lists..."
+        sudo apt-get update -y
+
+        if [ "$need_python312" = true ]; then
+            if ! command -v add-apt-repository &>/dev/null; then
+                info "Installing software-properties-common for PPA support..."
+                sudo apt-get install -y software-properties-common
+            fi
+            info "Adding deadsnakes PPA for Python 3.12..."
+            sudo add-apt-repository -y ppa:deadsnakes/ppa
+            sudo apt-get update -y
+        fi
+
+        info "Installing packages: ${missing_apt_pkgs[*]}"
+        sudo apt-get install -y "${missing_apt_pkgs[@]}"
+
+        # Verify
+        local still_missing=()
+        for cmd in "${missing_apt_cmds[@]}"; do
+            if ! command -v "$cmd" &>/dev/null; then
+                still_missing+=("$cmd")
+            fi
+        done
+        if [ ${#still_missing[@]} -gt 0 ]; then
+            error "The following commands are still not available after installation: ${still_missing[*]}"
+            exit 1
+        fi
+        ok "System packages installed successfully."
+    fi
+
+    # ── Install gcloud & zerotier ──
+    [ "$need_gcloud" = true ]   && install_gcloud
+    [ "$need_zerotier" = true ] && install_zerotier
 }
 
 # ── Install uv ────────────────────────────────────────────────
@@ -346,8 +485,6 @@ main() {
     echo ""
 
     detect_platform
-    check_command docker
-    check_command make
     check_and_install_dependencies
     check_python_version
     install_uv

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,6 @@ BIN_DIR="$HOME/.local/bin"
 MIN_PYTHON_MAJOR=3
 MIN_PYTHON_MINOR=12
 UV_VERSION="0.8.13"
-INSTALL_ZEROTIER=false
 GCP_SA_KEY_URL="https://us-central1-ww-migration-arkhai.cloudfunctions.net/getServiceAccountKey"
 DOCKER_IMAGE="us-east4-docker.pkg.dev/ww-migration-arkhai/a2a-agent/a2a-agent:v0.0.1"
 GCP_DOCKER_REGISTRY="$(echo "$DOCKER_IMAGE" | cut -d'/' -f1)"
@@ -72,6 +71,156 @@ detect_platform() {
             exit 1
             ;;
     esac
+}
+
+# ── Dependency resolution (gcloud & zerotier) ────────────────
+
+# Known install locations to check when a command is not on PATH
+GCLOUD_SEARCH_PATHS=(
+    "$HOME/google-cloud-sdk/bin"
+    "/usr/local/google-cloud-sdk/bin"
+    "/opt/google-cloud-sdk/bin"
+    "/snap/google-cloud-cli/current/bin"
+)
+
+ZEROTIER_SEARCH_PATHS=(
+    "/usr/sbin"
+    "/usr/local/bin"
+    "/Library/Application Support/ZeroTier/One"
+    "/opt/zerotier/bin"
+)
+
+# Try to find a command either on PATH or in known locations.
+# If found off-PATH, exports the directory to PATH.
+# Returns 0 if found, 1 if not.
+resolve_command() {
+    local cmd="$1"
+    shift
+    local search_paths=("$@")
+
+    if command -v "$cmd" &>/dev/null; then
+        return 0
+    fi
+
+    for dir in "${search_paths[@]}"; do
+        if [ -x "$dir/$cmd" ]; then
+            info "Found '$cmd' at $dir (adding to PATH)"
+            export PATH="$dir:$PATH"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+install_gcloud() {
+    info "Installing Google Cloud SDK..."
+
+    local file_name checksum
+    case "${OS}-${ARCH}" in
+        macos-x86_64)
+            file_name="google-cloud-cli-darwin-x86_64.tar.gz"
+            checksum="46d255163f034666940549aace9452d300fce11ca41b6c8a953d50af4301f5fb"
+            ;;
+        macos-arm64)
+            file_name="google-cloud-cli-darwin-arm.tar.gz"
+            checksum="7aec01fcba56ae6d0590ac0ee135401a2f679136d4e11cc6137415e69aa7536a"
+            ;;
+        *)
+            error "No Google Cloud SDK package available for ${OS}-${ARCH}."
+            error "Please install it manually: https://cloud.google.com/sdk/docs/install"
+            exit 1
+            ;;
+    esac
+
+    local tmp_dir
+    tmp_dir="$(mktemp -d)"
+    local archive="$tmp_dir/$file_name"
+
+    curl -#fL "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/$file_name" -o "$archive"
+
+    # Verify checksum
+    local actual_checksum
+    actual_checksum="$(shasum -a 256 "$archive" | awk '{print $1}')"
+    if [ "$actual_checksum" != "$checksum" ]; then
+        error "Checksum verification failed for $file_name"
+        error "Expected: $checksum"
+        error "Got:      $actual_checksum"
+        rm -rf "$tmp_dir"
+        exit 1
+    fi
+    ok "Checksum verified"
+
+    tar -xzf "$archive" -C "$HOME"
+    rm -rf "$tmp_dir"
+
+    # Run the SDK install script (non-interactive)
+    "$HOME/google-cloud-sdk/install.sh" --quiet --path-update=true
+
+    export PATH="$HOME/google-cloud-sdk/bin:$PATH"
+
+    if ! command -v gcloud &>/dev/null; then
+        error "Google Cloud SDK installation failed. Please install manually."
+        exit 1
+    fi
+
+    ok "Google Cloud SDK installed ($(gcloud --version 2>&1 | head -1))"
+}
+
+install_zerotier() {
+    info "Installing ZeroTier..."
+    curl -s https://install.zerotier.com | sudo bash
+    if ! command -v zerotier-cli &>/dev/null; then
+        error "ZeroTier installation failed. Please install manually."
+        exit 1
+    fi
+    ok "ZeroTier installed"
+}
+
+check_and_install_dependencies() {
+    local missing=()
+    ZEROTIER_ALREADY_INSTALLED=true
+
+    if ! resolve_command gcloud "${GCLOUD_SEARCH_PATHS[@]}"; then
+        missing+=("Google Cloud SDK (gcloud)")
+    else
+        ok "gcloud found ($(command -v gcloud))"
+    fi
+
+    if ! resolve_command zerotier-cli "${ZEROTIER_SEARCH_PATHS[@]}"; then
+        missing+=("ZeroTier (zerotier-cli)")
+        ZEROTIER_ALREADY_INSTALLED=false
+    else
+        ok "zerotier-cli found ($(command -v zerotier-cli))"
+    fi
+
+    if [ ${#missing[@]} -eq 0 ]; then
+        return
+    fi
+
+    echo ""
+    warn "The following required dependencies are not found:"
+    for dep in "${missing[@]}"; do
+        echo "  - $dep"
+    done
+    echo ""
+
+    printf '\033[1;34m[?]\033[0m Would you like to install them? [Y/n] '
+    read -r answer </dev/tty
+    case "$answer" in
+        [nN]|[nN][oO])
+            error "Cannot proceed without required dependencies."
+            exit 1
+            ;;
+    esac
+    echo ""
+
+    for dep in "${missing[@]}"; do
+        case "$dep" in
+            *gcloud*)    install_gcloud ;;
+            *zerotier*)  install_zerotier ;;
+        esac
+    done
 }
 
 # ── Install uv ────────────────────────────────────────────────
@@ -235,18 +384,10 @@ main() {
     echo "  └──────────────────────────────────┘"
     echo ""
 
-    printf '\033[1;34m[?]\033[0m Would you like to install ZeroTier for P2P networking? [y/N] '
-    read -r zt_answer </dev/tty
-    case "$zt_answer" in
-        [yY]|[yY][eE][sS]) INSTALL_ZEROTIER=true; ok "ZeroTier will be installed" ;;
-        *) info "Skipping ZeroTier installation" ;;
-    esac
-    echo ""
-
     detect_platform
     check_command docker
-    check_command gcloud
     check_command make
+    check_and_install_dependencies
     check_python_version
     install_uv
     install_repo
@@ -260,10 +401,10 @@ main() {
 
     info "Running market install to set up service dependencies..."
     echo ""
-    if [ "$INSTALL_ZEROTIER" = true ]; then
-        market install --with-zerotier
-    else
+    if [ "$ZEROTIER_ALREADY_INSTALLED" = true ]; then
         market install
+    else
+        market install --with-zerotier
     fi
 
     # ── Pull Docker image ──────────

--- a/install.sh
+++ b/install.sh
@@ -41,6 +41,13 @@ check_command() {
     fi
 }
 
+check_docker_running() {
+    if ! docker info &>/dev/null; then
+        error "Docker daemon is not running. Please start Docker and try again."
+        exit 1
+    fi
+}
+
 check_python_version() {
     local python_cmd=""
     if command -v python3 &>/dev/null; then
@@ -486,6 +493,7 @@ main() {
 
     detect_platform
     check_and_install_dependencies
+    check_docker_running
     check_python_version
     install_uv
     install_repo


### PR DESCRIPTION
## Summary
  - Replaces manual dependency checks (`check_command`) with a comprehensive
  `check_and_install_dependencies` function that detects all missing system packages,
  gcloud, and ZeroTier in one pass
  - Adds a system dependency mapping for Linux (apt) that auto-installs missing packages
  (curl, rsync, git, build-essential, npm, docker, python3.12) with a single user
  confirmation prompt
  - Adds `resolve_command` helper that searches known install paths (e.g.
  `~/google-cloud-sdk/bin`) before declaring a dependency missing
  - On macOS, lists missing commands and suggests Homebrew install commands instead of
  attempting auto-install
  - Fixes ZeroTier install logic: now installs ZeroTier when it's **not** already present
   (previously the flag was inverted)

  ## Test plan
  - [ ] Run `install.sh` on a clean Ubuntu machine and verify all missing apt packages
  are detected and installed
  - [ ] Run `install.sh` on a machine with all deps already present — should skip
  installation
  - [ ] Run on macOS with a missing command and verify it exits with a helpful Homebrew
  suggestion
  - [ ] Verify gcloud is found when installed at `~/google-cloud-sdk/bin` but not on PATH
  - [ ] Verify ZeroTier is installed when missing and `market install --with-zerotier` is
   called
  - [ ] Verify declining the install prompt exits gracefully
  - [ ] Run on a system without `sudo` as non-root and verify the appropriate error
  message