### PR TITLE
Fix/zerotier network commands

### DIFF
--- a/cli/market/groups/network.py
+++ b/cli/market/groups/network.py
@@ -42,8 +42,8 @@ def network_join(
     """Join a ZeroTier network."""
     run_step(
         f"Join ZeroTier network {network_id}",
-        ["sudo", "zerotier-cli", "join", network_id],
-        REPO_ROOT,
+        ["make", "join", f"NETWORK_ID={network_id}"],
+        REPO_ROOT / "infra",
     )
 
 

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -2,6 +2,10 @@ install:
 	curl -s https://install.zerotier.com | sudo bash
 
 create-network:
+	@if [ ! -f ./zerotier/.env ]; then \
+		echo "No .env file found — creating .env..."; \
+		touch ./zerotier/.env; \
+	fi
 	@echo "Creating ZeroTier network..."
 	@bash zerotier/create_ztnetwork.sh
 
@@ -20,6 +24,28 @@ add-node:
 	fi; \
 	bash zerotier/authorize_zt_member.sh $$ZEROTIER_NETWORK $(NODE_ID)
 
+join:
+	@if [ ! -f ./zerotier/.env ]; then \
+		echo "No .env file found — creating .env..."; \
+		touch ./zerotier/.env; \
+	fi
+	@if [ -z "$(NETWORK_ID)" ]; then \
+		echo "Usage: make join NETWORK_ID=<network-id>"; \
+		echo ""; \
+		echo "Example: make join NETWORK_ID=5170efff3f3bf6ba"; \
+		exit 1; \
+	fi
+	@sudo zerotier-cli join $(NETWORK_ID); \
+	if grep -q "^ZEROTIER_NETWORK=" ./zerotier/.env; then \
+		if [ "$$(uname)" = "Darwin" ]; then \
+			sed -i '' "s/^ZEROTIER_NETWORK=.*/ZEROTIER_NETWORK=$(NETWORK_ID)/" ./zerotier/.env; \
+		else \
+			sed -i "s/^ZEROTIER_NETWORK=.*/ZEROTIER_NETWORK=$(NETWORK_ID)/" ./zerotier/.env; \
+		fi; \
+	else \
+		echo "ZEROTIER_NETWORK=$(NETWORK_ID)" >> ./zerotier/.env; \
+	fi
+
 authorize-approved:
 	@bash zerotier/authorize_approved_members.sh
 
@@ -27,5 +53,17 @@ authorize-approved-retry:
 	@bash zerotier/authorize_approved_members.sh --retry-errors
 
 get-peers:
+	@if [ ! -f ./zerotier/.env ]; then \
+		echo "Error: No network configured."; \
+		echo "Join a network first with: market network join <network-id>"; \
+		echo "Or create one with: market network create"; \
+		exit 1; \
+	fi
 	@. ./zerotier/.env; \
+	if [ -z "$$ZEROTIER_NETWORK" ]; then \
+		echo "Error: ZEROTIER_NETWORK not set."; \
+		echo "Join a network first with: market network join <network-id>"; \
+		echo "Or create one with: market network create"; \
+		exit 1; \
+	fi; \
 	./zerotier/get_peers.sh $$ZEROTIER_NETWORK

--- a/install.sh
+++ b/install.sh
@@ -23,6 +23,7 @@ LINUX_SYSTEM_DEPS=(
     "npm:npm"
     "docker:docker.io"
     "python3.12:python3.12"
+    "jq:jq"
 )
 LINUX_PYTHON_DEV_PKGS=("python3.12-dev" "software-properties-common")
 


### PR DESCRIPTION
# Changes
- Move `market network join` command logic into `infra/Makefile`
- When .env file is needed but not found, create empty .env file
- `market network join` and `market network create` now inserts the used network id into the .env file
- `market network get_peers` now prompts user to join or create network first when no network id is present
- Add `jq` to list of dependencies as it is needed by `get_peers.sh` 