### PR TITLE
Fix market CLI release installer publishing

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -18,9 +18,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          token: ${{ secrets.GH_PAT_SUBMODULES }}
 
       - name: Determine CLI version
         run: |

--- a/buyer/INSTALLER.md
+++ b/buyer/INSTALLER.md
@@ -17,7 +17,7 @@ Pin a specific version:
 
 ```bash
 curl -fsSL https://github.com/arkhai-io/simple-compute-market/releases/latest/download/install.sh | \
-  bash -s -- --version market-cli-v1.0.0
+  bash -s -- --version market-cli-v0.5.1
 ```
 
 ## Dev install (from a clone)
@@ -80,7 +80,7 @@ venv directly: `source buyer/.venv/bin/activate`.
 ## Versioning
 
 Releases are tagged `market-cli-v{major}.{minor}.{patch}` (e.g.
-`market-cli-v1.0.0`). The `latest` release pointer at GitHub always
+`market-cli-v0.5.1`). The `latest` release pointer at GitHub always
 resolves to the most recent published tag.
 
 Manual dispatch (no tag) produces a `dev-{short-sha}` build that is

--- a/scripts/install-remote.sh
+++ b/scripts/install-remote.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 #
 # Usage (specific version):
 #   curl -fsSL https://github.com/arkhai-io/simple-compute-market/releases/latest/download/install.sh | \
-#     bash -s -- --version market-cli-v1.0.0
+#     bash -s -- --version market-cli-v0.5.1
 #
 # Downloads the Market CLI tarball from the corresponding GitHub
 # Release, extracts it, and runs the bundled install.sh.
@@ -75,7 +75,7 @@ parse_args() {
         case "$1" in
             --version)
                 if [ -z "${2:-}" ]; then
-                    error "--version requires a value (e.g. --version market-cli-v1.0.0)"
+                    error "--version requires a value (e.g. --version market-cli-v0.5.1)"
                     exit 1
                 fi
                 CLI_VERSION="$2"

--- a/scripts/tests/test_install_remote_urls.py
+++ b/scripts/tests/test_install_remote_urls.py
@@ -1,0 +1,46 @@
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALLER = REPO_ROOT / "scripts" / "install-remote.sh"
+
+
+def _installer_text() -> str:
+    return INSTALLER.read_text(encoding="utf-8")
+
+
+def test_remote_installer_uses_github_release_assets():
+    text = _installer_text()
+
+    assert "downloadMarketCli" not in text
+    assert "cloudfunctions.net" not in text
+    assert (
+        'GITHUB_RELEASES_BASE="https://github.com/arkhai-io/simple-compute-market/releases"'
+        in text
+    )
+    assert 'TARBALL_NAME="market-cli.tar.gz"' in text
+    assert '${GITHUB_RELEASES_BASE}/latest/download' in text
+    assert '${GITHUB_RELEASES_BASE}/download/${version}' in text
+    assert '${TARBALL_NAME}.sha256' in text
+
+
+def test_remote_installer_latest_and_pinned_url_shape():
+    text = _installer_text()
+    base = re.search(r'^GITHUB_RELEASES_BASE="([^"]+)"$', text, re.MULTILINE)
+    tarball = re.search(r'^TARBALL_NAME="([^"]+)"$', text, re.MULTILINE)
+
+    assert base is not None
+    assert tarball is not None
+
+    releases_base = base.group(1)
+    tarball_name = tarball.group(1)
+
+    assert f"{releases_base}/latest/download/{tarball_name}" == (
+        "https://github.com/arkhai-io/simple-compute-market/releases/latest/download/"
+        "market-cli.tar.gz"
+    )
+    assert f"{releases_base}/download/market-cli-v0.5.1/{tarball_name}" == (
+        "https://github.com/arkhai-io/simple-compute-market/releases/download/"
+        "market-cli-v0.5.1/market-cli.tar.gz"
+    )


### PR DESCRIPTION
## Summary

- remove the stale submodule/PAT checkout from the Market CLI release workflow
- add a regression test that keeps the remote installer on GitHub Release asset URLs and off the retired Cloud Function path
- update pinned installer examples to the published `market-cli-v0.5.1` tag

## Validation

- `bash -n scripts/install-remote.sh`
- `python3 -m pytest scripts/tests/test_install_remote_urls.py`
- `git diff --check`
- published `market-cli-v0.5.1` from the narrow release branch
- verified latest no-clone install succeeds in isolated `HOME`/`MARKET_INSTALL_DIR`
- verified pinned `market-cli-v0.5.1` install succeeds in isolated `HOME`/`MARKET_INSTALL_DIR`

## Notes

The old `market-cli-v0.4.1` tarball is not mutated. The new latest release uses GitHub Release assets directly for `install.sh`, `market-cli.tar.gz`, and `market-cli.tar.gz.sha256`.

Fixes #108.