### PR TITLE
Fix storefront close-listing route

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2341,10 +2341,12 @@ This inverts the conceptual layer (provisioning is infrastructure; storefront is
 `arkhai-storefront-client` encodes two contracts with the agent server (`storefront/src/market_storefront/agent.py`) that are not enforced at import time — mismatches produce silent 403s or wrong response shapes at runtime:
 
 1. **Auth message format** — `_build_auth_headers` must match `_check_agent_request_auth` in `agent.py`:
-   - `create_order` → `"create_order:<agent_wallet_address>:<timestamp>"`
-   - `close_listing` → `"close_order:<listing_id>:<timestamp>"`
+   - `create_listing` → `"create_listing:<agent_wallet_address>:<timestamp>"`
+   - `close_listing` → `"close_listing:<listing_id>:<timestamp>"`
 
-2. **Endpoint signatures** — `/listings/create`, `/listings/close`, `/alerts/resource` request/response shapes.
+2. **Endpoint signatures** — `/api/v1/listings/create`,
+   `/api/v1/listings/{listing_id}/close`, and `/alerts/resource`
+   request/response shapes.
 
 When either contract changes: bump `version` in `storefront-client/pyproject.toml`, update the minimum version constraint in all consuming `pyproject.toml` files, rebuild the wheel with `make dist-storefront-client`, and run `make init` in each consumer. Keep all changes in one commit so the version boundary is auditable in git history. See `storefront-client/README.md` for the full checklist.
 

--- a/storefront-client/README.md
+++ b/storefront-client/README.md
@@ -42,7 +42,7 @@ Both clients cover:
 
 - `GET  /.well-known/erc-8004-registration.json`  → `get_registration`
 - `POST /listings/create`                            → `create_listing`
-- `POST /listings/close`                             → `close_listing`
+- `POST /api/v1/listings/{listing_id}/close`         → `close_listing`
 - `POST /listings/refund`                            → `refund_listing`
 - `POST /listings/claim`                             → `claim_listing`
 - `POST /listings/discover`                          → `discover_listings`
@@ -75,10 +75,11 @@ bump `storefront-client` version and update `_build_auth_headers` in
 
 ### 2. Endpoint signatures
 
-`/listings/{create,close,refund,claim,discover}`, `/alerts/resource`
-request and response shapes. If any field is added, removed, or
-renamed, bump the version and update the corresponding method in
-`client.py`.
+`/api/v1/listings/create`, `/api/v1/listings/{listing_id}/close`,
+`/api/v1/listings/{listing_id}/refund`, `/listings/{claim,discover}`,
+and `/alerts/resource` request and response shapes. If any field is
+added, removed, or renamed, bump the version and update the
+corresponding method in `client.py`.
 
 ### Version bump checklist
 

--- a/storefront-client/src/storefront_client/client.py
+++ b/storefront-client/src/storefront_client/client.py
@@ -623,10 +623,14 @@ class StorefrontClient(_StorefrontClientBase):
         )
 
     async def close_listing(self, listing_id: str) -> StorefrontListingCloseResponse:
-        """POST /listings/close"""
+        """POST /api/v1/listings/{listing_id}/close"""
         headers = self._auth_headers("close_listing", listing_id)
         return StorefrontListingCloseResponse.from_dict(
-            await self._post("/listings/close", {"listing_id": listing_id}, extra_headers=headers)
+            await self._post(
+                f"/api/v1/listings/{listing_id}/close",
+                {},
+                extra_headers=headers,
+            )
         )
 
     async def refund_listing(
@@ -1362,10 +1366,14 @@ class SyncStorefrontClient(_StorefrontClientBase):
         )
 
     def close_listing(self, listing_id: str) -> StorefrontListingCloseResponse:
-        """POST /listings/close"""
+        """POST /api/v1/listings/{listing_id}/close"""
         headers = self._auth_headers("close_listing", listing_id)
         return StorefrontListingCloseResponse.from_dict(
-            self._post("/listings/close", {"listing_id": listing_id}, extra_headers=headers)
+            self._post(
+                f"/api/v1/listings/{listing_id}/close",
+                {},
+                extra_headers=headers,
+            )
         )
 
     def refund_listing(
@@ -1629,4 +1637,3 @@ class SyncStorefrontClient(_StorefrontClientBase):
             f"/api/v1/admin/settle/{escrow_uid}/evaluate", body,
             extra_headers=self._admin_headers(),
         )
-

--- a/storefront-client/src/storefront_client/models.py
+++ b/storefront-client/src/storefront_client/models.py
@@ -47,17 +47,18 @@ class StorefrontListingCreateResponse:
 
 
 # ---------------------------------------------------------------------------
-# Listing close response  (POST /listings/close)
+# Listing close response  (POST /api/v1/listings/{listing_id}/close)
 # ---------------------------------------------------------------------------
 
 
 @dataclass
 class StorefrontListingCloseResponse:
-    """Response from POST /listings/close.
+    """Response from POST /api/v1/listings/{listing_id}/close.
 
     status values: ``"closed"``
     """
 
+    status: str | None = None
     listing_id: str | None = None
     root_agent_response: str | None = None
     extra: dict[str, Any] = field(default_factory=dict)

--- a/storefront-client/tests/test_close_listing_routes.py
+++ b/storefront-client/tests/test_close_listing_routes.py
@@ -1,0 +1,63 @@
+import asyncio
+import json
+
+import httpx
+
+from storefront_client.client import StorefrontClient, SyncStorefrontClient
+
+
+class _CapturingAsyncTransport(httpx.AsyncBaseTransport):
+    def __init__(self) -> None:
+        self.requests: list[httpx.Request] = []
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        return httpx.Response(
+            200,
+            json={"status": "closed", "listing_id": "listing-abc"},
+            request=request,
+        )
+
+
+class _CapturingSyncTransport(httpx.BaseTransport):
+    def __init__(self) -> None:
+        self.requests: list[httpx.Request] = []
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        return httpx.Response(
+            200,
+            json={"status": "closed", "listing_id": "listing-abc"},
+            request=request,
+        )
+
+
+def test_async_close_listing_posts_to_versioned_path_param_route():
+    async def _run() -> None:
+        transport = _CapturingAsyncTransport()
+        async with StorefrontClient("http://test", transport=transport) as client:
+            resp = await client.close_listing("listing-abc")
+
+        assert resp.status == "closed"
+        assert resp.listing_id == "listing-abc"
+        assert len(transport.requests) == 1
+        request = transport.requests[0]
+        assert request.method == "POST"
+        assert str(request.url) == "http://test/api/v1/listings/listing-abc/close"
+        assert json.loads(request.content) == {}
+
+    asyncio.run(_run())
+
+
+def test_sync_close_listing_posts_to_versioned_path_param_route():
+    transport = _CapturingSyncTransport()
+    with SyncStorefrontClient("http://test", transport=transport) as client:
+        resp = client.close_listing("listing-abc")
+
+    assert resp.status == "closed"
+    assert resp.listing_id == "listing-abc"
+    assert len(transport.requests) == 1
+    request = transport.requests[0]
+    assert request.method == "POST"
+    assert str(request.url) == "http://test/api/v1/listings/listing-abc/close"
+    assert json.loads(request.content) == {}

--- a/storefront/src/market_storefront/cli_publish.py
+++ b/storefront/src/market_storefront/cli_publish.py
@@ -201,7 +201,7 @@ def _close_order(
     order_id: str,
     private_key: Optional[str],
 ) -> dict:
-    """POST /listings/close on the storefront; returns the response as a dict."""
+    """POST /api/v1/listings/{listing_id}/close; return the response as a dict."""
     with SyncStorefrontClient(agent_url, private_key=private_key) as client:
         try:
             resp = client.close_listing(order_id)


### PR DESCRIPTION
## Summary

Fixes #107 by aligning the shared storefront client with the current versioned close-listing route.

- Send `close_listing()` requests to `POST /api/v1/listings/{listing_id}/close` instead of the stale unversioned `/listings/close` endpoint.
- Keep the existing close-listing auth message format while sending an empty request body, matching the server route.
- Parse close-listing responses with the returned `status` field so successful closes do not fail after HTTP 200.
- Update related client docs and architecture notes.

## Boundary

This is the narrow #107 extraction from the old issue-discovery branch. It does not include the broader issue-discovery tooling or orchestration work from the closed umbrella PR #110.

## Validation

- `cd storefront-client && .venv/bin/python -m pytest tests/test_auth_headers.py tests/test_close_listing_routes.py -q`
- `cd storefront && .venv/bin/python -m pytest tests/integration/test_storefront_client.py::TestCloseOrderEndpoint::test_valid_close_returns_200 tests/unit/test_identity_dispatch.py tests/unit/test_cli_publish_helpers.py::test_open_order_ids_returns_only_open -q`
- `git diff --check`

Fixes #107.