### PR TITLE
Fix buyer BuyConfig construction

### DIFF
--- a/buyer/market_buyer/groups/buy.py
+++ b/buyer/market_buyer/groups/buy.py
@@ -605,13 +605,6 @@ def register(app: typer.Typer) -> None:
             toml_path="aggregation.policy",
         ) or None
 
-        # Counter policy is config-only — no CLI flag yet. Strict_echo
-        # default rejects any seller modification to a buyer-pinned field;
-        # operators who want to accept counters set the TOML key.
-        counter_policy = resolve_config_value(
-            toml_path="counter_policy.policy",
-        ) or None
-
         config = BuyConfig(
             registry_urls=reg_urls,
             buyer_address=addr,
@@ -619,7 +612,6 @@ def register(app: typer.Typer) -> None:
             discovery_timeout=deadline,
             indexer_auth=reg_auth,
             aggregation_policy=aggregation_policy,
-            counter_policy=counter_policy,
         )
         constraints = BuyConstraints(
             max_price=max_price,

--- a/buyer/tests/test_buy_resume_cli.py
+++ b/buyer/tests/test_buy_resume_cli.py
@@ -27,7 +27,9 @@ import pytest
 from typer.testing import CliRunner
 
 from market_buyer.cli import app
+from market_buyer.buy_orchestrator import BuyResult
 from market_buyer.run_log import RunLog, read_run
+from service.config_loader import ChainConfig
 
 
 # Test wallet — derived address must match _BUYER_ADDR below for
@@ -348,6 +350,69 @@ class TestBuyFrom:
         ])
         assert result.exit_code == 2
         assert "initial-price" in result.output.lower() or "max-price" in result.output.lower()
+
+    def test_buy_fresh_constructs_buy_config(self, runner, monkeypatch):
+        """Fresh buy reaches run_buy with a valid BuyConfig."""
+        listing = {
+            "listing_id": "L-1",
+            "storefront_url": "http://seller:8001",
+            "accepted_escrows": [
+                {
+                    "chain_name": "anvil",
+                    "escrow_address": "0x" + "aa" * 20,
+                    "literal_fields": {"token": "0x" + "bb" * 20},
+                    "rates": [{"field": "amount", "per": "hour", "value": "100"}],
+                }
+            ],
+        }
+        captured = {}
+
+        monkeypatch.setattr(
+            "market_buyer.common.select_chain_for_listing",
+            lambda listing, override, yes: ChainConfig(
+                name="anvil",
+                rpc_url="http://rpc",
+                chain_id=31337,
+                alkahest_address_config_path="/tmp/alkahest.json",
+            ),
+        )
+        monkeypatch.setattr(
+            "market_buyer.groups.buy.query_registry_for_matches_multi",
+            lambda *a, **kw: [listing],
+        )
+        monkeypatch.setattr(
+            "market_buyer.groups.buy._resolve_prices_from_matches",
+            lambda **kw: (100, 150),
+        )
+        monkeypatch.setattr(
+            "market_buyer.escrow_client.make_buyer_payment_escrow_terms_fn",
+            lambda **kw: lambda *a, **inner_kw: [],
+        )
+        monkeypatch.setattr(
+            "market_buyer.escrow_client.make_create_escrow_fn",
+            lambda **kw: lambda escrows: [],
+        )
+
+        def fake_run_buy(**kwargs):
+            captured["config"] = kwargs["config"]
+            return BuyResult(status="ready", negotiation_id="neg-1", rounds=1)
+
+        monkeypatch.setattr("market_buyer.groups.buy.run_buy", fake_run_buy)
+
+        result = runner.invoke(app, [
+            "buy",
+            "--duration-hours", "1",
+            "--buyer-address", _BUYER_ADDR,
+            "--buyer-priv-key", _BUYER_PK,
+            "--ssh-public-key", "ssh-ed25519 AAAA buyer@test",
+            "--registry-urls", "http://reg",
+            "--chain", "anvil",
+            "--yes",
+        ])
+
+        assert result.exit_code == 0, result.output
+        assert captured["config"].registry_urls == ["http://reg"]
+        assert captured["config"].buyer_address == _BUYER_ADDR
 
     def test_buy_from_mid_stream_without_max_price_errors(
         self, runner, monkeypatch,


### PR DESCRIPTION
## Summary

- Remove the unsupported `counter_policy` keyword from fresh `market buy` `BuyConfig` construction.
- Add a fresh-buy CLI regression test that reaches `run_buy` with a valid `BuyConfig`.

## Validation

- `uv run --extra test --find-links ../.dist pytest tests/test_buy_resume_cli.py::TestBuyFrom::test_buy_fresh_constructs_buy_config tests/test_buy_resume_cli.py::TestBuyFrom::test_buy_fresh_rejects_only_one_price tests/test_buy_pricing_and_filters.py -q`
- `git diff --check`

Fixes #115