### PR TITLE
Feat: E2E Mock Provisioning Tests (Happy + Failure Paths)

### DIFF
--- a/cli/market/groups/order.py
+++ b/cli/market/groups/order.py
@@ -170,13 +170,23 @@ def order_history(
         "-e",
         help="Path to env file (default: core/agent/.env).",
     ),
+    db: str | None = typer.Option(
+        None,
+        "--db",
+        help="Explicit path to the agent SQLite DB.",
+    ),
 ) -> None:
     """Show order history from local SQLite."""
     env_path = Path(env) if env else REPO_ROOT / "core" / "agent" / ".env"
     db_path = read_env_value(env_path, "AGENT_DB_PATH")
     if not db_path:
-        typer.secho(f"AGENT_DB_PATH not found in {env_path}", err=True, fg=typer.colors.RED)
+        typer.secho(
+            "Local DB not found. Pass --db <path> or --env <envfile> with AGENT_DB_PATH set.",
+            err=True,
+            fg=typer.colors.RED,
+        )
         raise typer.Exit(code=1)
+    env_path = Path(env) if env else REPO_ROOT / "core" / "agent" / ".env"
     agent_mode = read_env_value(env_path, "AGENT_MODE", default="host")
     if agent_mode == "container":
         # DB lives in a host-mounted volume; resolve container path to host path

--- a/core/agent/app/agent.py
+++ b/core/agent/app/agent.py
@@ -67,6 +67,7 @@ from core.agent.app.schema.pydantic_models import (
     MarketOrder,
     MakeOfferEvent,
     ReceiveComputeObligationFulfillmentEvent,
+    FulfillmentFailedEvent,
     ArbitrationCompleteEvent,
     ResourceImbalanceEvent,
     ResourceAlertRequest,
@@ -405,6 +406,17 @@ def _parse_domain_event(payload: Dict[str, Any]) -> DomainEvent:
                 "source_url": source_url,
             }
             return ReceiveComputeObligationFulfillmentEvent.from_payload(fulfillment_payload)
+
+        elif event_type == EventType.FULFILLMENT_FAILED:
+            return FulfillmentFailedEvent(
+                event_id=payload.get("event_id", f"ff_{uuid.uuid4()}"),
+                source=payload.get("source", "unknown"),
+                escrow_uid=data.get("escrow_uid", ""),
+                reason=data.get("reason"),
+                seller_order_id=data.get("seller_order_id"),
+                buyer_order_id=data.get("buyer_order_id"),
+                data=data,
+            )
 
         elif event_type == EventType.ARBITRATION_COMPLETE:
             arb_payload = {**data, "source": payload.get("source") or data.get("source", "unknown")}

--- a/core/agent/app/policy/seeding.py
+++ b/core/agent/app/policy/seeding.py
@@ -18,6 +18,7 @@ class ComputePolicySeeder:
         EventType.MAKE_OFFER.value,
         EventType.ACCEPT_OFFER.value,
         EventType.RECEIVE_COMPUTE_OBLIGATION_FULFILLMENT.value,
+        EventType.FULFILLMENT_FAILED.value,
         EventType.ARBITRATION_COMPLETE.value,
         EventType.ORDER_CREATE.value,
         EventType.ORDER_CLOSE.value,
@@ -116,6 +117,16 @@ class ComputePolicySeeder:
             )
         except Exception as e:
             logger.warning(f"[POLICY SEED] Failed to save receive_fulfillment policy: {e}")
+
+        try:
+            await self._policy_store.save_policy(
+                agent_id=self._agent_id,
+                policy_name="fulfillment_failed_default_v1",
+                trigger_type=EventType.FULFILLMENT_FAILED.value,
+                callable_ref="ff.action.handle_fulfillment_failure",
+            )
+        except Exception as e:
+            logger.warning(f"[POLICY SEED] Failed to save fulfillment_failed policy: {e}")
 
         try:
             await self._policy_store.save_policy(

--- a/core/agent/app/schema/pydantic_models.py
+++ b/core/agent/app/schema/pydantic_models.py
@@ -259,6 +259,7 @@ class EventType(str, Enum):
     MAKE_OFFER = "make_offer"
     ACCEPT_OFFER = "accept_offer"
     RECEIVE_COMPUTE_OBLIGATION_FULFILLMENT = "receive_compute_obligation_fulfillment"
+    FULFILLMENT_FAILED = "fulfillment_failed"
     ARBITRATION_COMPLETE = "arbitration_complete"
     RESOURCE_IMBALANCE = "resource_imbalance"
     CRON_JOB = "cron_job"
@@ -433,6 +434,16 @@ class ReceiveComputeObligationFulfillmentEvent(DomainEvent):
             tenant_credentials=payload.get("tenant_credentials"),
             data=payload,
         )
+
+class FulfillmentFailedEvent(DomainEvent):
+    """Event triggered when the seller's provisioning fails after accepting an offer."""
+
+    event_type: EventType = Field(default=EventType.FULFILLMENT_FAILED)
+    escrow_uid: str = Field(description="Escrow UID that was locked for this deal")
+    reason: str | None = Field(default=None, description="Human-readable failure reason")
+    seller_order_id: str | None = Field(default=None, description="Seller's local order ID")
+    buyer_order_id: str | None = Field(default=None, description="Buyer's local order ID")
+
 
 class ArbitrationCompleteEvent(DomainEvent):
     """Event triggered when arbitration over fulfillment has completed."""
@@ -694,6 +705,7 @@ class ActionType(str, Enum):
     FULFILL_COMPUTE_OBLIGATION = "fulfill_compute_obligation"
     TRUST_COMPUTE_OBLIGATION_FULFILLMENT = "trust_compute_obligation_fulfillment"
     COLLECT_ESCROW = "collect_escrow"
+    HANDLE_FULFILLMENT_FAILURE = "handle_fulfillment_failure"
     VERIFY_COMPUTE_OBLIGATION_FULFILLMENT = "verify_compute_obligation_fulfillment"
 
     # No-op

--- a/core/agent/app/utils/action_executor.py
+++ b/core/agent/app/utils/action_executor.py
@@ -349,6 +349,8 @@ async def execute_action(
                         status="accepted",
                         escrow_uid=escrow_uid,
                         order_taker=parameters.get("counterparty_url"),
+                        taker_attestation=escrow_uid,  # buyer (taker) contributed escrow
+                        oracle_address=oracle_address,
                     )
                 except Exception as exc:
                     logger.warning("[LOCAL DB] Failed to update matched_order_id %s at fulfillment: %s", matched_order_id, exc)
@@ -404,6 +406,7 @@ async def execute_action(
             logger.info("[ACTION] Arbitration decisions: %s", decisions)
             try:
                 escrow_uid = parameters.get("escrow_uid")
+                fulfillment_uid = parameters.get("fulfillment_uid")
                 connection_details = parameters.get("connection_details")
                 tenant_credentials = parameters.get("tenant_credentials")
                 sqlite_client = get_sqlite_client()
@@ -412,6 +415,7 @@ async def execute_action(
                         escrow_uid=escrow_uid,
                         status="accepted",
                         fulfillment_resource=connection_details,
+                        taker_attestation=fulfillment_uid,  # seller (taker) contributed fulfillment
                     )
                 if tenant_credentials and escrow_uid:
                     order_id_for_escrow = await sqlite_client.get_order_id_by_escrow_uid(escrow_uid=escrow_uid)
@@ -437,7 +441,7 @@ async def execute_action(
                         logger.warning("[LOCAL DB] Cannot store tenant credentials: no order found for escrow_uid=%s", escrow_uid)
             except Exception as exc:
                 logger.warning("[LOCAL DB] Failed to store fulfillment details for escrow %s: %s", parameters.get("escrow_uid"), exc)
-            # Close buyer's order when arbitration succeeded (all decisions True).
+            # Update buyer's own registry order with taker_attestation, then close.
             if decisions and all(d.get("decision") for d in decisions):
                 _escrow = parameters.get("escrow_uid")
                 if _escrow:
@@ -445,12 +449,15 @@ async def execute_action(
                         sqlite_client = get_sqlite_client()
                         _oid = await sqlite_client.get_order_id_by_escrow_uid(escrow_uid=_escrow)
                         if _oid:
-                            await sqlite_client.update_order(order_id=_oid, status="closed")
                             registry_client = get_registry_client()
+                            if fulfillment_uid and CONFIG.enable_registry_discovery:
+                                await registry_client.update_order(_oid, {"taker_attestation": fulfillment_uid})
+                                logger.info("[TRUST] Updated buyer order %s with taker_attestation", _oid)
+                            await sqlite_client.update_order(order_id=_oid, status="closed")
                             await registry_client.update_order(_oid, {"status": "closed"})
                             logger.info("[TRUST] Closed buyer order %s after successful arbitration", _oid)
                     except Exception as exc:
-                        logger.warning("[TRUST] Failed to close buyer order after arbitration: %s", exc)
+                        logger.warning("[TRUST] Failed to update/close buyer order after arbitration: %s", exc)
             if ctx:
                 # Counterparty to notify is whoever sent the fulfillment (source of the trust action).
                 counterparty_ref = parameters.get("counterparty_url") or parameters.get("agent_url")
@@ -792,16 +799,20 @@ async def _fulfill_in_background(
 
     if result.get("status") == "fulfilled":
         # --- Success path (existing logic) ---
+        fulfillment_uid = result.get("fulfillment_uid")
         if matched_order_id:
             try:
                 sqlite_client = get_sqlite_client()
                 await sqlite_client.update_order(
                     order_id=matched_order_id,
-                    maker_attestation=result.get("fulfillment_uid"),
+                    maker_attestation=fulfillment_uid,
                     fulfillment_resource=result.get("connection_details"),
                 )
             except Exception as exc:
                 logger.warning("[LOCAL DB] Failed to update fulfillment for matched_order_id %s: %s", matched_order_id, exc)
+
+        # NOTE: buyer's registry order taker_attestation is set by the buyer itself
+        # in TRUST_COMPUTE_OBLIGATION_FULFILLMENT (EIP-191 auth prevents cross-agent updates).
 
         for oid in filter(None, [matched_order_id, buyer_order_id]):
             try:
@@ -1649,7 +1660,8 @@ async def _accept_as_buyer(
     we_are_maker = _agent_urls_match(order_dict.get("order_maker"), BASE_URL_OVERRIDE)
     taker_url = counterparty_url if we_are_maker else BASE_URL_OVERRIDE
     order_dict["order_taker"] = taker_url
-    order_dict["taker_attestation"] = escrow_uid
+    # Buyer is always maker of own order → escrow goes in maker_attestation
+    order_dict["maker_attestation"] = escrow_uid
     order_dict["oracle_address"] = oracle_address
 
     # Echo the seller's order_id back so they can update their local DB without a lookup.
@@ -1680,7 +1692,7 @@ async def _accept_as_buyer(
                 order_id=our_order_id,
                 status="accepted",
                 order_taker=taker_url,
-                taker_attestation=escrow_uid,
+                maker_attestation=escrow_uid,  # buyer is maker of own order
                 escrow_uid=escrow_uid,
                 matched_offer_id=their_order_id,
                 oracle_address=oracle_address,
@@ -1691,23 +1703,31 @@ async def _accept_as_buyer(
     if CONFIG.enable_registry_discovery:
         try:
             registry_client = get_registry_client()
-            registry_updates = {"status": "accepted", "order_taker": taker_url, "taker_attestation": escrow_uid}
-            # Update the order that is in the registry (order_dict["order_id"] is the buyer's order
-            # in buyer-as-maker flow; matched_order_id is the seller's order in seller-as-maker flow).
+            # Update counterparty's (seller's) order — buyer is taker there
             their_id = order_dict.get("order_id")
             if their_id:
-                result = await registry_client.update_order(their_id, registry_updates)
+                their_updates = {"status": "accepted", "order_taker": taker_url, "taker_attestation": escrow_uid, "oracle_address": oracle_address}
+                result = await registry_client.update_order(their_id, their_updates)
                 if result:
-                    logger.info("[REGISTRY] Updated order %s to accepted", their_id)
+                    logger.info("[REGISTRY] Updated seller's order %s to accepted", their_id)
                 else:
-                    logger.warning("[REGISTRY] Failed to update order %s", their_id)
-            # In seller-as-maker flow, also update the seller's registry entry.
+                    logger.warning("[REGISTRY] Failed to update seller's order %s", their_id)
+            # Also update our own order — buyer is maker, contributed escrow
+            if our_order_id:
+                our_updates = {"status": "accepted", "order_taker": counterparty_url, "maker_attestation": escrow_uid, "oracle_address": oracle_address}
+                result = await registry_client.update_order(our_order_id, our_updates)
+                if result:
+                    logger.info("[REGISTRY] Updated buyer's own order %s with maker_attestation", our_order_id)
+                else:
+                    logger.warning("[REGISTRY] Failed to update buyer's order %s", our_order_id)
+            # In seller-as-maker flow, also update the matched order if different
             if matched_order_id and matched_order_id != their_id:
-                result = await registry_client.update_order(matched_order_id, registry_updates)
+                matched_updates = {"status": "accepted", "order_taker": taker_url, "taker_attestation": escrow_uid, "oracle_address": oracle_address}
+                result = await registry_client.update_order(matched_order_id, matched_updates)
                 if result:
-                    logger.info("[REGISTRY] Updated seller's order %s to accepted", matched_order_id)
+                    logger.info("[REGISTRY] Updated matched order %s to accepted", matched_order_id)
                 else:
-                    logger.warning("[REGISTRY] Failed to update seller's order %s", matched_order_id)
+                    logger.warning("[REGISTRY] Failed to update matched order %s", matched_order_id)
         except Exception as e:
             logger.warning("[REGISTRY] Failed to update order in registry: %s", e)
 

--- a/core/agent/app/utils/action_executor.py
+++ b/core/agent/app/utils/action_executor.py
@@ -340,9 +340,7 @@ async def execute_action(
             if not ssh_public_key:
                 raise ValueError("ssh_public_key is required for fulfill_compute_obligation")
 
-            # Update our own local order if matched_order_id was threaded through the event.
-            # This handles the seller-as-taker case where order_id in the order dict is the
-            # buyer's order_id (not present in the seller's local DB).
+            # Update our own local order synchronously (fast).
             if matched_order_id:
                 try:
                     sqlite_client = get_sqlite_client()
@@ -355,118 +353,40 @@ async def execute_action(
                 except Exception as exc:
                     logger.warning("[LOCAL DB] Failed to update matched_order_id %s at fulfillment: %s", matched_order_id, exc)
 
-            result = await fulfill_compute_obligation(
-                client=alkahest_client,
-                escrow_uid=escrow_uid,
-                oracle_address=parameters.get("oracle_address") or order_dict.get("oracle_address"),
-                ssh_public_key=ssh_public_key,
-                order=order_dict,
-                seller_order_id=matched_order_id,
-            )
-            if result.get("status") == "fulfilled":
-                # Update our own local order with fulfillment details.
-                # fulfill_compute_obligation uses order_dict["order_id"] (the buyer's ID) for its
-                # internal DB write, which doesn't exist in the seller's local DB.  We correct that
-                # here using matched_order_id (the seller's own order).
-                if matched_order_id:
-                    try:
-                        sqlite_client = get_sqlite_client()
-                        await sqlite_client.update_order(
-                            order_id=matched_order_id,
-                            maker_attestation=result.get("fulfillment_uid"),
-                            fulfillment_resource=result.get("connection_details"),
-                        )
-                    except Exception as exc:
-                        logger.warning("[LOCAL DB] Failed to update fulfillment for matched_order_id %s: %s", matched_order_id, exc)
-                # Close both orders in registry and local DB after successful fulfillment.
-                # buyer_order_id is the buyer's order_id, derived from order.order_id in the
-                # AcceptOfferEvent (the offer field IS the buyer's order).  Falls back to
-                # order_dict.get("order_id") which is the same value.
-                buyer_order_id = parameters.get("buyer_order_id") or order_dict.get("order_id")
-                for oid in filter(None, [matched_order_id, buyer_order_id]):
-                    try:
-                        registry_client = get_registry_client()
-                        await registry_client.update_order(oid, {"status": "closed"})
-                        sqlite_client = get_sqlite_client()
-                        await sqlite_client.update_order(order_id=oid, status="closed")
-                        logger.info(f"[FULFILL] Closed order {oid}")
-                    except Exception as e:
-                        logger.warning(f"[FULFILL] Failed to close order {oid}: {e}")
-                # Close the negotiation thread — covers equal-price direct-accept where the
-                # buyer never entered a negotiation round and their ACCEPT_OFFER had no
-                # negotiation_id, leaving the seller's thread open indefinitely.
-                if matched_order_id and buyer_order_id:
-                    try:
-                        neg_id = make_negotiation_id(matched_order_id, buyer_order_id)
-                        async with NegotiationThreadTransaction("FULFILL_COMPUTE_OBLIGATION") as txn:
-                            thread_info = await txn.thread_store.get_thread_info(neg_id, owner_id=BASE_URL_OVERRIDE or "")
-                            our_price = (thread_info or {}).get("our_initial_price")
-                            # Derive agreed price from last non-terminal message's their_price
-                            # (the counterparty's final proposal), rather than reading the raw
-                            # order amount which reflects the original ask, not the agreed price.
-                            messages = await txn.thread_store.get_thread(neg_id)
-                            agreed_price = next(
-                                (m["their_price"] for m in reversed(messages) if m.get("their_price") is not None),
-                                None,
-                            )
-                            await txn.add_message(
-                                negotiation_id=neg_id,
-                                sender=_sender_id(),
-                                our_price=our_price,
-                                their_price=agreed_price,
-                                proposed_price=agreed_price,
-                                action_taken=ActionType.FULFILL_COMPUTE_OBLIGATION.value,
-                                message_type="fulfilled",
-                            )
-                            await txn.mark_terminal(neg_id, "success")
-                    except Exception as _term_err:
-                        logger.warning(
-                            "[ACTION] Could not mark negotiation thread terminal after fulfillment: %s",
-                            _term_err,
-                        )
-                # Include event_type for downstream parsing and propagate to remote agent.
-                result["event_type"] = EventType.RECEIVE_COMPUTE_OBLIGATION_FULFILLMENT.value
-                if ctx:
-                    # Counterparty to notify is the order taker (we are the maker fulfilling for them).
-                    order_obj = parameters.get("order")
-                    if isinstance(order_obj, dict):
-                        order_dict = order_obj
-                    elif hasattr(order_obj, "model_dump"):
-                        order_dict = order_obj.model_dump(mode="json") if order_obj else {}
-                    else:
-                        order_dict = {}
-                    counterparty_ref = parameters.get("counterparty_url") or _resolve_counterparty_url_from_order(order_dict)
-                    counterparty_url = _coerce_agent_reference_to_url(counterparty_ref)
-                    if not counterparty_url:
-                        raise ValueError(
-                            f"fulfill_compute_obligation: cannot notify buyer — "
-                            f"unresolved counterparty={counterparty_ref!r}"
-                        )
-                    try:
-                        event = Event(
-                            author=AGENT_ID,
-                            content=genai_types.Content(
-                                role="model",
-                                parts=[
-                                    genai_types.Part.from_function_response(
-                                        name=EventType.RECEIVE_COMPUTE_OBLIGATION_FULFILLMENT.value,
-                                        response=result,
-                                    )
-                                ],
-                            ),
-                            invocation_id=ctx.invocation_id,
-                            branch=ctx.branch,
-                        )
-                        _background_send(ctx, event, agent_url=counterparty_url)
-                    except Exception as send_err:
-                        logger.warning("[ACTION] Failed to send fulfillment to remote agent: %s", send_err)
-            else:
-                logger.warning(
-                    "[ACTION] Skipping fulfillment event; status=%s",
-                    result.get("status"),
+            # Pre-resolve counterparty URL synchronously so we fail fast if missing.
+            counterparty_ref = parameters.get("counterparty_url") or _resolve_counterparty_url_from_order(order_dict)
+            counterparty_url = _coerce_agent_reference_to_url(counterparty_ref)
+            buyer_order_id = parameters.get("buyer_order_id") or order_dict.get("order_id")
+
+            if not counterparty_url:
+                raise ValueError(
+                    f"fulfill_compute_obligation: cannot notify buyer — "
+                    f"unresolved counterparty={counterparty_ref!r}"
                 )
-            outcome["result"] = result
-            outcome["message"] = result.get("message")
+
+            # Dispatch provisioning + fulfillment to a background task so the
+            # A2A response (ACK) is returned immediately to the buyer.
+            asyncio.create_task(
+                _fulfill_in_background(
+                    alkahest_client=alkahest_client,
+                    ctx=ctx,
+                    escrow_uid=escrow_uid,
+                    ssh_public_key=ssh_public_key,
+                    oracle_address=oracle_address,
+                    order_dict=order_dict,
+                    matched_order_id=matched_order_id,
+                    buyer_order_id=buyer_order_id,
+                    counterparty_url=counterparty_url,
+                    parameters=parameters,
+                )
+            )
+
+            outcome["result"] = {
+                "status": "provisioning",
+                "message": "Compute obligation accepted; provisioning in background",
+                "escrow_uid": escrow_uid,
+            }
+            outcome["message"] = outcome["result"]["message"]
 
         case ActionType.TRUST_COMPUTE_OBLIGATION_FULFILLMENT.value:
             logger.info(f"[ACTION] Trusting compute fulfillment with params: {parameters}")
@@ -627,6 +547,61 @@ async def execute_action(
                 }
                 outcome["message"] = outcome["result"]["message"]
             
+        case ActionType.HANDLE_FULFILLMENT_FAILURE.value:
+            logger.info("[ACTION] Handling fulfillment failure: %s", parameters)
+            escrow_uid = parameters.get("escrow_uid")
+            reason = parameters.get("reason")
+            buyer_order_id = parameters.get("buyer_order_id")
+            seller_order_id = parameters.get("seller_order_id")
+
+            # 1. Record failure in buyer's negotiation thread
+            if buyer_order_id and seller_order_id:
+                neg_id = make_negotiation_id(buyer_order_id, seller_order_id)
+                try:
+                    async with NegotiationThreadTransaction("HANDLE_FULFILLMENT_FAILURE") as txn:
+                        thread_info = await txn.thread_store.get_thread_info(neg_id, owner_id=BASE_URL_OVERRIDE or "")
+                        our_price = (thread_info or {}).get("our_initial_price")
+                        messages = await txn.thread_store.get_thread(neg_id)
+                        agreed_price = next(
+                            (m["their_price"] for m in reversed(messages) if m.get("their_price") is not None),
+                            None,
+                        )
+                        await txn.add_message(
+                            negotiation_id=neg_id,
+                            sender=_sender_id(),
+                            our_price=our_price,
+                            their_price=agreed_price,
+                            proposed_price=agreed_price,
+                            action_taken="fulfillment_failed",
+                            message_type="failed",
+                        )
+                        await txn.mark_terminal(neg_id, "failure")
+                    logger.info("[FAILURE] Recorded failure in negotiation thread %s", neg_id)
+                except Exception as _neg_err:
+                    logger.warning("[FAILURE] Failed to record in negotiation thread: %s", _neg_err)
+
+            # 2. Reopen buyer's order
+            if buyer_order_id:
+                try:
+                    sqlite_client = get_sqlite_client()
+                    await sqlite_client.update_order(order_id=buyer_order_id, status="open")
+                    registry_client = get_registry_client()
+                    await registry_client.update_order(buyer_order_id, {"status": "open"})
+                    logger.info("[FAILURE] Reopened buyer order %s after fulfillment failure", buyer_order_id)
+                except Exception as _reopen_err:
+                    logger.warning("[FAILURE] Failed to reopen buyer order %s: %s", buyer_order_id, _reopen_err)
+
+            # 3. Escrow release — deferred (no alkahest revocation API wired yet)
+            if escrow_uid:
+                logger.warning("[FAILURE] Escrow %s remains locked — on-chain revocation not yet implemented", escrow_uid)
+
+            outcome["result"] = {
+                "status": "failure_acknowledged",
+                "message": f"Fulfillment failed: {reason}. Order reopened.",
+                "escrow_uid": escrow_uid,
+            }
+            outcome["message"] = outcome["result"]["message"]
+
         case ActionType.COUNTER_OFFER.value:
             logger.info(f"[ACTION] Countering offer with params: {parameters}")
             # Execute counter offer: create negotiation thread and send negotiation event
@@ -782,6 +757,177 @@ def _background_send(
             logger.warning("[A2A] Background send to %s failed: %s", agent_url, exc)
 
     asyncio.create_task(_safe_send())
+
+
+async def _fulfill_in_background(
+    *,
+    alkahest_client,
+    ctx: InvocationContext | None,
+    escrow_uid: str,
+    ssh_public_key: str,
+    oracle_address: str | None,
+    order_dict: dict,
+    matched_order_id: str | None,
+    buyer_order_id: str | None,
+    counterparty_url: str | None,
+    parameters: dict,
+) -> None:
+    """Run provisioning + fulfillment in a background task.
+
+    On success: update DB, close orders, close neg thread, send fulfillment to buyer.
+    On failure: record failure in neg thread, reopen seller order, notify buyer.
+    """
+    try:
+        result = await fulfill_compute_obligation(
+            client=alkahest_client,
+            escrow_uid=escrow_uid,
+            oracle_address=oracle_address,
+            ssh_public_key=ssh_public_key,
+            order=order_dict,
+            seller_order_id=matched_order_id,
+        )
+    except Exception as exc:
+        logger.error("[FULFILL_BG] fulfill_compute_obligation raised: %s", exc)
+        result = {"status": "error", "message": f"Provisioning failed: {exc}"}
+
+    if result.get("status") == "fulfilled":
+        # --- Success path (existing logic) ---
+        if matched_order_id:
+            try:
+                sqlite_client = get_sqlite_client()
+                await sqlite_client.update_order(
+                    order_id=matched_order_id,
+                    maker_attestation=result.get("fulfillment_uid"),
+                    fulfillment_resource=result.get("connection_details"),
+                )
+            except Exception as exc:
+                logger.warning("[LOCAL DB] Failed to update fulfillment for matched_order_id %s: %s", matched_order_id, exc)
+
+        for oid in filter(None, [matched_order_id, buyer_order_id]):
+            try:
+                registry_client = get_registry_client()
+                await registry_client.update_order(oid, {"status": "closed"})
+                sqlite_client = get_sqlite_client()
+                await sqlite_client.update_order(order_id=oid, status="closed")
+                logger.info("[FULFILL_BG] Closed order %s", oid)
+            except Exception as e:
+                logger.warning("[FULFILL_BG] Failed to close order %s: %s", oid, e)
+
+        # Close the negotiation thread
+        if matched_order_id and buyer_order_id:
+            try:
+                neg_id = make_negotiation_id(matched_order_id, buyer_order_id)
+                async with NegotiationThreadTransaction("FULFILL_COMPUTE_OBLIGATION") as txn:
+                    thread_info = await txn.thread_store.get_thread_info(neg_id, owner_id=BASE_URL_OVERRIDE or "")
+                    our_price = (thread_info or {}).get("our_initial_price")
+                    messages = await txn.thread_store.get_thread(neg_id)
+                    agreed_price = next(
+                        (m["their_price"] for m in reversed(messages) if m.get("their_price") is not None),
+                        None,
+                    )
+                    await txn.add_message(
+                        negotiation_id=neg_id,
+                        sender=_sender_id(),
+                        our_price=our_price,
+                        their_price=agreed_price,
+                        proposed_price=agreed_price,
+                        action_taken=ActionType.FULFILL_COMPUTE_OBLIGATION.value,
+                        message_type="fulfilled",
+                    )
+                    await txn.mark_terminal(neg_id, "success")
+            except Exception as _term_err:
+                logger.warning("[FULFILL_BG] Could not mark negotiation thread terminal after fulfillment: %s", _term_err)
+
+        # Send fulfillment to buyer
+        result["event_type"] = EventType.RECEIVE_COMPUTE_OBLIGATION_FULFILLMENT.value
+        if ctx and counterparty_url:
+            try:
+                event = Event(
+                    author=AGENT_ID,
+                    content=genai_types.Content(
+                        role="model",
+                        parts=[
+                            genai_types.Part.from_function_response(
+                                name=EventType.RECEIVE_COMPUTE_OBLIGATION_FULFILLMENT.value,
+                                response=result,
+                            )
+                        ],
+                    ),
+                    invocation_id=ctx.invocation_id,
+                    branch=ctx.branch,
+                )
+                _background_send(ctx, event, agent_url=counterparty_url)
+            except Exception as send_err:
+                logger.warning("[FULFILL_BG] Failed to send fulfillment to remote agent: %s", send_err)
+    else:
+        # --- Failure path ---
+        error_msg = result.get("message", "Unknown provisioning error")
+        logger.error("[FULFILL_BG] Provisioning failed: %s", error_msg)
+
+        # 1. Record failure in seller's negotiation thread
+        if matched_order_id and buyer_order_id:
+            try:
+                neg_id = make_negotiation_id(matched_order_id, buyer_order_id)
+                async with NegotiationThreadTransaction("FULFILL_FAILURE") as txn:
+                    thread_info = await txn.thread_store.get_thread_info(neg_id, owner_id=BASE_URL_OVERRIDE or "")
+                    our_price = (thread_info or {}).get("our_initial_price")
+                    messages = await txn.thread_store.get_thread(neg_id)
+                    agreed_price = next(
+                        (m["their_price"] for m in reversed(messages) if m.get("their_price") is not None),
+                        None,
+                    )
+                    await txn.add_message(
+                        negotiation_id=neg_id,
+                        sender=_sender_id(),
+                        our_price=our_price,
+                        their_price=agreed_price,
+                        proposed_price=agreed_price,
+                        action_taken=ActionType.FULFILL_COMPUTE_OBLIGATION.value,
+                        message_type="failed",
+                    )
+                    await txn.mark_terminal(neg_id, "failure")
+            except Exception as neg_err:
+                logger.warning("[FULFILL_BG] Failed to record failure in negotiation thread: %s", neg_err)
+
+        # 2. Reopen seller's order
+        if matched_order_id:
+            try:
+                sqlite_client = get_sqlite_client()
+                await sqlite_client.update_order(order_id=matched_order_id, status="open")
+                registry_client = get_registry_client()
+                await registry_client.update_order(matched_order_id, {"status": "open"})
+                logger.info("[FULFILL_BG] Reopened seller order %s after failure", matched_order_id)
+            except Exception as reopen_err:
+                logger.warning("[FULFILL_BG] Failed to reopen seller order %s: %s", matched_order_id, reopen_err)
+
+        # 3. Notify buyer of failure
+        if ctx and counterparty_url:
+            try:
+                failure_payload = {
+                    "event_type": EventType.FULFILLMENT_FAILED.value,
+                    "escrow_uid": escrow_uid,
+                    "reason": error_msg,
+                    "seller_order_id": matched_order_id,
+                    "buyer_order_id": buyer_order_id,
+                }
+                event = Event(
+                    author=AGENT_ID,
+                    content=genai_types.Content(
+                        role="model",
+                        parts=[
+                            genai_types.Part.from_function_response(
+                                name=EventType.FULFILLMENT_FAILED.value,
+                                response=failure_payload,
+                            )
+                        ],
+                    ),
+                    invocation_id=ctx.invocation_id,
+                    branch=ctx.branch,
+                )
+                _background_send(ctx, event, agent_url=counterparty_url)
+                logger.info("[FULFILL_BG] Sent fulfillment_failed notification to buyer at %s", counterparty_url)
+            except Exception as send_err:
+                logger.warning("[FULFILL_BG] Failed to send failure notification to buyer: %s", send_err)
 
 
 def rebalance_internal_resources() -> bool:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,6 +114,9 @@ services:
       # Force re-registration on every fresh Anvil — clear stale IDs from env file
       - ONCHAIN_AGENT_ID=
       - ZEROTIER_IP=
+      # Overridable via host env vars (e.g. PROVISIONING_MODE=mock make e2e-mock-happy)
+      - PROVISIONING_MODE=${PROVISIONING_MODE:-http}
+      - MOCK_PROVISIONING_SUCCESS=${MOCK_PROVISIONING_SUCCESS:-true}
     volumes:
       - ./shared-env:/app/shared-env
       - zerotier-sell:/var/lib/zerotier-one

--- a/domain/compute/agent/app/policy/store.py
+++ b/domain/compute/agent/app/policy/store.py
@@ -8,6 +8,7 @@ from core.agent.app.schema.pydantic_models import (
     ActionType as DomainActionType,
     AcceptOfferEvent,
     ReceiveComputeObligationFulfillmentEvent,
+    FulfillmentFailedEvent,
     ArbitrationCompleteEvent,
     DecisionContext,
     MakeOfferEvent,
@@ -245,6 +246,22 @@ def rcf_action_trust_fulfillment(context: DecisionContext) -> DomainAction | Non
             "connection_details": context.event.connection_details,
             "counterparty_url": context.event.fulfilling_party_url,
             "tenant_credentials": context.event.tenant_credentials,
+        },
+    )
+
+# Fulfillment failed -> acknowledge failure, reopen order
+@policy_callable("ff.action.handle_fulfillment_failure")
+def ff_action_handle_fulfillment_failure(context: DecisionContext) -> DomainAction | None:
+    """When the seller notifies us that provisioning failed, handle the failure."""
+    if not isinstance(context.event, FulfillmentFailedEvent):
+        return None
+    return DomainAction(
+        action_type=DomainActionType.HANDLE_FULFILLMENT_FAILURE,
+        parameters={
+            "escrow_uid": context.event.escrow_uid,
+            "reason": context.event.reason,
+            "seller_order_id": context.event.seller_order_id,
+            "buyer_order_id": context.event.buyer_order_id,
         },
     )
 

--- a/erc-8004-registry-py/alembic/versions/007_add_oracle_address.py
+++ b/erc-8004-registry-py/alembic/versions/007_add_oracle_address.py
@@ -1,0 +1,24 @@
+"""add_oracle_address
+
+Revision ID: 007_add_oracle_address
+Revises: 006_rename_duration_to_duration_hours
+Create Date: 2026-03-26 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "007_add_oracle_address"
+down_revision = "006_rename_duration_to_duration_hours"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("market_orders", sa.Column("oracle_address", sa.Text(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("market_orders", "oracle_address")

--- a/erc-8004-registry-py/src/api/order_routes.py
+++ b/erc-8004-registry-py/src/api/order_routes.py
@@ -72,6 +72,7 @@ async def publish_order(
             "duration_hours": order_data.get("duration_hours"),
             "maker_attestation": order_data.get("maker_attestation"),
             "taker_attestation": order_data.get("taker_attestation"),
+            "oracle_address": order_data.get("oracle_address"),
         }
         for field, value in update_fields.items():
             if value is not None:
@@ -95,6 +96,7 @@ async def publish_order(
             duration_hours=order_data.get("duration_hours", 1),
             maker_attestation=order_data.get("maker_attestation"),
             taker_attestation=order_data.get("taker_attestation"),
+            oracle_address=order_data.get("oracle_address"),
             status=validate_order_status(status_str),
         )
         db.add(order)
@@ -227,16 +229,27 @@ async def update_order(
     original_demand_resource = order.demand_resource
     
     symmetric_order = None
-    if "order_taker" in updates:
-        temp_taker = updates["order_taker"]
-        original_taker = order.order_taker
-        order.order_taker = temp_taker
-        try:
+    needs_symmetric_lookup = (
+        "order_taker" in updates
+        or ("maker_attestation" in updates and order.order_taker)
+        or ("taker_attestation" in updates and order.order_taker)
+        or ("oracle_address" in updates and order.order_taker)
+    )
+    if needs_symmetric_lookup:
+        if "order_taker" in updates:
+            temp_taker = updates["order_taker"]
+            original_taker = order.order_taker
+            order.order_taker = temp_taker
+            try:
+                symmetric_order = find_symmetric_order(
+                    db, order, original_offer_resource, original_demand_resource
+                )
+            finally:
+                order.order_taker = original_taker
+        else:
             symmetric_order = find_symmetric_order(
                 db, order, original_offer_resource, original_demand_resource
             )
-        finally:
-            order.order_taker = original_taker
     
     if "status" in updates:
         order.status = validate_order_status(updates["status"])
@@ -246,8 +259,10 @@ async def update_order(
         order.taker_attestation = updates["taker_attestation"]
     if "maker_attestation" in updates:
         order.maker_attestation = updates["maker_attestation"]
+    if "oracle_address" in updates:
+        order.oracle_address = updates["oracle_address"]
     order.updated_at = datetime.utcnow()
-    
+
     if symmetric_order:
         if "status" in updates:
             symmetric_order.status = validate_order_status(updates["status"])
@@ -257,6 +272,8 @@ async def update_order(
             symmetric_order.taker_attestation = order.maker_attestation
         if "taker_attestation" in updates and order.taker_attestation:
             symmetric_order.maker_attestation = order.taker_attestation
+        if "oracle_address" in updates and order.oracle_address:
+            symmetric_order.oracle_address = order.oracle_address
         symmetric_order.updated_at = datetime.utcnow()
     
     try:

--- a/erc-8004-registry-py/src/api/utils.py
+++ b/erc-8004-registry-py/src/api/utils.py
@@ -305,6 +305,7 @@ def order_to_dict(order: MarketOrder) -> dict:
         "duration_hours": order.duration_hours,
         "maker_attestation": order.maker_attestation,
         "taker_attestation": order.taker_attestation,
+        "oracle_address": order.oracle_address,
         "status": order.status.value,
         "created_at": order.created_at.isoformat(),
         "updated_at": order.updated_at.isoformat(),
@@ -374,7 +375,7 @@ def find_symmetric_order(db: Session, order: MarketOrder, original_offer_resourc
         and_(
             MarketOrder.order_id != order.order_id,
             MarketOrder.order_maker == order.order_taker,
-            MarketOrder.status == OrderStatusEnum.open,
+            MarketOrder.status.in_([OrderStatusEnum.open, OrderStatusEnum.accepted]),
         )
     ).all()
     

--- a/erc-8004-registry-py/src/db/models.py
+++ b/erc-8004-registry-py/src/db/models.py
@@ -111,6 +111,7 @@ class MarketOrder(Base):
     duration_hours = Column(Integer, nullable=False)
     maker_attestation = Column(Text, nullable=True)
     taker_attestation = Column(Text, nullable=True)
+    oracle_address = Column(Text, nullable=True)
     status = Column(SQLEnum(OrderStatusEnum), nullable=False, default=OrderStatusEnum.open)
     created_at = Column(DateTime(timezone=True), nullable=False, default=datetime.utcnow)
     updated_at = Column(DateTime(timezone=True), nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)

--- a/integration-tests/Makefile
+++ b/integration-tests/Makefile
@@ -52,3 +52,47 @@ test-ci:
 		--no-header \
 		-p no:cacheprovider \
 		$(PYTEST_ARGS)
+
+# -----------------------------------------------------------------------
+# E2E Mock Provisioning Tests
+# -----------------------------------------------------------------------
+# These targets manage the full docker-compose lifecycle + pytest run.
+# Usage:
+#   make e2e-mock-happy          # happy path only
+#   make e2e-mock-failure        # failure path only
+# -----------------------------------------------------------------------
+
+REPO_ROOT       := $(shell git -C .. rev-parse --show-toplevel)
+COMPOSE         := docker compose -f "$(REPO_ROOT)/docker-compose.yml"
+E2E_PROFILE     ?= local,e2e-mock
+
+e2e-clean-dbs:
+	rm -f "$(REPO_ROOT)/core/agent/app/data/buy-agent/agent.db" "$(REPO_ROOT)/core/agent/app/data/sell-agent/agent.db"
+
+e2e-wait-ready:
+	@echo "Waiting for registry healthcheck..."
+	@for i in $$(seq 1 30); do curl -sf http://localhost:8080/health >/dev/null 2>&1 && break; sleep 2; done
+	@echo "Waiting for buyer agent HTTP..."
+	@for i in $$(seq 1 30); do curl -sf http://localhost:8000/.well-known/agent.json >/dev/null 2>&1 && break; sleep 2; done
+	@echo "Waiting for seller agent HTTP..."
+	@for i in $$(seq 1 30); do curl -sf http://localhost:8001/.well-known/agent.json >/dev/null 2>&1 && break; sleep 2; done
+	@echo "Waiting for agents to register on-chain (~25s)..."
+	@for i in $$(seq 1 45); do \
+		COUNT=$$(curl -sf http://localhost:8080/agents 2>/dev/null | python3 -c "import sys,json; print(len(json.load(sys.stdin).get('items',[])))" 2>/dev/null || echo 0); \
+		[ "$$COUNT" -ge 2 ] && break; \
+		sleep 2; \
+	done
+	@echo "All services ready."
+
+e2e-mock-happy: e2e-clean-dbs
+	$(COMPOSE) down -v
+	PROVISIONING_MODE=mock $(COMPOSE) up -d
+	$(MAKE) e2e-wait-ready
+	ACTIVE_PROFILES=$(E2E_PROFILE) uv run pytest -m mock_provisioning_happy -v --tb=long
+
+e2e-mock-failure: e2e-clean-dbs
+	$(COMPOSE) down -v
+	PROVISIONING_MODE=mock MOCK_PROVISIONING_SUCCESS=false $(COMPOSE) up -d
+	$(MAKE) e2e-wait-ready
+	ACTIVE_PROFILES=$(E2E_PROFILE) uv run pytest -m mock_provisioning_failure -v --tb=long
+

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -146,6 +146,26 @@ make test ACTIVE_PROFILES=staging CONFIG_DIRECTORY=/mnt/e2e-config
 make test PYTEST_ARGS="-k test_contract_owner -v --tb=long"
 ```
 
+### E2E mock provisioning tests
+
+These targets spin up the full docker-compose stack, wait for services to be
+ready (including on-chain agent registration), run the tests, then tear down.
+
+```bash
+make e2e-mock-happy       # deal lifecycle: create → negotiate → escrow → fulfill → arbitrate → close
+make e2e-mock-failure     # provisioning fails → orders reopen
+```
+
+Each target uses the CLI (`market order create`, `market order history`,
+`market order show --negotiation --credentials --show-password`) to drive
+order creation and inspect results. CLI output is captured in the pytest log.
+
+To run against an already-running stack without lifecycle management:
+
+```bash
+ACTIVE_PROFILES=local,e2e-mock uv run pytest -m mock_provisioning_happy -v --tb=long
+```
+
 ---
 
 ## CI/CD

--- a/integration-tests/config/config-e2e-mock.yml
+++ b/integration-tests/config/config-e2e-mock.yml
@@ -1,0 +1,18 @@
+# ---------------------------------------------------------------------------
+# Profile: e2e-mock
+# Extends config-local.yml with agent/registry URLs and DB paths for
+# docker-compose e2e mock provisioning tests.
+# ---------------------------------------------------------------------------
+
+agents:
+  registry_url: "http://localhost:8080"
+  buyer_url: "http://localhost:8000"
+  seller_url: "http://localhost:8001"
+  buyer_db: "core/agent/app/data/buy-agent/agent.db"
+  seller_db: "core/agent/app/data/sell-agent/agent.db"
+  buyer_env: "core/agent/.env.alice.docker-compose"
+  seller_env: "core/agent/.env.bob.docker-compose"
+
+tests:
+  e2e_poll_timeout_s: 120
+  e2e_poll_interval_s: 3

--- a/integration-tests/pyproject.toml
+++ b/integration-tests/pyproject.toml
@@ -45,6 +45,9 @@ markers = [
     "wallets: Tests that validate wallet balances and key pairs",
     "smoke: Quick smoke tests",
     "slow: Tests that may take longer due to RPC latency",
+    "mock_provisioning: E2E mock provisioning flow tests",
+    "mock_provisioning_happy: Happy path — deal completes successfully",
+    "mock_provisioning_failure: Failure path — provisioning fails, orders reopen",
 ]
 log_cli = true
 log_cli_level = "INFO"

--- a/integration-tests/settings.toml
+++ b/integration-tests/settings.toml
@@ -38,9 +38,23 @@ private_key    = ""
 wallet_address = ""
 
 # ---------------------------------------------------------------------------
+# Agent / registry endpoints (e2e tests)
+# ---------------------------------------------------------------------------
+[default.agents]
+registry_url = ""
+buyer_url = ""
+seller_url = ""
+buyer_db = ""
+seller_db = ""
+buyer_env = ""
+seller_env = ""
+
+# ---------------------------------------------------------------------------
 # Test behaviour
 # ---------------------------------------------------------------------------
 [default.tests]
 minimum_eth_balance = "0.01"          # ETH — wallets must hold at least this
 gas_price_strategy  = "medium"        # low | medium | high
 require_checksummed_addresses = true
+e2e_poll_timeout_s = 120
+e2e_poll_interval_s = 3

--- a/integration-tests/tests/helpers/agent_client.py
+++ b/integration-tests/tests/helpers/agent_client.py
@@ -1,0 +1,84 @@
+"""HTTP client for agent API with EIP-191 authentication."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import urllib.request
+import urllib.error
+
+from eth_account import Account
+from eth_account.messages import encode_defunct
+
+log = logging.getLogger(__name__)
+
+
+def _build_auth_headers(private_key: str, operation: str, resource_id: str) -> dict[str, str]:
+    """Build X-Signature + X-Timestamp headers (EIP-191)."""
+    ts = int(time.time())
+    message = f"{operation}:{resource_id}:{ts}"
+    msg_hash = encode_defunct(text=message)
+    sig = Account.sign_message(msg_hash, private_key).signature.hex()
+    return {"X-Signature": sig, "X-Timestamp": str(ts)}
+
+
+def create_order(
+    base_url: str,
+    private_key: str,
+    wallet_address: str,
+    offer: dict,
+    demand: dict,
+    duration_hours: int = 1,
+    timeout: float = 120,
+) -> dict:
+    """POST /orders/create with signed headers. Returns response dict."""
+    url = f"{base_url.rstrip('/')}/orders/create"
+    headers = _build_auth_headers(private_key, "create_order", wallet_address)
+    headers["Content-Type"] = "application/json"
+
+    body = json.dumps({
+        "offer": offer,
+        "demand": demand,
+        "duration_hours": duration_hours,
+    }).encode()
+
+    req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+    log.info("POST %s (wallet=%s…)", url, wallet_address[:10])
+
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            data = json.loads(resp.read())
+            log.info("  → status=%s order_id=%s", data.get("status"), data.get("order_id"))
+            return data
+    except urllib.error.HTTPError as exc:
+        error_body = exc.read().decode(errors="replace")
+        log.error("  → HTTP %s: %s", exc.code, error_body[:500])
+        raise RuntimeError(f"HTTP {exc.code} from {url}: {error_body[:500]}") from exc
+
+
+def query_registry_orders(
+    registry_url: str,
+    status: str | None = None,
+    timeout: float = 10,
+) -> dict:
+    """GET /orders from the registry. Returns {items: [...], count: N}."""
+    url = f"{registry_url.rstrip('/')}/orders"
+    if status:
+        url += f"?status={status}"
+
+    req = urllib.request.Request(url, method="GET")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read())
+
+
+def get_registry_order(
+    registry_url: str,
+    order_id: str,
+    timeout: float = 10,
+) -> dict:
+    """GET /orders/{order_id} from the registry. Returns {order: {...}}."""
+    url = f"{registry_url.rstrip('/')}/orders/{order_id}"
+    req = urllib.request.Request(url, method="GET")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read())

--- a/integration-tests/tests/helpers/cli_client.py
+++ b/integration-tests/tests/helpers/cli_client.py
@@ -1,0 +1,198 @@
+"""CLI wrapper for `market order create` subprocess calls."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import subprocess
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_CLI_DIR = _REPO_ROOT / "cli"
+
+
+def cli_create_order(
+    agent_url: str,
+    env_file: str,
+    offer: dict,
+    demand: dict,
+    duration_hours: int = 1,
+    timeout: float = 30,
+) -> dict:
+    """Run ``market order create`` via subprocess and return parsed output.
+
+    Parameters
+    ----------
+    agent_url : str
+        Agent base URL reachable from host (e.g. ``http://localhost:8001``).
+    env_file : str
+        Path to agent env file (relative to repo root or absolute).
+        Used for ``AGENT_PRIV_KEY`` / ``AGENT_WALLET_ADDRESS``.
+    offer, demand : dict
+        Order resources as JSON-serialisable dicts.
+    duration_hours : int
+        Order duration.
+    timeout : float
+        Subprocess timeout in seconds.
+
+    Returns
+    -------
+    dict with keys:
+        ``status``     – parsed from CLI output (e.g. "created")
+        ``order_id``   – parsed from CLI output (may be None)
+        ``cli_stdout``  – raw stdout
+        ``cli_stderr``  – raw stderr
+        ``returncode`` – process exit code
+    """
+    env_path = Path(env_file)
+    if not env_path.is_absolute():
+        env_path = _REPO_ROOT / env_path
+
+    cmd = [
+        "uv", "run", "market", "order", "create",
+        "-a", agent_url,
+        "-e", str(env_path),
+        "-o", json.dumps(offer),
+        "-d", json.dumps(demand),
+        "-t", str(duration_hours),
+    ]
+
+    log.info("CLI: %s", " ".join(cmd))
+
+    result = subprocess.run(
+        cmd,
+        cwd=str(_CLI_DIR),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env={
+            **__import__("os").environ,
+            "NO_COLOR": "1",  # disable Rich ANSI codes
+        },
+    )
+
+    stdout = result.stdout
+    stderr = result.stderr
+
+    # Always log CLI output for visibility
+    if stdout.strip():
+        log.info("CLI stdout:\n%s", stdout)
+    if stderr.strip():
+        log.warning("CLI stderr:\n%s", stderr)
+
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"CLI exited with code {result.returncode}\n"
+            f"stdout: {stdout[:1000]}\nstderr: {stderr[:1000]}"
+        )
+
+    # Parse status and order_id from Rich table output
+    status = _parse_field(stdout, "Status")
+    order_id = _parse_field(stdout, "Order ID")
+
+    return {
+        "status": status,
+        "order_id": order_id,
+        "cli_stdout": stdout,
+        "cli_stderr": stderr,
+        "returncode": result.returncode,
+    }
+
+
+def cli_order_history(
+    env_file: str,
+    timeout: float = 15,
+) -> str:
+    """Run ``market order history -e <env>`` and return stdout."""
+    env_path = Path(env_file)
+    if not env_path.is_absolute():
+        env_path = _REPO_ROOT / env_path
+
+    cmd = ["uv", "run", "market", "order", "history", "-e", str(env_path)]
+    log.info("CLI: %s", " ".join(cmd))
+
+    result = subprocess.run(
+        cmd,
+        cwd=str(_CLI_DIR),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env={**__import__("os").environ, "NO_COLOR": "1"},
+    )
+
+    if result.stdout.strip():
+        log.info("CLI stdout:\n%s", result.stdout)
+    if result.stderr.strip():
+        log.warning("CLI stderr:\n%s", result.stderr)
+
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"CLI order history exited with code {result.returncode}\n"
+            f"stdout: {result.stdout[:1000]}\nstderr: {result.stderr[:1000]}"
+        )
+
+    return result.stdout
+
+
+def cli_order_show(
+    order_id: str,
+    env_file: str,
+    negotiation: bool = False,
+    credentials: bool = False,
+    show_password: bool = False,
+    timeout: float = 15,
+) -> str:
+    """Run ``market order show <id>`` with optional flags and return stdout."""
+    env_path = Path(env_file)
+    if not env_path.is_absolute():
+        env_path = _REPO_ROOT / env_file
+
+    cmd = [
+        "uv", "run", "market", "order", "show", order_id,
+        "-e", str(env_path),
+    ]
+    if negotiation:
+        cmd.append("--negotiation")
+    if credentials:
+        cmd.append("--credentials")
+    if show_password:
+        cmd.append("--show-password")
+
+    log.info("CLI: %s", " ".join(cmd))
+
+    result = subprocess.run(
+        cmd,
+        cwd=str(_CLI_DIR),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env={**__import__("os").environ, "NO_COLOR": "1"},
+    )
+
+    if result.stdout.strip():
+        log.info("CLI stdout:\n%s", result.stdout)
+    if result.stderr.strip():
+        log.warning("CLI stderr:\n%s", result.stderr)
+
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"CLI order show exited with code {result.returncode}\n"
+            f"stdout: {result.stdout[:1000]}\nstderr: {result.stderr[:1000]}"
+        )
+
+    return result.stdout
+
+
+def _parse_field(output: str, field_name: str) -> str | None:
+    """Extract a field value from Rich grid table output.
+
+    Handles both formatted (box-drawing) and plain text output.
+    Looks for patterns like ``Status   created`` or ``Order ID   abc123``.
+    """
+    # Try patterns: "FieldName<whitespace>Value" across lines
+    pattern = rf"(?:^|\s){re.escape(field_name)}\s+(\S+)"
+    m = re.search(pattern, output, re.MULTILINE)
+    return m.group(1) if m else None

--- a/integration-tests/tests/helpers/polling.py
+++ b/integration-tests/tests/helpers/polling.py
@@ -1,0 +1,77 @@
+"""Polling / wait utilities for e2e tests."""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Callable, TypeVar
+
+from tests.helpers.agent_client import query_registry_orders
+from tests.helpers.sqlite_reader import get_all_orders
+
+log = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+def poll_until(
+    predicate: Callable[[], T],
+    timeout_s: float = 120,
+    interval_s: float = 3,
+    description: str = "",
+) -> T:
+    """Call *predicate* repeatedly until it returns a truthy value or timeout."""
+    deadline = time.monotonic() + timeout_s
+    last_exc: Exception | None = None
+
+    while time.monotonic() < deadline:
+        try:
+            result = predicate()
+            if result:
+                return result
+        except Exception as exc:
+            last_exc = exc
+            log.debug("poll_until(%s): %s", description, exc)
+        time.sleep(interval_s)
+
+    msg = f"Timed out after {timeout_s}s waiting for: {description}"
+    if last_exc:
+        msg += f" (last error: {last_exc})"
+    raise TimeoutError(msg)
+
+
+def poll_registry_orders(
+    registry_url: str,
+    status: str,
+    min_count: int,
+    timeout_s: float = 120,
+    interval_s: float = 3,
+) -> list[dict[str, Any]]:
+    """Poll GET /orders?status={status} until count >= min_count."""
+
+    def _check() -> list[dict[str, Any]] | None:
+        data = query_registry_orders(registry_url, status=status)
+        items = data.get("items", [])
+        if len(items) >= min_count:
+            return items
+        return None
+
+    desc = f"registry has >= {min_count} orders with status={status}"
+    return poll_until(_check, timeout_s=timeout_s, interval_s=interval_s, description=desc)
+
+
+def poll_sqlite_order_status(
+    db_path: str,
+    expected_status: str,
+    timeout_s: float = 120,
+    interval_s: float = 3,
+) -> list[dict[str, Any]]:
+    """Poll SQLite until at least one order has *expected_status*."""
+
+    def _check() -> list[dict[str, Any]] | None:
+        orders = get_all_orders(db_path)
+        matching = [o for o in orders if o["status"] == expected_status]
+        return matching or None
+
+    desc = f"sqlite {db_path} has order with status={expected_status}"
+    return poll_until(_check, timeout_s=timeout_s, interval_s=interval_s, description=desc)

--- a/integration-tests/tests/helpers/sqlite_reader.py
+++ b/integration-tests/tests/helpers/sqlite_reader.py
@@ -1,0 +1,34 @@
+"""Read-only SQLite queries for e2e verification."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+
+_ORDER_COLUMNS = [
+    "order_id", "status", "created_at", "updated_at",
+    "offer_resource", "demand_resource", "fulfillment_resource",
+    "duration_hours", "order_maker", "order_taker", "matched_offer_id",
+    "maker_attestation", "taker_attestation", "escrow_uid", "oracle_address",
+]
+
+
+def get_all_orders(db_path: str) -> list[dict[str, Any]]:
+    """Return all orders with full column set."""
+    conn = sqlite3.connect(db_path, timeout=5)
+    conn.row_factory = sqlite3.Row
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            f"SELECT {', '.join(_ORDER_COLUMNS)} FROM orders ORDER BY updated_at DESC"
+        )
+        return [dict(row) for row in cur.fetchall()]
+    finally:
+        conn.close()
+
+
+def get_latest_order(db_path: str) -> dict[str, Any] | None:
+    """Return the most recently updated order, or None."""
+    orders = get_all_orders(db_path)
+    return orders[0] if orders else None

--- a/integration-tests/tests/test_mock_provisioning.py
+++ b/integration-tests/tests/test_mock_provisioning.py
@@ -1,0 +1,374 @@
+"""
+E2E test: mock provisioning flow.
+
+Tests the full order lifecycle:
+  create → negotiate → accept → escrow → fulfill (mock) → arbitrate → close
+
+Requires a running docker-compose stack with PROVISIONING_MODE=mock on seller.
+Run with: ACTIVE_PROFILES=local,e2e-mock pytest -m mock_provisioning_happy -v
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from arkhai_e2e_tests.settings import settings
+from tests.helpers.cli_client import cli_create_order, cli_order_history, cli_order_show
+from tests.helpers.polling import (
+    poll_registry_orders,
+    poll_until,
+)
+from tests.helpers.sqlite_reader import get_all_orders, get_latest_order
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants — must match seller's imported resources (ww1-machine.csv)
+# ---------------------------------------------------------------------------
+SELLER_OFFER = {"gpu_model": "RTX 5080", "quantity": 1, "sla": 90.0, "region": "California, US"}
+SELLER_DEMAND = {"token": "MOCK", "amount": 100}
+
+BUYER_OFFER = {"token": "MOCK", "amount": 80}
+BUYER_DEMAND = {"gpu_model": "RTX 5080", "quantity": 1, "sla": 90.0, "region": "California, US"}
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _buyer_url() -> str:
+    return settings.AGENTS.BUYER_URL
+
+
+def _seller_url() -> str:
+    return settings.AGENTS.SELLER_URL
+
+
+def _buyer_env() -> str:
+    return settings.AGENTS.BUYER_ENV
+
+
+def _seller_env() -> str:
+    return settings.AGENTS.SELLER_ENV
+
+
+def _registry_url() -> str:
+    return settings.AGENTS.REGISTRY_URL
+
+
+def _buyer_db() -> str:
+    value = settings.AGENTS.BUYER_DB
+    p = Path(value)
+    if not p.is_absolute():
+        p = _REPO_ROOT / p
+    return str(p)
+
+
+def _seller_db() -> str:
+    value = settings.AGENTS.SELLER_DB
+    p = Path(value)
+    if not p.is_absolute():
+        p = _REPO_ROOT / p
+    return str(p)
+
+
+def _poll_timeout() -> float:
+    return float(settings.get("TESTS__E2E_POLL_TIMEOUT_S", 120))
+
+
+def _poll_interval() -> float:
+    return float(settings.get("TESTS__E2E_POLL_INTERVAL_S", 3))
+
+
+# ============================================================================
+# HAPPY PATH
+# ============================================================================
+
+
+@pytest.mark.mock_provisioning
+@pytest.mark.mock_provisioning_happy
+class TestHappyPath:
+    """Full deal lifecycle with mock provisioning (success mode)."""
+
+    # Shared state across ordered test methods
+    _state: dict = {}
+
+    def test_01_create_seller_order(self):
+        """Seller posts a compute-supply order via CLI."""
+        resp = cli_create_order(
+            agent_url=_seller_url(),
+            env_file=_seller_env(),
+            offer=SELLER_OFFER,
+            demand=SELLER_DEMAND,
+        )
+        assert resp["status"] == "created", f"Expected 'created', got {resp}"
+        self.__class__._state["seller_order_id"] = resp["order_id"]
+        log.info("Seller order: %s", resp["order_id"])
+
+    def test_02_registry_indexes_seller_order(self):
+        """Registry should have at least 1 open order within 30s."""
+        items = poll_registry_orders(
+            _registry_url(), status="open", min_count=1,
+            timeout_s=30, interval_s=_poll_interval(),
+        )
+        assert len(items) >= 1
+        log.info("Registry has %d open order(s)", len(items))
+
+    def test_03_create_buyer_order(self):
+        """Buyer posts a matching compute-demand order via CLI (triggers negotiation)."""
+        resp = cli_create_order(
+            agent_url=_buyer_url(),
+            env_file=_buyer_env(),
+            offer=BUYER_OFFER,
+            demand=BUYER_DEMAND,
+        )
+        assert resp["status"] in ("created", "queued"), f"Unexpected: {resp}"
+        self.__class__._state["buyer_order_id"] = resp["order_id"]
+        log.info("Buyer order: %s", resp["order_id"])
+
+    def test_04_deal_completes(self):
+        """Both orders should reach status=closed in the registry."""
+        items = poll_registry_orders(
+            _registry_url(), status="closed", min_count=2,
+            timeout_s=_poll_timeout(), interval_s=_poll_interval(),
+        )
+        assert len(items) >= 2
+        self.__class__._state["closed_registry_orders"] = items
+        log.info("Registry has %d closed order(s)", len(items))
+
+    def test_05_cli_buyer_history(self):
+        """CLI: buyer order history after deal completes."""
+        cli_order_history(env_file=_buyer_env())
+
+    def test_06_cli_seller_history(self):
+        """CLI: seller order history after deal completes."""
+        cli_order_history(env_file=_seller_env())
+
+    def test_07_cli_buyer_order_show(self):
+        """CLI: buyer order show with negotiation + credentials."""
+        order_id = self.__class__._state.get("buyer_order_id")
+        assert order_id, "No buyer_order_id in state"
+        cli_order_show(
+            order_id, env_file=_buyer_env(),
+            negotiation=True, credentials=True, show_password=True,
+        )
+
+    def test_08_cli_seller_order_show(self):
+        """CLI: seller order show with negotiation + credentials."""
+        order_id = self.__class__._state.get("seller_order_id")
+        assert order_id, "No seller_order_id in state"
+        cli_order_show(
+            order_id, env_file=_seller_env(),
+            negotiation=True, credentials=True, show_password=True,
+        )
+
+    def test_09_buyer_local_db(self):
+        """Buyer's SQLite: status=closed, correct attestation mapping."""
+        order = get_latest_order(_buyer_db())
+        assert order is not None, "No orders in buyer DB"
+        assert order["status"] == "closed", f"Buyer status={order['status']}"
+        # Buyer is maker → maker_attestation = escrow_uid
+        assert order["maker_attestation"] is not None, "Buyer maker_attestation is null"
+        assert order["maker_attestation"] == order["escrow_uid"], (
+            f"Buyer maker_attestation ({order['maker_attestation']}) != escrow_uid ({order['escrow_uid']})"
+        )
+        # Buyer's taker = seller → taker_attestation = fulfillment_uid
+        assert order["taker_attestation"] is not None, "Buyer taker_attestation is null"
+        assert order["taker_attestation"] != order["escrow_uid"], (
+            "Buyer taker_attestation should be fulfillment_uid, not escrow_uid"
+        )
+        assert order["oracle_address"] is not None, "Buyer oracle_address is null"
+        self.__class__._state["buyer_order"] = order
+        log.info("Buyer DB OK: ma=%s ta=%s", order["maker_attestation"][:8], order["taker_attestation"][:8])
+
+    def test_10_seller_local_db(self):
+        """Seller's SQLite: status=closed, correct attestation mapping."""
+        order = get_latest_order(_seller_db())
+        assert order is not None, "No orders in seller DB"
+        assert order["status"] == "closed", f"Seller status={order['status']}"
+        # Seller is maker → maker_attestation = fulfillment_uid
+        assert order["maker_attestation"] is not None, "Seller maker_attestation is null"
+        # Seller's taker = buyer → taker_attestation = escrow_uid
+        assert order["taker_attestation"] is not None, "Seller taker_attestation is null"
+        assert order["oracle_address"] is not None, "Seller oracle_address is null"
+        self.__class__._state["seller_order"] = order
+        log.info("Seller DB OK: ma=%s ta=%s", order["maker_attestation"][:8], order["taker_attestation"][:8])
+
+    def test_11_registry_attestations(self):
+        """Both registry orders have attestation fields populated."""
+        for item in self.__class__._state["closed_registry_orders"]:
+            assert item["maker_attestation"] is not None, (
+                f"Registry order {item['order_id'][:8]} has null maker_attestation"
+            )
+            assert item["taker_attestation"] is not None, (
+                f"Registry order {item['order_id'][:8]} has null taker_attestation"
+            )
+            assert item["oracle_address"] is not None, (
+                f"Registry order {item['order_id'][:8]} has null oracle_address"
+            )
+
+    def test_12_cross_check_attestations(self):
+        """Buyer's maker_attestation == Seller's taker_attestation and vice versa."""
+        buyer = self.__class__._state["buyer_order"]
+        seller = self.__class__._state["seller_order"]
+
+        assert buyer["maker_attestation"] == seller["taker_attestation"], (
+            f"Buyer maker_attestation ({buyer['maker_attestation'][:8]}) "
+            f"!= Seller taker_attestation ({seller['taker_attestation'][:8]})"
+        )
+        assert buyer["taker_attestation"] == seller["maker_attestation"], (
+            f"Buyer taker_attestation ({buyer['taker_attestation'][:8]}) "
+            f"!= Seller maker_attestation ({seller['maker_attestation'][:8]})"
+        )
+        log.info(
+            "Cross-check OK: escrow_uid=%s fulfillment_uid=%s",
+            buyer["maker_attestation"][:8],
+            buyer["taker_attestation"][:8],
+        )
+
+
+# ============================================================================
+# FAILURE PATH
+# ============================================================================
+
+
+@pytest.mark.mock_provisioning
+@pytest.mark.mock_provisioning_failure
+class TestFailurePath:
+    """Provisioning fails → both orders reopen."""
+
+    _state: dict = {}
+
+    def test_01_create_seller_order(self):
+        """Seller posts a compute-supply order via CLI."""
+        resp = cli_create_order(
+            agent_url=_seller_url(),
+            env_file=_seller_env(),
+            offer=SELLER_OFFER,
+            demand=SELLER_DEMAND,
+        )
+        assert resp["status"] == "created", f"Expected 'created', got {resp}"
+        self.__class__._state["seller_order_id"] = resp["order_id"]
+
+    def test_02_registry_indexes_seller_order(self):
+        """Registry should index the seller order."""
+        items = poll_registry_orders(
+            _registry_url(), status="open", min_count=1,
+            timeout_s=30, interval_s=_poll_interval(),
+        )
+        assert len(items) >= 1
+
+    def test_03_create_buyer_order(self):
+        """Buyer posts a matching order via CLI (triggers negotiation + failure)."""
+        resp = cli_create_order(
+            agent_url=_buyer_url(),
+            env_file=_buyer_env(),
+            offer=BUYER_OFFER,
+            demand=BUYER_DEMAND,
+        )
+        assert resp["status"] in ("created", "queued"), f"Unexpected: {resp}"
+        self.__class__._state["buyer_order_id"] = resp["order_id"]
+
+    def test_04_orders_reopen(self):
+        """After provisioning fails, both orders should reopen to status=open.
+
+        The flow is: negotiate → accept → escrow → fulfill FAILS →
+        seller reopens → buyer reopens.
+        We poll the seller's SQLite for an order that transitions back to 'open'
+        after having been 'accepted' (indicated by escrow_uid being set).
+        """
+        def _seller_reopened():
+            orders = get_all_orders(_seller_db())
+            for o in orders:
+                if o["status"] == "open" and o.get("escrow_uid"):
+                    return o
+            return None
+
+        seller_order = poll_until(
+            _seller_reopened,
+            timeout_s=_poll_timeout(),
+            interval_s=_poll_interval(),
+            description="seller order reopened after failure",
+        )
+        assert seller_order is not None
+        self.__class__._state["seller_order"] = seller_order
+        log.info("Seller order reopened: %s", seller_order["order_id"][:8])
+
+    def test_05_cli_buyer_history_failure(self):
+        """CLI: buyer order history after failure."""
+        cli_order_history(env_file=_buyer_env())
+
+    def test_06_cli_seller_history_failure(self):
+        """CLI: seller order history after failure."""
+        cli_order_history(env_file=_seller_env())
+
+    def test_07_cli_buyer_order_show_failure(self):
+        """CLI: buyer order show with negotiation after failure."""
+        order_id = self.__class__._state.get("buyer_order_id")
+        assert order_id, "No buyer_order_id in state"
+        cli_order_show(
+            order_id, env_file=_buyer_env(),
+            negotiation=True, credentials=True, show_password=True,
+        )
+
+    def test_08_cli_seller_order_show_failure(self):
+        """CLI: seller order show with negotiation after failure."""
+        order_id = self.__class__._state.get("seller_order_id")
+        assert order_id, "No seller_order_id in state"
+        cli_order_show(
+            order_id, env_file=_seller_env(),
+            negotiation=True, credentials=True, show_password=True,
+        )
+
+    def test_09_seller_local_db_failure(self):
+        """Seller's order: status=open, no maker_attestation (no fulfillment), taker_attestation set (escrow)."""
+        order = self.__class__._state["seller_order"]
+        assert order["status"] == "open"
+        assert order["maker_attestation"] is None, (
+            f"Seller maker_attestation should be null after failure, got {order['maker_attestation']}"
+        )
+        assert order["taker_attestation"] is not None, (
+            "Seller taker_attestation (escrow_uid) should be set even after failure"
+        )
+
+    def test_10_buyer_local_db_failure(self):
+        """Buyer's order: status=open, maker_attestation set (escrow), no taker_attestation."""
+        def _buyer_reopened():
+            orders = get_all_orders(_buyer_db())
+            for o in orders:
+                if o["status"] == "open" and o.get("escrow_uid"):
+                    return o
+            return None
+
+        order = poll_until(
+            _buyer_reopened,
+            timeout_s=30,
+            interval_s=_poll_interval(),
+            description="buyer order reopened after failure",
+        )
+        assert order is not None
+        assert order["status"] == "open"
+        assert order["maker_attestation"] is not None, (
+            "Buyer maker_attestation (escrow_uid) should be set"
+        )
+        assert order["taker_attestation"] is None, (
+            f"Buyer taker_attestation should be null after failure, got {order['taker_attestation']}"
+        )
+        self.__class__._state["buyer_order"] = order
+
+    def test_11_docker_logs_show_failure(self):
+        """Seller container logs should mention provisioning failure."""
+        result = subprocess.run(
+            ["docker", "logs", "market-agent-sell"],
+            capture_output=True, text=True, timeout=10,
+        )
+        combined = result.stdout + result.stderr
+        assert any(
+            phrase in combined
+            for phrase in ("Provisioning failed", "mock failure", "ProvisioningJobError")
+        ), "Expected provisioning failure message in seller logs"

--- a/service/src/service/clients/mock_provisioning.py
+++ b/service/src/service/clients/mock_provisioning.py
@@ -62,8 +62,9 @@ RESOURCES_RESULT: dict[str, Any] = {
     "running_vms": 0,
 }
 
-# Set to True to make provision_machine_async raise ProvisioningJobError
-SHOULD_FAIL: bool = False
+# Set to True to make provision_machine_async raise ProvisioningJobError.
+# Env var MOCK_PROVISIONING_SUCCESS=false activates failure mode for docker-compose testing.
+SHOULD_FAIL: bool = os.getenv("MOCK_PROVISIONING_SUCCESS", "true").lower() == "false"
 
 # How long (seconds) before a provisioned slot is auto-freed. Mirrors MOCK_RESOURCE_FREE_INTERVAL env var.
 MOCK_RESOURCE_FREE_INTERVAL: int = int(os.getenv("MOCK_RESOURCE_FREE_INTERVAL", "60"))
@@ -112,7 +113,7 @@ def _reset_defaults() -> None:
     }
     SHUTDOWN_RESULT = {"status": "ok", "vm_host": "ww1", "vm_target": "tenant-vm"}
     RESOURCES_RESULT = {"status": "ok", "vm_host": "ww1", "available": True, "running_vms": 0}
-    SHOULD_FAIL = False
+    SHOULD_FAIL = os.getenv("MOCK_PROVISIONING_SUCCESS", "true").lower() == "false"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Automated e2e tests for the full market order lifecycle using mock provisioning. Covers both the **happy path** (deal completes, orders close) and the **failure path** (provisioning fails, orders reopen).

Order creation and inspection use the CLI (`market order create`, `market order history`, `market order show`) via subprocess — CLI output is captured in the pytest log for full visibility.

Includes merges of:
- [PR #89 — fix/negotiation-thread](https://github.com/arkhai-io/simple-market-service/pull/89): A2A negotiation bug fixes
- [PR #92 — feature/cli-to-containers](https://github.com/arkhai-io/simple-market-service/pull/92): CLI container mode support
- Cherry-picked: attestation UID mapping fix, async provisioning failure notification, CLI DB path anchoring

## What's new

### Test infrastructure (`integration-tests/tests/`)

| File | Purpose |
|------|---------|
| `helpers/cli_client.py` | CLI subprocess wrapper — `market order create`, `history`, `show` |
| `helpers/agent_client.py` | HTTP client for registry GET queries |
| `helpers/polling.py` | `poll_until`, `poll_registry_orders`, `poll_sqlite_order_status` |
| `helpers/sqlite_reader.py` | Read-only queries against host-mounted agent SQLite DBs |
| `test_mock_provisioning.py` | 12 happy-path + 11 failure-path tests |

### Happy path (`TestHappyPath`, 12 tests)
1. Seller creates compute-supply order via CLI (RTX 5080)
2. Registry indexes seller order
3. Buyer creates matching compute-demand order via CLI → triggers negotiation
4. Poll registry until 2 orders reach `status=closed`
5. `market order history` — buyer agent
6. `market order history` — seller agent
7. `market order show <id> --negotiation --credentials --show-password` — buyer
8. `market order show <id> --negotiation --credentials --show-password` — seller
9. Verify buyer local DB: `maker_attestation=escrow_uid`, `taker_attestation=fulfillment_uid`
10. Verify seller local DB: `maker_attestation=fulfillment_uid`, `taker_attestation=escrow_uid`
11. Verify registry attestation fields populated on both orders
12. Cross-check: buyer's `maker_attestation` == seller's `taker_attestation` (and vice versa)

### Failure path (`TestFailurePath`, 11 tests)
1-3: Same CLI order creation
4. Poll SQLite until orders reopen (`status=open` with `escrow_uid` set)
5-6. `market order history` — buyer + seller
7-8. `market order show --negotiation --credentials --show-password` — buyer + seller
9. Seller: `maker_attestation=null`, `taker_attestation=escrow_uid`
10. Buyer: `maker_attestation=escrow_uid`, `taker_attestation=null`
11. Docker logs contain provisioning failure evidence

### Compose + Makefile

- `docker-compose.yml`: `PROVISIONING_MODE` and `MOCK_PROVISIONING_SUCCESS` env var passthrough on `sell_agent` (defaults: `http` / `true`)
- E2E Makefile targets live in `integration-tests/Makefile`: `e2e-mock-happy`, `e2e-mock-failure`

## Verification

```bash
cd integration-tests

# Happy path
make e2e-mock-happy

# Failure path
make e2e-mock-failure

# Manual run against already-running stack
ACTIVE_PROFILES=local,e2e-mock uv run pytest -m mock_provisioning_happy -v
```

## Attestation mapping reference

| Agent's Order | maker_attestation | taker_attestation |
|---------------|-------------------|-------------------|
| Buyer (maker) | escrow_uid        | fulfillment_uid   |
| Seller (maker)| fulfillment_uid   | escrow_uid        |

`oracle_address` = buyer's wallet address (stored on both orders).