### PR TITLE
Fix buyer chain selection during buy

### DIFF
--- a/buyer/market_buyer/groups/buy.py
+++ b/buyer/market_buyer/groups/buy.py
@@ -467,7 +467,7 @@ def register(app: typer.Typer) -> None:
         chain_cfg = select_chain_for_listing(
             listing=None, override=chain_name, yes=assume_yes,
         )
-        chain = chain_cfg.name
+        selected_chain_name = chain_cfg.name
         rpc = chain_cfg.rpc_url
         addr_cfg = chain_cfg.alkahest_address_config_path
 
@@ -539,13 +539,13 @@ def register(app: typer.Typer) -> None:
         # Token + expiration come from the proposal (echoed by the seller).
         # The closure only needs chain config to resolve on-chain addresses.
         build_escrow_terms = make_buyer_payment_escrow_terms_fn(
-            chain_name=chain,
+            chain_name=selected_chain_name,
             addr_config_path=addr_cfg or None,
         )
         create_escrow = make_create_escrow_fn(
             private_key=pk,
             rpc_url=rpc,
-            chain_name=chain,
+            chain_name=selected_chain_name,
             addr_config_path=addr_cfg or None,
         )
 
@@ -634,7 +634,7 @@ def register(app: typer.Typer) -> None:
         def build_escrow_proposal_for_match(match: dict) -> EscrowProposal | None:
             entry = select_escrow_entry(
                 match,
-                chain_name=chain,
+                chain_name=selected_chain_name,
                 token_contract_filter=tc,
                 assume_yes=assume_yes,
                 rpc_url=rpc,
@@ -646,7 +646,7 @@ def register(app: typer.Typer) -> None:
             from service.schemas import accepted_token_address
             token = accepted_token_address(entry)
             return EscrowProposal(
-                chain_name=entry.get("chain_name", chain),
+                chain_name=entry.get("chain_name", selected_chain_name),
                 escrow_address=entry["escrow_address"],
                 fields={"token": token},
                 literal_fields={"token": token},
@@ -727,12 +727,15 @@ def register(app: typer.Typer) -> None:
         # legacy single-terminal key that synthesizes the default chain.
         # Without either, the buyer falls through to the default terminal
         # (RL needs torch — not installed in the lean buyer wheel).
-        chain = None
+        negotiation_chain = None
         policies = resolve_config_value(toml_path="negotiation.policies")
         policy_mode = resolve_config_value(toml_path="negotiation.policy_mode")
         if policies or policy_mode:
             from market_buyer.buyer_client import _load_buyer_chain
-            chain = _load_buyer_chain(policies=policies, policy_mode=policy_mode)
+            negotiation_chain = _load_buyer_chain(
+                policies=policies,
+                policy_mode=policy_mode,
+            )
 
         try:
             result = run_buy(
@@ -749,7 +752,7 @@ def register(app: typer.Typer) -> None:
                 settlement_total_timeout=settlement_timeout,
                 on_event=_observe,
                 confirm_settlement=confirm_settlement_cb,
-                chain=chain,
+                chain=negotiation_chain,
             )
         except RuntimeError as exc:
             run_log.end("error", error=str(exc))

--- a/buyer/tests/test_buy_resume_cli.py
+++ b/buyer/tests/test_buy_resume_cli.py
@@ -395,6 +395,7 @@ class TestBuyFrom:
 
         def fake_run_buy(**kwargs):
             captured["config"] = kwargs["config"]
+            captured["proposal"] = kwargs["build_escrow_proposal"](listing)
             return BuyResult(status="ready", negotiation_id="neg-1", rounds=1)
 
         monkeypatch.setattr("market_buyer.groups.buy.run_buy", fake_run_buy)
@@ -413,6 +414,7 @@ class TestBuyFrom:
         assert result.exit_code == 0, result.output
         assert captured["config"].registry_urls == ["http://reg"]
         assert captured["config"].buyer_address == _BUYER_ADDR
+        assert captured["proposal"].chain_name == "anvil"
 
     def test_buy_from_mid_stream_without_max_price_errors(
         self, runner, monkeypatch,


### PR DESCRIPTION
## Summary

- Keep the selected blockchain chain name separate from the negotiation middleware chain object in fresh `market buy`.
- Extend the fresh-buy CLI regression test to verify the matched listing builds an `anvil` escrow proposal.

## Validation

- `uv run --extra test --find-links ../.dist pytest tests/test_buy_resume_cli.py::TestBuyFrom::test_buy_fresh_constructs_buy_config tests/test_buy_resume_cli.py::TestBuyFrom::test_buy_fresh_rejects_only_one_price tests/test_buy_pricing_and_filters.py -q`
- `git diff --check`

Fixes #118