### PR TITLE
Fix: Include scripts

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -40,7 +40,7 @@ jobs:
             --exclude='.git' \
             --exclude='.github' \
             --exclude='mcp' \
-            --exclude="$(basename "$REPO_ROOT")/scripts" \
+            --exclude='./scripts' \
             --exclude='tmp' \
             --exclude='__pycache__' \
             --exclude='*.pyc' \

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -40,7 +40,7 @@ jobs:
             --exclude='.git' \
             --exclude='.github' \
             --exclude='mcp' \
-            --exclude='scripts' \
+            --exclude="$(basename "$REPO_ROOT")/scripts" \
             --exclude='tmp' \
             --exclude='__pycache__' \
             --exclude='*.pyc' \

--- a/core/agent/app/data/token_registry.json
+++ b/core/agent/app/data/token_registry.json
@@ -2,25 +2,13 @@
   {
     "symbol": "USDC",
     "name": "USD Coin",
-    "contract_address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+    "contract_address": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
     "decimals": 6
-  },
-  {
-    "symbol": "USDT",
-    "name": "Tether USD",
-    "contract_address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
-    "decimals": 6
-  },
-  {
-    "symbol": "MOCK",
-    "name": "Mock Token",
-    "contract_address": "0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0",
-    "decimals": 0
   },
   {
     "symbol": "WETH",
-    "name": "Wrapped Ether",
-    "contract_address": "0x4200000000000000000000000000000000000006",
+    "name": "Wrapped Ether (WETH9)",
+    "contract_address": "0xfff9976782d46cc05630d1f6ebab18b2324d6b14",
     "decimals": 18
   }
 ]

--- a/install.sh
+++ b/install.sh
@@ -392,13 +392,16 @@ install_repo() {
 
 install_cli() {
     local cli_dir="$INSTALL_DIR/cli"
+    local core_dir="$INSTALL_DIR/core"
+    local core_venv="$core_dir/.venv"
 
-    info "Setting up Python environment..."
-    cd "$cli_dir"
-    uv venv
-    uv pip install -q -e .
+    info "Installing CLI into core venv..."
+    if [ ! -d "$core_venv" ]; then
+        uv --project "$core_dir" sync --no-dev -q
+    fi
+    uv pip install -q --python "$core_venv/bin/python" -e "$cli_dir"
 
-    ok "CLI installed in $cli_dir/.venv"
+    ok "CLI installed into $core_venv"
 }
 
 # ── Create symlink and set up PATH ────────────────────────────

--- a/install.sh
+++ b/install.sh
@@ -407,7 +407,7 @@ install_cli() {
 # ── Create symlink and set up PATH ────────────────────────────
 
 setup_path() {
-    local market_bin="$INSTALL_DIR/cli/.venv/bin/market"
+    local market_bin="$INSTALL_DIR/core/.venv/bin/market"
 
     mkdir -p "$BIN_DIR"
 

--- a/scripts/build-installer.sh
+++ b/scripts/build-installer.sh
@@ -35,7 +35,7 @@ tar czf "$TARBALL" \
     --exclude='.git' \
     --exclude='.github' \
     --exclude='mcp' \
-    --exclude='scripts' \
+    --exclude="$(basename "$REPO_ROOT")/scripts" \
     --exclude='tmp' \
     --exclude='__pycache__' \
     --exclude='*.pyc' \

--- a/scripts/upload-gcs.sh
+++ b/scripts/upload-gcs.sh
@@ -45,7 +45,7 @@ tar czf "$TARBALL" \
     --exclude='.git' \
     --exclude='.github' \
     --exclude='mcp' \
-    --exclude='scripts' \
+    --exclude="$(basename "$REPO_ROOT")/scripts" \
     --exclude='tmp' \
     --exclude='__pycache__' \
     --exclude='*.pyc' \


### PR DESCRIPTION
# Changes Made
- release-cli excludes are now narrower to include necessary `core/agent/scripts`
- Updated token registry to point to Ethereum Sepolia token addresses
- Updated `.venv` used to `core` rather than `cli`

# Testing
- Run download script
- Confirm that `.market/core/agent/scripts` exists
- Confirm that running `market register -e .env` works