### PR TITLE
fix: quickstart Mac compatibility and missing registry config

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,18 @@ In a new terminal:
 ```bash
 cd erc-8004-registry-py
 uv sync
+cp .env.sample .env
+```
+
+Edit `.env` with the contract addresses and RPC URL from step 3:
+
+- `RPC_URL=http://localhost:<port>/` (use the HTTP RPC URL printed by the deploy script)
+- `CHAIN_ID=31337`
+- `IDENTITY_REGISTRY_ADDRESS`, `REPUTATION_REGISTRY_ADDRESS`, `VALIDATION_REGISTRY_ADDRESS` (from the deploy output)
+
+Then start the server:
+
+```bash
 make serve
 ```
 

--- a/core/agent/.env.sample
+++ b/core/agent/.env.sample
@@ -29,7 +29,8 @@ CHAIN_NAME=anvil
 # For CHAIN_NAME=anvil, provide: path to the deployed contract addresses JSON
 # ALKAHEST_ADDRESS_CONFIG_PATH=../core/agent/app/data/alkahest_anvil_addresses.json
 # Token registry maps symbol → contract address for each supported payment token
-TOKEN_REGISTRY_PATH=../core/agent/app/data/token_registry_docker_compose.json
+# Relative to CWD when running from core/agent/
+TOKEN_REGISTRY_PATH=./app/data/token_registry_docker_compose.json
 
 # --- Networking ---
 # Ed25519 public key injected into provisioned VMs so the buyer can SSH in

--- a/core/agent/Makefile
+++ b/core/agent/Makefile
@@ -50,8 +50,8 @@ PYTHONPATH := ../..$(if $(PYTHONPATH),:$(PYTHONPATH))
 
 # Load .env variables into Make if the file exists
 ifneq (,$(wildcard $(ENV_FILE)))
-  include $(ENV_FILE)
-  export $(shell sed '/^\s*#/d;/^\s*$$/d;s/=.*//' $(ENV_FILE))
+  -include $(ENV_FILE)
+  export
 endif
 
 serve-a2a:

--- a/erc-8004-registry-py/Makefile
+++ b/erc-8004-registry-py/Makefile
@@ -32,8 +32,8 @@ smoke:
 ENV_FILE := $(if $(wildcard .env.local),.env.local,$(if $(wildcard .env),.env,))
 ENV_ARG := $(if $(ENV_FILE),--env-file $(ENV_FILE),)
 ifneq (,$(ENV_FILE))
-  include $(ENV_FILE)
-  export $(shell sed '/^\s*#/d;/^\s*$$/d;s/=.*//' $(ENV_FILE))
+  -include $(ENV_FILE)
+  export
 endif
 
 serve:


### PR DESCRIPTION
## Summary

Fixes three issues discovered while running the README quickstart on macOS:

### 1. Makefiles broken on GNU Make 3.81 (macOS default)
Both `core/agent/Makefile` and `erc-8004-registry-py/Makefile` used `export $(shell sed ...)` inside conditional blocks, which GNU Make 3.81 can't parse — causing `unterminated call to function 'shell'` whenever a `.env` file exists. Replaced with `-include` + bare `export`, which is portable across all Make versions.

### 2. Missing registry .env configuration in quickstart Step 4
Step 4 said to just `uv sync && make serve`, but the registry needs `RPC_URL`, `CHAIN_ID`, and all three contract addresses configured to connect to the local chain. Without this, it defaults to `localhost:8545` and fails. Added configuration instructions.

### 3. Wrong TOKEN_REGISTRY_PATH in .env.sample
The path was `../core/agent/app/data/token_registry_docker_compose.json` (a Docker Compose-era relative path). When running from `core/agent/`, this resolves incorrectly. Fixed to `./app/data/token_registry_docker_compose.json`.