### PR TITLE
[codex] Merge issue-discovery fixes into dev

### DIFF
--- a/compute-provisioning-iac/README.md
+++ b/compute-provisioning-iac/README.md
@@ -46,6 +46,10 @@ cd compute-provisioning-iac/ansible
 ansible-galaxy collection install -r requirements.yml
 ```
 
+Collection versions are pinned because the documented Ansible baseline includes
+older control-node runtimes. Updating the pins should be paired with a matching
+Ansible baseline update and validation of the playbook syntax checks below.
+
 ### 3. Setup Inventory
 Configure your hosts in `inventory/hosts`:
 

--- a/compute-provisioning-iac/ansible/requirements.yml
+++ b/compute-provisioning-iac/ansible/requirements.yml
@@ -1,4 +1,7 @@
 collections:
   - name: community.general
+    version: "4.8.7"
   - name: community.docker
+    version: "2.7.2"
   - name: community.crypto
+    version: "2.5.0"

--- a/docs/buyer-quickstart.md
+++ b/docs/buyer-quickstart.md
@@ -31,9 +31,18 @@ Released build (latest):
 curl -fsSL https://github.com/arkhai-io/simple-compute-market/releases/latest/download/install.sh | bash
 ```
 
-Installs `market` into `~/.local/bin` (needs Python 3.12+ and `curl`/`wget`;
-on macOS, `brew install python@3.12`). Pin a version with
+Installs `market` into `~/.local/bin`. The installer uses `uv` to provision
+the Python version required by the buyer CLI; a literal `python3.12` system
+command is not required. Pin a version with
 `... | bash -s -- --version market-cli-v0.5.3`.
+
+In noninteractive Linux environments, allow apt dependency installation
+explicitly:
+
+```bash
+curl -fsSL https://github.com/arkhai-io/simple-compute-market/releases/latest/download/install.sh \
+  | MARKET_INSTALL_ASSUME_YES=1 bash
+```
 
 Or from the repo:
 

--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 INSTALL_DIR="${MARKET_INSTALL_DIR:-$HOME/.market}"
 BIN_DIR="$HOME/.local/bin"
 UV_VERSION="0.8.13"
+ASSUME_YES=false
 
 # ── System dependency mapping ─────────────────────────────────
 # Format: "command:apt-package"
@@ -15,10 +16,8 @@ LINUX_SYSTEM_DEPS=(
     "gcc:build-essential"
     "g++:build-essential"
     "make:build-essential"
-    "python3.12:python3.12"
     "jq:jq"
 )
-LINUX_PYTHON_DEV_PKGS=("python3.12-dev" "software-properties-common")
 
 # ── Color helpers ──────────────────────────────────────────────
 info()  { printf '\033[1;34m[info]\033[0m %s\n' "$*"; }
@@ -32,6 +31,27 @@ ok()    { printf '\033[1;32m[ok]\033[0m %s\n' "$*"; }
 # provisions a managed CPython matching the buyer's requires-python
 # (>=3.12), downloading it if absent. Gating on the system `python3`
 # wrongly rejected macOS, which ships only python3 (3.9).
+
+parse_args() {
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --yes|-y)
+                ASSUME_YES=true
+                shift
+                ;;
+            *)
+                shift
+                ;;
+        esac
+    done
+}
+
+assume_yes_enabled() {
+    case "${MARKET_INSTALL_ASSUME_YES:-}" in
+        1|true|TRUE|yes|YES|y|Y) return 0 ;;
+    esac
+    [ "$ASSUME_YES" = true ]
+}
 
 detect_platform() {
     local os arch
@@ -63,7 +83,6 @@ check_and_install_dependencies() {
     local display_items=()        # human-readable list for the prompt
     local missing_apt_cmds=()     # commands to verify after apt install
     local missing_apt_pkgs=()     # deduplicated apt packages
-    local need_python312=false
     local has_apt=false
 
     # -- System packages (Linux only) --
@@ -89,31 +108,14 @@ check_and_install_dependencies() {
                         missing_apt_pkgs+=("$pkg")
                         display_items+=("$pkg (apt)")
                     fi
-                    [ "$cmd" = "python3.12" ] && need_python312=true
                 fi
             done
-
-            if [ "$need_python312" = true ]; then
-                for extra in "${LINUX_PYTHON_DEV_PKGS[@]}"; do
-                    local already=false
-                    for p in "${missing_apt_pkgs[@]+"${missing_apt_pkgs[@]}"}"; do
-                        [ "$p" = "$extra" ] && already=true && break
-                    done
-                    if [ "$already" = false ]; then
-                        missing_apt_pkgs+=("$extra")
-                        display_items+=("$extra (apt)")
-                    fi
-                done
-            fi
         fi
 
     elif [ "$OS" = "macos" ]; then
         local mac_missing=()
         for entry in "${LINUX_SYSTEM_DEPS[@]}"; do
             local cmd="${entry%%:*}"
-            # uv provisions a managed Python 3.12 during `uv sync`, so a
-            # system python3.12 is not required (macOS ships only python3).
-            [ "$cmd" = "python3.12" ] && continue
             if ! command -v "$cmd" &>/dev/null; then
                 mac_missing+=("$cmd")
             fi
@@ -160,29 +162,27 @@ check_and_install_dependencies() {
     done
     echo ""
 
-    printf '\033[1;34m[?]\033[0m Would you like to install them? [Y/n] '
-    read -r answer </dev/tty
-    case "$answer" in
-        [nN]|[nN][oO])
-            error "Cannot proceed without required dependencies."
-            exit 1
-            ;;
-    esac
+    if assume_yes_enabled; then
+        info "Installing missing dependencies because --yes/-y or MARKET_INSTALL_ASSUME_YES is set."
+    elif [ -e /dev/tty ] && [ -r /dev/tty ]; then
+        printf '\033[1;34m[?]\033[0m Would you like to install them? [Y/n] '
+        read -r answer </dev/tty
+        case "$answer" in
+            [nN]|[nN][oO])
+                error "Cannot proceed without required dependencies."
+                exit 1
+                ;;
+        esac
+    else
+        error "Cannot prompt for dependency installation because no TTY is available."
+        error "Install the missing packages above, or rerun with MARKET_INSTALL_ASSUME_YES=1 to allow apt installation."
+        exit 1
+    fi
     echo ""
 
     if [ ${#missing_apt_pkgs[@]} -gt 0 ]; then
         info "Updating package lists..."
         sudo apt-get update -y
-
-        if [ "$need_python312" = true ]; then
-            if ! command -v add-apt-repository &>/dev/null; then
-                info "Installing software-properties-common for PPA support..."
-                sudo apt-get install -y software-properties-common
-            fi
-            info "Adding deadsnakes PPA for Python 3.12..."
-            sudo add-apt-repository -y ppa:deadsnakes/ppa
-            sudo apt-get update -y
-        fi
 
         info "Installing packages: ${missing_apt_pkgs[*]}"
         sudo apt-get install -y "${missing_apt_pkgs[@]}"
@@ -355,6 +355,7 @@ main() {
     echo "  └──────────────────────────────────┘"
     echo ""
 
+    parse_args "$@"
     detect_platform
     check_and_install_dependencies
     install_uv

--- a/provisioning-service/src/db/database.py
+++ b/provisioning-service/src/db/database.py
@@ -1,4 +1,4 @@
-from sqlalchemy import create_engine, Engine
+from sqlalchemy import create_engine, Engine, inspect, text
 from sqlalchemy.orm import sessionmaker, Session
 from sqlalchemy.pool import StaticPool
 
@@ -22,3 +22,18 @@ def create_session_factory(engine: Engine) -> sessionmaker[Session]:
 def init_db(engine: Engine) -> None:
     """Create all tables. Called once during application startup."""
     Base.metadata.create_all(bind=engine)
+    if engine.dialect.name == "sqlite":
+        _migrate_sqlite_schema(engine)
+
+
+def _migrate_sqlite_schema(engine: Engine) -> None:
+    """Apply small additive SQLite migrations for persisted local DBs."""
+    inspector = inspect(engine)
+    table_names = set(inspector.get_table_names())
+    if "hosts" not in table_names:
+        return
+
+    host_columns = {column["name"] for column in inspector.get_columns("hosts")}
+    if "public_host" not in host_columns:
+        with engine.begin() as connection:
+            connection.execute(text("ALTER TABLE hosts ADD COLUMN public_host VARCHAR"))

--- a/provisioning-service/src/tests/unit/test_database.py
+++ b/provisioning-service/src/tests/unit/test_database.py
@@ -1,0 +1,85 @@
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from db.database import init_db
+from db.models import Host
+
+
+def _sqlite_memory_engine():
+    return create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+
+def _create_hosts_table_without_public_host(engine):
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                CREATE TABLE hosts (
+                    name VARCHAR NOT NULL,
+                    kvm_host VARCHAR NOT NULL,
+                    ssh_user VARCHAR NOT NULL,
+                    ssh_key_type VARCHAR NOT NULL,
+                    ssh_key_value VARCHAR NOT NULL,
+                    gpu_count INTEGER NOT NULL,
+                    enabled BOOLEAN NOT NULL,
+                    created_at DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                    PRIMARY KEY (name)
+                )
+                """
+            )
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO hosts (
+                    name,
+                    kvm_host,
+                    ssh_user,
+                    ssh_key_type,
+                    ssh_key_value,
+                    gpu_count,
+                    enabled
+                ) VALUES (
+                    'kvm1',
+                    '10.0.0.1',
+                    'root',
+                    'path',
+                    '/keys/id_ed25519',
+                    0,
+                    1
+                )
+                """
+            )
+        )
+
+
+def test_init_db_adds_public_host_to_existing_sqlite_hosts_table():
+    engine = _sqlite_memory_engine()
+    _create_hosts_table_without_public_host(engine)
+
+    init_db(engine)
+
+    columns = {column["name"] for column in inspect(engine).get_columns("hosts")}
+    assert "public_host" in columns
+
+    with Session(engine) as session:
+        host = session.query(Host).one()
+        assert host.name == "kvm1"
+        assert host.public_host is None
+
+
+def test_init_db_sqlite_public_host_migration_is_idempotent():
+    engine = _sqlite_memory_engine()
+    _create_hosts_table_without_public_host(engine)
+
+    init_db(engine)
+    init_db(engine)
+
+    columns = [column["name"] for column in inspect(engine).get_columns("hosts")]
+    assert columns.count("public_host") == 1

--- a/scripts/tests/test_install_sh_dependencies.py
+++ b/scripts/tests/test_install_sh_dependencies.py
@@ -1,0 +1,33 @@
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALLER = REPO_ROOT / "install.sh"
+
+
+def _installer_text() -> str:
+    return INSTALLER.read_text(encoding="utf-8")
+
+
+def test_installer_does_not_require_literal_python312_command():
+    text = _installer_text()
+
+    assert '"python3.12:python3.12"' not in text
+    assert "python3.12-dev" not in text
+    assert "deadsnakes" not in text
+    assert "add-apt-repository" not in text
+
+
+def test_installer_has_explicit_noninteractive_dependency_path():
+    text = _installer_text()
+
+    assert "MARKET_INSTALL_ASSUME_YES" in text
+    assert "--yes|-y" in text
+    assert "Cannot prompt for dependency installation because no TTY is available" in text
+    assert "read -r answer </dev/tty" in text
+    assert "elif [ -e /dev/tty ] && [ -r /dev/tty ]" in text
+
+
+def test_installer_shell_syntax_is_valid():
+    subprocess.run(["bash", "-n", str(INSTALLER)], check=True)

--- a/storefront/src/market_storefront/utils/action_executor.py
+++ b/storefront/src/market_storefront/utils/action_executor.py
@@ -124,6 +124,78 @@ def _coerce_agent_reference_to_url(agent_ref: str | None) -> str | None:
 
 
 
+async def sync_listing_status_to_registry(
+    listing_id: str,
+    status: str,
+) -> dict[str, Any]:
+    """Propagate a local listing lifecycle status to configured registries.
+
+    The storefront SQLite row is the seller-side source of truth for
+    negotiation. Registries are discovery indexes, so lifecycle transitions
+    that change buyer visibility must be mirrored there with the existing
+    owner-signed update endpoint.
+    """
+    if not isinstance(listing_id, str) or not listing_id.strip():
+        return {
+            "status": "error",
+            "message": "Missing listing_id for registry status sync",
+        }
+    if not isinstance(status, str) or not status.strip():
+        return {
+            "status": "error",
+            "message": "Missing status for registry status sync",
+            "listing_id": listing_id,
+        }
+    if not settings.enable_registry_discovery:
+        return {
+            "status": "skipped",
+            "message": "Registry discovery is disabled; listing not updated in registry",
+            "listing_id": listing_id,
+            "listing_status": status,
+        }
+
+    try:
+        async with _make_registry_client() as registry_client:
+            target_urls = await _registries_to_target(listing_id, registry_client.urls)
+            update_request = UpdateListingRequest(
+                updates={"status": status},
+                private_key=settings.wallet.private_key,
+            )
+            payloads = {url: update_request for url in target_urls}
+            results = await registry_client.update_listing_per_registry(
+                listing_id, payloads,
+            )
+        await _record_publications(listing_id, results)
+        first_ok = next(
+            (r["response"] for r in results if r["success"] and r["response"]),
+            None,
+        )
+        if first_ok:
+            return {
+                "status": status,
+                "message": f"Listing {listing_id} marked {status} in registry",
+                "listing_id": listing_id,
+                "registry_result": first_ok,
+            }
+        return {
+            "status": "error",
+            "message": f"Failed to update listing {listing_id} in registry",
+            "listing_id": listing_id,
+            "listing_status": status,
+        }
+    except Exception as exc:
+        logger.warning(
+            "[REGISTRY] Failed to sync listing %s status %s: %s",
+            listing_id, status, exc,
+        )
+        return {
+            "status": "error",
+            "message": f"Registry update failed for listing {listing_id}: {exc}",
+            "listing_id": listing_id,
+            "listing_status": status,
+        }
+
+
 async def close_order(parameters: dict[str, Any] | None = None) -> dict[str, Any]:
     """Close an order locally and in the registry (if enabled)."""
     parameters = parameters or {}
@@ -140,48 +212,10 @@ async def close_order(parameters: dict[str, Any] | None = None) -> dict[str, Any
     except Exception as exc:
         logger.warning("[LOCAL DB] Failed to update order %s as closed: %s", order_id, exc)
 
-    if not settings.enable_registry_discovery:
-        return {
-            "status": "skipped",
-            "message": "Registry discovery is disabled; order not updated in registry",
-            "listing_id": order_id,
-        }
-
-    try:
-        async with _make_registry_client() as registry_client:
-            target_urls = await _registries_to_target(order_id, registry_client.urls)
-            update_request = UpdateListingRequest(
-                updates={"status": "closed"},
-                private_key=settings.wallet.private_key,
-            )
-            payloads = {url: update_request for url in target_urls}
-            results = await registry_client.update_listing_per_registry(
-                order_id, payloads,
-            )
-        await _record_publications(order_id, results)
-        first_ok = next(
-            (r["response"] for r in results if r["success"] and r["response"]),
-            None,
-        )
-        if first_ok:
-            return {
-                "status": "closed",
-                "message": f"Order {order_id} marked closed in registry",
-                "listing_id": order_id,
-                "registry_result": first_ok,
-            }
-        return {
-            "status": "error",
-            "message": f"Failed to update order {order_id} in registry",
-            "listing_id": order_id,
-        }
-    except Exception as exc:
-        logger.warning("[REGISTRY] Failed to close order %s in registry: %s", order_id, exc)
-        return {
-            "status": "error",
-            "message": f"Registry update failed for order {order_id}: {exc}",
-            "listing_id": order_id,
-        }
+    result = await sync_listing_status_to_registry(order_id, "closed")
+    if result.get("status") == "closed":
+        result["message"] = f"Order {order_id} marked closed in registry"
+    return result
 
 
 async def _do_provision(

--- a/storefront/src/market_storefront/utils/settlement_jobs.py
+++ b/storefront/src/market_storefront/utils/settlement_jobs.py
@@ -209,6 +209,10 @@ async def start_settlement_job(
             "[SETTLE_JOB] Could not mark order %s as accepted: %s",
             our_listing_id, exc,
         )
+    else:
+        await _sync_listing_status_to_registry_best_effort(
+            our_listing_id, "accepted", action="mark accepted",
+        )
 
     asyncio.create_task(
         _run_settlement_job_bg(
@@ -239,6 +243,9 @@ async def _reopen_listing_after_failure(sqlite_client: Any, listing_id: str) -> 
     """
     try:
         await sqlite_client.update_listing(listing_id=listing_id, status="open")
+        await _sync_listing_status_to_registry_best_effort(
+            listing_id, "open", action="reopen after failure",
+        )
         logger.info(
             "[SETTLE_JOB] Reopened listing %s after provisioning failure", listing_id
         )
@@ -246,6 +253,29 @@ async def _reopen_listing_after_failure(sqlite_client: Any, listing_id: str) -> 
         logger.warning(
             "[SETTLE_JOB] Could not reopen listing %s after failure: %s",
             listing_id, exc,
+        )
+
+
+async def _sync_listing_status_to_registry_best_effort(
+    listing_id: str,
+    status: str,
+    *,
+    action: str,
+) -> None:
+    """Mirror local lifecycle status to registry without blocking settlement."""
+    try:
+        from market_storefront.utils.action_executor import sync_listing_status_to_registry
+        sync_result = await sync_listing_status_to_registry(listing_id, status)
+    except Exception as exc:
+        logger.warning(
+            "[SETTLE_JOB] Could not %s registry listing %s: %s",
+            action, listing_id, exc,
+        )
+        return
+    if sync_result.get("status") == "error":
+        logger.warning(
+            "[SETTLE_JOB] Could not %s registry listing %s: %s",
+            action, listing_id, sync_result.get("message"),
         )
 
 

--- a/storefront/tests/unit/test_publications_wiring.py
+++ b/storefront/tests/unit/test_publications_wiring.py
@@ -191,3 +191,50 @@ class TestRegistriesToTarget:
             "L1", ["http://r1", "http://r2"],
         )
         assert urls == ["http://r1"]
+
+
+class TestSyncListingStatusToRegistry:
+    """Lifecycle transitions should keep registry discovery state current."""
+
+    @pytest.mark.asyncio
+    async def test_updates_active_publication_registries(self, patched_sqlite):
+        await patched_sqlite.upsert_publication(
+            listing_id="Laccepted", registry_url="http://r1",
+            payload={"listing_id": "Laccepted"}, status="published",
+        )
+        await patched_sqlite.upsert_publication(
+            listing_id="Laccepted", registry_url="http://r2",
+            payload={"listing_id": "Laccepted"}, status="unpublished",
+        )
+        results = [
+            PublishResult(
+                registry_url="http://r1", success=True,
+                response={"listing_id": "Laccepted", "status": "accepted"},
+                error=None, payload={"status": "accepted"},
+                registry_assigned_id="Laccepted",
+            ),
+        ]
+        cm, client = _mock_multi_registry(["http://r1", "http://r2"], results)
+
+        with (
+            patch("market_storefront.utils.action_executor._make_registry_client",
+                  return_value=cm),
+            settings_overrides(enable_registry_discovery=True,
+                               **{"wallet.private_key": "0xkey"}),
+        ):
+            out = await action_executor.sync_listing_status_to_registry(
+                "Laccepted", "accepted",
+            )
+
+        assert out["status"] == "accepted"
+        client.update_listing_per_registry.assert_awaited_once()
+        listing_id, payloads = client.update_listing_per_registry.await_args.args
+        assert listing_id == "Laccepted"
+        assert list(payloads) == ["http://r1"]
+        assert payloads["http://r1"].updates == {"status": "accepted"}
+
+        row = await patched_sqlite.load_publication(
+            listing_id="Laccepted", registry_url="http://r1",
+        )
+        assert row["status"] == "published"
+        assert row["payload"] == {"status": "accepted"}

--- a/storefront/tests/unit/test_settlement_jobs.py
+++ b/storefront/tests/unit/test_settlement_jobs.py
@@ -292,6 +292,36 @@ async def test_start_happy_path_inserts_row_and_kicks_off_task(client):
 
 
 @pytest.mark.asyncio
+async def test_start_marks_listing_accepted_in_registry(client):
+    await _seed_seller_order(client)
+    await _seed_negotiation(client)
+    sync_mock = AsyncMock(return_value={"status": "accepted"})
+
+    with patch(
+        "market_storefront.utils.settlement_jobs._run_settlement_job_bg",
+        new=AsyncMock(),
+    ), patch(
+        "market_storefront.utils.escrow_verification.verify_escrow_for_settlement",
+        new=AsyncMock(),
+    ), patch(
+        "market_storefront.utils.action_executor.sync_listing_status_to_registry",
+        new=sync_mock,
+    ):
+        await start_settlement_job(
+            escrow_uid="0xescrow",
+            negotiation_id="neg-1",
+            ssh_public_key="ssh-rsa ...",
+            sqlite_client=client,
+            alkahest_client=MagicMock(),
+            chain_name='anvil',
+        )
+
+    listing = await client.load_listing(listing_id="seller-ord-1")
+    assert listing["status"] == "accepted"
+    sync_mock.assert_awaited_once_with("seller-ord-1", "accepted")
+
+
+@pytest.mark.asyncio
 async def test_start_aborts_when_escrow_verification_rejects(client):
     """If on-chain verification fails, no escrows row is inserted and no
     background task is scheduled — fail-closed."""
@@ -457,6 +487,33 @@ async def test_background_task_reopens_listing_on_failure(client):
     assert (await client.load_escrow(escrow_uid="0xescrow"))["status"] == "failed"
     listing = await client.load_listing(listing_id="seller-ord-1")
     assert listing["status"] == "open"
+
+
+@pytest.mark.asyncio
+async def test_background_task_reopens_registry_listing_on_failure(client):
+    await _seed_seller_order(client, listing_id="seller-ord-1")
+    await client.update_listing(listing_id="seller-ord-1", status="accepted")
+    await _seed_escrow_provisioning(client)
+    mock_fulfill = AsyncMock(side_effect=RuntimeError("vm host unreachable"))
+    sync_mock = AsyncMock(return_value={"status": "open"})
+
+    with patch(
+        "market_storefront.utils.action_executor.fulfill_compute_obligation",
+        new=mock_fulfill,
+    ), patch(
+        "market_storefront.utils.action_executor.sync_listing_status_to_registry",
+        new=sync_mock,
+    ):
+        await _run_settlement_job_bg(
+            escrow_uid="0xescrow",
+            provision=ProvisionTerms(duration_seconds=3600, ssh_public_key="ssh-rsa ..."),
+            listing_id="seller-ord-1",
+            order_dict={"listing_id": "seller-ord-1", "max_duration_seconds": 3600},
+            sqlite_client=client,
+            alkahest_client=MagicMock(),
+        )
+
+    sync_mock.assert_awaited_once_with("seller-ord-1", "open")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Plain-language summary

This PR brings the remaining issue-discovery fixes from `feat/issue-discovery-harness` into `dev`.

It addresses four concrete blockers discovered while running agent-driven orchestration against a scratch-deployed compute market:

- persisted provisioning SQLite databases could crash after image upgrades when the `hosts.public_host` column was missing
- registry discovery could continue advertising a listing as open after the storefront had accepted it
- the public buyer installer required the literal `python3.12` command even when a compatible Python 3.12+ environment was available
- the provisioning IAC Ansible collection requirements resolved to latest collection versions incompatible with the documented Ansible baseline

The PR keeps the fixes focused on public compute-market behavior and reusable regression coverage. Private scratch orchestration state, kubeconfigs, secrets, Terraform state, and run artifacts are not included.

## Architectural summary

The issue-discovery runs exposed several places where documented operator, buyer, and seller paths depended on assumptions that were not stable across upgrade, release, or fresh-machine environments.

This PR keeps the architecture unchanged and fixes those assumptions at the boundary where they failed:

- provisioning startup now performs a minimal additive SQLite compatibility migration after `create_all`
- storefront lifecycle transitions now propagate status changes to already-targeted registries through the existing owner-signed registry update path
- the buyer installer now treats `uv` as the component responsible for enforcing/provisioning the buyer Python runtime declared by `buyer/pyproject.toml`
- provisioning IAC now pins the Ansible collections to versions validated against the documented Ansible control-node baseline

The public repo remains responsible for product behavior, installer behavior, documented provisioning IAC behavior, and regression tests. Private infra remains responsible for scratch GCP deployment, secrets, kubeconfig, logs, and orchestration artifacts.

## Change groups

### Provisioning SQLite upgrade compatibility

Refs #124.

Root cause:

`Base.metadata.create_all()` creates missing tables, but it does not alter existing SQLite tables. A persisted provisioning DB created before `Host.public_host` existed could therefore crash newer images when ORM queries selected the missing column.

Changes:

- Add a SQLite-only startup migration for `hosts.public_host`.
- Keep fresh database creation behavior unchanged.
- Keep Postgres behavior unchanged.
- Add regression coverage using an old-schema SQLite database.
- Add idempotency coverage so repeated startup does not try to add the same column twice.

Result:

Provisioning can restart against older persisted SQLite state without wiping the database or requiring a manual scratch PVC reset.

### Storefront and registry lifecycle status sync

Refs #126.

Root cause:

The storefront is the seller-side source of truth for listing lifecycle, but registries are buyer-facing discovery indexes. Settlement could move a storefront listing to `accepted` while the registry still advertised the same listing as `open`, allowing buyers to discover stale inventory.

Changes:

- Add `sync_listing_status_to_registry` for signed per-registry lifecycle updates.
- Reuse the same helper from `close_order`.
- Sync `accepted` status after escrow verification succeeds and settlement starts.
- Sync `open` status when failed provisioning reopens a listing.
- Add unit coverage for registry targeting and settlement lifecycle propagation.

Result:

New purchases update registry discovery state when the storefront listing changes lifecycle state. Accepted listings no longer continue to appear as open inventory in the validated deployed path.

### Buyer installer Python detection

Refs #125.

Root cause:

The buyer quickstart says Python 3.12+, and the buyer package declares its runtime requirement in `buyer/pyproject.toml`, but `install.sh` required the literal `python3.12` binary and attempted interactive apt installation through `/dev/tty`. That breaks compatible noninteractive environments where `uv` can provide the required runtime.

Changes:

- Remove `python3.12`, `python3.12-dev`, `software-properties-common`, and deadsnakes PPA handling from installer dependency probes.
- Add explicit noninteractive dependency-install support through `--yes`, `-y`, and `MARKET_INSTALL_ASSUME_YES`.
- Fail with a clear message when dependencies are missing in a noninteractive run without opt-in.
- Update buyer quickstart release-install notes.
- Add installer static/syntax regression tests.

Result:

The installer no longer rejects compatible environments solely because the `python3.12` command is absent. The source fix is present here, but #125 should remain open until a normal public `market-cli-v*` release carries this fix and latest-release validation passes.

### Provisioning IAC Ansible collection baseline

Refs #127.

Root cause:

The provisioning docs instruct operators to install collections from `compute-provisioning-iac/ansible/requirements.yml`, but unpinned Galaxy requirements resolved to modern collection metadata incompatible with the documented Ansible 2.9+/2.10-era baseline.

Changes:

- Pin `community.general` to `4.8.7`.
- Pin `community.docker` to `2.7.2`.
- Pin `community.crypto` to `2.5.0`.
- Document why the collection requirements are pinned near the install step.

Result:

Following the documented collection install now resolves versions compatible with the documented Ansible baseline instead of pulling incompatible latest metadata.

## Boundary decisions and deferrals

- This PR does not introduce Alembic or a general provisioning migration framework.
- This PR does not alter Postgres behavior.
- This PR does not add new registry endpoints or a new discovery model.
- This PR does not make registry sync a hard settlement blocker; failures are logged while storefront state remains authoritative.
- This PR does not reconcile old stale registry rows created before the fix.
- This PR does not change the buyer CLI Python requirement; `uv` still enforces the package runtime requirement.
- This PR does not publish a new `market-cli-v*` release.
- This PR does not raise the documented Ansible baseline.
- This PR does not change provisioning playbooks, roles, inventory, or host setup behavior beyond collection version resolution.
- This PR does not include private scratch orchestration artifacts, kubeconfigs, Terraform state, rendered secrets, credentials, or raw private logs.

## Validation

### Provisioning SQLite migration

- `make test-unit` in `provisioning-service`: 266 passed.
- Targeted regression:
  - `PYTHONPATH=src uv run --find-links ../.dist pytest src/tests/unit/test_database.py -v`
  - 2 passed.

### Storefront lifecycle registry sync

- `uv run --project storefront pytest storefront/tests/unit/test_publications_wiring.py storefront/tests/unit/test_settlement_jobs.py -q`
  - 26 passed.
- `uv run --project storefront python -m py_compile storefront/src/market_storefront/utils/action_executor.py storefront/src/market_storefront/utils/settlement_jobs.py`
  - passed.
- `git diff --check`
  - passed.

### Buyer installer

- `uv run --project buyer pytest scripts/tests/test_install_remote_urls.py scripts/tests/test_install_sh_dependencies.py -q`
  - 5 passed.
- `bash -n install.sh`
  - passed.
- Local release-shaped installer validation passed under an isolated home using the updated installer.
- `market --help` and version reporting worked after local release-shaped install.

### Provisioning IAC Ansible baseline

- Installed pinned collections into a fresh temporary collection path with `ansible-galaxy 2.10.8`.
- `ANSIBLE_COLLECTIONS_PATHS=<temp> ansible-doc -t module community.general.ufw`
  - passed.
- `ANSIBLE_COLLECTIONS_PATHS=<temp> make validate` from `compute-provisioning-iac`
  - inventory/playbook syntax checks completed
  - 6 contract tests passed.
- `git diff --check`
  - passed.

### Deployed scratch validation

A deployed scratch market was upgraded to images built from commit `8dbbc5b`.

Validated flow:

- seller published bundled inventory
- current-ref public clone/build buyer completed `market buy`
- buyer reached terminal status `ready`
- escrow UID and fulfillment UID were emitted in buyer logs
- storefront reported the purchased listing as `accepted`
- registry default/open listing queries no longer returned the accepted listing
- held mock resource was released during cleanup

This provides deployed evidence for the lifecycle status-sync fix in addition to unit coverage.

## Issue state

- #124: fixed by this PR and already closed after validation.
- #125: source-fixed by this PR, but should remain open until the normal public release line publishes a new `market-cli-v*` release and latest-release validation passes.
- #126: fixed by this PR and already closed after source and deployed validation.
- #127: fixed by this PR and already closed after pinned-baseline validation.

## Result

After this PR merges into `dev`, the issue-discovery branch fixes will be available on the normal development line.

The only remaining public issue from this batch should be #125, blocked on release publication and latest-release validation rather than source code changes in this PR.