### PR TITLE
feat(zt): Set MTU to 1300

### DIFF
--- a/infra/zerotier/ZeroTierSetup.MD
+++ b/infra/zerotier/ZeroTierSetup.MD
@@ -29,6 +29,21 @@ echo "Your node ID: $NODE_ID"
 
 Use the create_ztnetwork.sh script to create a ZeroTier network.
 
+> **MTU note:** `create_ztnetwork.sh` sets `mtu: 1300` on new networks. This is required to avoid
+> IP fragmentation when routing A2A traffic (HTTP POST bodies ~2KB) over ZeroTier's UDP overlay on
+> internet paths with physical MTU 1500. The default ZeroTier MTU of 2800 causes large payloads to
+> be silently dropped.
+>
+> For changing this value on the network, patch the MTU manually:
+> ```bash
+> AUTH=$(sudo cat /var/lib/zerotier-one/authtoken.secret)
+> curl -X POST "$CONTROLLER_URL/controller/network/<NETWORK_ID>" \
+>   -H "X-ZT1-Auth: $AUTH" \
+>   -H "Content-Type: application/json" \
+>   -d '{"mtu": 1300}'
+> ```
+> Nodes pick up the new MTU within ~60 seconds. Verify with `ip link show | grep zt`.
+
 Modify NETWORK_NAME IP_RANGE_START IP_RANGE_END NETWORK_CIDR script variables as appropriate
 
 join the network from the client:

--- a/infra/zerotier/create_ztnetwork.sh
+++ b/infra/zerotier/create_ztnetwork.sh
@@ -145,6 +145,7 @@ RESPONSE=$(curl -s --max-time 10 -X POST $CONTROLLER_URL/controller/network/${NE
   -d "{
     \"name\": \"$NETWORK_NAME\",
     \"private\": true,
+    \"mtu\": 1300,
     \"v4AssignMode\": {
       \"zt\": true
     },


### PR DESCRIPTION
# Changes Made
- Upon ZT network creation, config ZT MTU to 1300 to prevent dropping large payloads.

# Testing
1. Create a new ZT Network:
   ```
   market network create
   ```
2. Query the network's configuration with:
   ```
   curl -X POST "http:/localhost:9993/controller/network/<network_id>" -H "X-ZT1-AUTH: <token>" -d '{}'
   ```
   The returned `mtu` value in the response JSON should be `1300`.