### PR TITLE
Feature: E2E CLI Fixes

### DIFF
--- a/core/agent/Makefile
+++ b/core/agent/Makefile
@@ -67,6 +67,9 @@ serve-a2a:
 			exit 1; \
 		fi; \
 		sudo -v || { echo "Error: sudo authentication failed" >&2; exit 1; }; \
+		( while true; do sleep 300; sudo -n -v 2>/dev/null || true; done ) & \
+		SUDO_KEEPALIVE=$$!; \
+		trap "kill $$SUDO_KEEPALIVE 2>/dev/null; stty echo" EXIT; \
 		if ! NODE_ID=$$(sudo -n zerotier-cli info 2>/dev/null | cut -d " " -f3) || [ -z "$$NODE_ID" ]; then \
 			echo "Error: sudo access required for zerotier-cli. Run: sudo zerotier-cli info" >&2; \
 			exit 1; \
@@ -90,7 +93,7 @@ serve-a2a:
 	fi; \
 	echo "==============================================================================="; \
 	if [ -n "$$ZT_NETWORK" ]; then \
-		trap "stty echo; echo Leaving ZeroTier network $$ZT_NETWORK; sudo -n zerotier-cli leave $$ZT_NETWORK" INT EXIT; \
+		trap "kill $$SUDO_KEEPALIVE 2>/dev/null; stty echo; echo Leaving ZeroTier network $$ZT_NETWORK; sudo -n zerotier-cli leave $$ZT_NETWORK" INT EXIT; \
 		echo Connecting to ZeroTier network $$ZT_NETWORK; \
 		echo ZeroTier node ID: $$NODE_ID; \
 		sudo -n zerotier-cli join $$ZT_NETWORK; \

--- a/core/agent/Makefile
+++ b/core/agent/Makefile
@@ -66,7 +66,11 @@ serve-a2a:
 			echo "Error: ZeroTier CLI not found. Install with: cd infra && make install" >&2; \
 			exit 1; \
 		fi; \
-		NODE_ID=$$(sudo zerotier-cli info | cut -d " " -f3); \
+		sudo -v || { echo "Error: sudo authentication failed" >&2; exit 1; }; \
+		if ! NODE_ID=$$(sudo -n zerotier-cli info 2>/dev/null | cut -d " " -f3) || [ -z "$$NODE_ID" ]; then \
+			echo "Error: sudo access required for zerotier-cli. Run: sudo zerotier-cli info" >&2; \
+			exit 1; \
+		fi; \
 	fi; \
 	echo "==============================================================================="; \
 	echo "| 🚀 Starting A2A agent server...                                             |"; \
@@ -86,10 +90,10 @@ serve-a2a:
 	fi; \
 	echo "==============================================================================="; \
 	if [ -n "$$ZT_NETWORK" ]; then \
-		trap "stty echo; echo Leaving ZeroTier network $$ZT_NETWORK; sudo zerotier-cli leave $$ZT_NETWORK" INT EXIT; \
+		trap "stty echo; echo Leaving ZeroTier network $$ZT_NETWORK; sudo -n zerotier-cli leave $$ZT_NETWORK" INT EXIT; \
 		echo Connecting to ZeroTier network $$ZT_NETWORK; \
 		echo ZeroTier node ID: $$NODE_ID; \
-		sudo zerotier-cli join $$ZT_NETWORK; \
+		sudo -n zerotier-cli join $$ZT_NETWORK; \
 	fi; \
 	GOOGLE_GENAI_USE_VERTEXAI=False uv --project .. run uvicorn core.agent.app.server:app --host 0.0.0.0 --port $$PORT --reload $$ENV_ARG'
 

--- a/core/agent/Makefile
+++ b/core/agent/Makefile
@@ -56,6 +56,7 @@ endif
 
 serve-a2a:
 	@bash -c 'set -e; \
+	trap "stty echo" EXIT; \
 	PORT="$(or $(PORT),8000)"; \
 	ZT_NETWORK="$(ZEROTIER_NETWORK)"; \
 	ENV_ARG="$(ENV_ARG)"; \
@@ -85,7 +86,7 @@ serve-a2a:
 	fi; \
 	echo "==============================================================================="; \
 	if [ -n "$$ZT_NETWORK" ]; then \
-		trap "echo Leaving ZeroTier network $$ZT_NETWORK; sudo zerotier-cli leave $$ZT_NETWORK" INT EXIT; \
+		trap "stty echo; echo Leaving ZeroTier network $$ZT_NETWORK; sudo zerotier-cli leave $$ZT_NETWORK" INT EXIT; \
 		echo Connecting to ZeroTier network $$ZT_NETWORK; \
 		echo ZeroTier node ID: $$NODE_ID; \
 		sudo zerotier-cli join $$ZT_NETWORK; \

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -7,6 +7,7 @@ authors = [
 ]
 dependencies = [
     "market-service",
+    "market-cli",
     "google-adk[a2a] @ git+https://github.com/google/adk-python@5eca72f9bfd05c7c28a3d738391138a59a31167d",
     "opentelemetry-exporter-gcp-trace>=1.9.0,<2.0.0",
     "google-cloud-logging>=3.12.0,<4.0.0",
@@ -52,6 +53,7 @@ no-build-isolation-package = ["pufferlib"]
 
 [tool.uv.sources]
 market-service = { path = "../service", editable = true }
+market-cli = { path = "../cli", editable = true }
 torch = [
     { index = "pytorch-cpu" },
 ]

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -128,6 +128,15 @@ version = "0.1.0"
 source = { git = "https://github.com/arkhai-io/alkahest?subdirectory=sdks%2Fpy&rev=main#2cbafc6345369be23aa6563602891726ed5a0b7c" }
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2318,6 +2327,25 @@ wheels = [
 ]
 
 [[package]]
+name = "market-cli"
+version = "0.1.0"
+source = { editable = "../cli" }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "typer" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
+    { name = "pyyaml", specifier = ">=6.0.0" },
+    { name = "rich", specifier = ">=13.7.0" },
+    { name = "typer", specifier = ">=0.12.0" },
+]
+provides-extras = ["test"]
+
+[[package]]
 name = "market-core"
 version = "0.1.0"
 source = { editable = "." }
@@ -2329,6 +2357,7 @@ dependencies = [
     { name = "google-adk", extra = ["a2a"] },
     { name = "google-cloud-aiplatform", extra = ["evaluation"] },
     { name = "google-cloud-logging" },
+    { name = "market-cli" },
     { name = "market-service" },
     { name = "opentelemetry-exporter-gcp-trace" },
     { name = "psycopg2-binary" },
@@ -2371,6 +2400,7 @@ requires-dist = [
     { name = "google-cloud-aiplatform", extras = ["evaluation"], specifier = ">=1.118.0,<2.0.0" },
     { name = "google-cloud-logging", specifier = ">=3.12.0,<4.0.0" },
     { name = "jupyter", marker = "extra == 'jupyter'", specifier = ">=1.0.0,<2.0.0" },
+    { name = "market-cli", editable = "../cli" },
     { name = "market-service", editable = "../service" },
     { name = "mypy", marker = "extra == 'lint'", specifier = ">=1.15.0,<2.0.0" },
     { name = "opentelemetry-exporter-gcp-trace", specifier = ">=1.9.0,<2.0.0" },
@@ -4156,6 +4186,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "shimmy"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4558,6 +4597,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.24.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
 ]
 
 [[package]]

--- a/install.sh
+++ b/install.sh
@@ -391,15 +391,11 @@ install_repo() {
 # ── Set up venv and install CLI ───────────────────────────────
 
 install_cli() {
-    local cli_dir="$INSTALL_DIR/cli"
     local core_dir="$INSTALL_DIR/core"
     local core_venv="$core_dir/.venv"
 
     info "Installing CLI into core venv..."
-    if [ ! -d "$core_venv" ]; then
-        uv --project "$core_dir" sync --no-dev -q
-    fi
-    uv pip install -q --python "$core_venv/bin/python" -e "$cli_dir"
+    uv --project "$core_dir" sync --no-dev -q
 
     ok "CLI installed into $core_venv"
 }


### PR DESCRIPTION
# Changes Made
- terminal echo now resumes after failed `sudo` from ZeroTier
- keepalive keeps `sudo` from expiring, so additional password prompt is no longer needed at Agent teardown ZeroTier CLI exit
- `market-cli` is now part of core dependencies, to automatically install `market`

# Testing

## ZeroTier Sudo
1. Run Agent
1. After 15 minutes, exit agent
1. Verify the following:
   1. no sudo prompt for the teardown
   2. Terminal input is echoed normally

## Market CLI
1. Sync core dependencies.
   ```
   cd core
   uv sync
   ```
3. Verify that `market` is available with `market --help`