### PR TITLE
Pools 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GIT_NAME   ?= simple-compute-market
 FOUNDRY_VERSION := v1.5.1
 DIST_DIR := ${CURDIR}/.dist
 
-.PHONY: build build-dev build-seller build-apicredits-service build-apicredits-storefront build-apicredits-sample-app test test-core test-provisioning test-provisioning-iac test-registry test-storefront test-vms-buyer test-apicredits test-apicredits-middleware test-kits dist dist-storefront-client dist-bare-metal dist-vms dist-storefront dist-policy dist-provisioning-operator-client dist-compute-provisioning dist-apicredits-service dist-apicredits-storefront dist-apicredits-buyer dist-apicredits-middleware dist-apicredits-sample-app dist-registry-client dist-registry dist-identity dist-core dist-arkhai-core-buyer dist-arkhai-core-storefront dist-kit-site dist-alkahest dist-config dist-buyer dist-clean init init-prerequisites init-submodules init-zero-tier init-buyer init-storefront init-arkhai-core-registry push-runtime-artifacts push-images push-dev-images push-helm push-wheels push-cli clobber-wheels
+.PHONY: build build-dev build-seller build-apicredits-service build-apicredits-storefront build-apicredits-sample-app test test-core test-provisioning test-provisioning-iac test-registry test-storefront test-vms-buyer test-apicredits test-apicredits-middleware test-kits dist dist-storefront-client dist-bare-metal dist-vms dist-storefront dist-policy dist-provisioning-operator-client dist-compute-provisioning dist-kit-resource-pools dist-apicredits-service dist-apicredits-storefront dist-apicredits-buyer dist-apicredits-middleware dist-apicredits-sample-app dist-registry-client dist-registry dist-identity dist-core dist-arkhai-core-buyer dist-arkhai-core-storefront dist-kit-site dist-alkahest dist-config dist-buyer dist-clean init init-prerequisites init-submodules init-zero-tier init-buyer init-storefront init-arkhai-core-registry push-runtime-artifacts push-images push-dev-images push-helm push-wheels push-cli clobber-wheels
 .PHONY: dist-apicredits-domain
 
 # ---------------------------------------------------------------------------
@@ -24,7 +24,7 @@ DIST_DIR := ${CURDIR}/.dist
 # to uv sync.  Further upgrade: publish .dist/ contents to GCP Artifact
 # Registry and switch to --index https://...gar.../simple.
 # ---------------------------------------------------------------------------
-dist: dist-storefront-client dist-identity dist-core dist-arkhai-core-buyer dist-arkhai-core-storefront dist-kit-site dist-alkahest dist-config dist-bare-metal dist-vms dist-storefront dist-policy dist-provisioning-operator-client dist-compute-provisioning dist-apicredits-domain dist-apicredits-service dist-apicredits-storefront dist-apicredits-buyer dist-apicredits-middleware dist-apicredits-sample-app dist-registry-client dist-buyer
+dist: dist-storefront-client dist-identity dist-core dist-arkhai-core-buyer dist-arkhai-core-storefront dist-kit-site dist-kit-resource-pools dist-alkahest dist-config dist-bare-metal dist-vms dist-storefront dist-policy dist-provisioning-operator-client dist-compute-provisioning dist-apicredits-domain dist-apicredits-service dist-apicredits-storefront dist-apicredits-buyer dist-apicredits-middleware dist-apicredits-sample-app dist-registry-client dist-buyer
 
 dist-storefront-client: ## Build arkhai-core-storefront-client wheel into .dist/
 	-mkdir -p $(DIST_DIR)
@@ -139,6 +139,12 @@ dist-kit-site: ## Build arkhai-kit-site wheel into .dist/
 	cd kit/site && $(MAKE) build DIST_DIR=$(DIST_DIR)
 	@ls $(DIST_DIR)/arkhai_kit_site-*-none-any.whl > /dev/null 2>&1 || \
 		(echo "ERROR: arkhai-kit-site produced a platform-specific wheel — must build inside Docker" && exit 1)
+
+dist-kit-resource-pools: ## Build arkhai-kit-resource-pools wheel into .dist/
+	-mkdir -p $(DIST_DIR)
+	cd kit/resource-pools && $(MAKE) build DIST_DIR=$(DIST_DIR)
+	@ls $(DIST_DIR)/arkhai_kit_resource_pools-*-none-any.whl > /dev/null 2>&1 || \
+		(echo "ERROR: arkhai-kit-resource-pools produced a platform-specific wheel — must build inside Docker" && exit 1)
 
 dist-alkahest: ## Build arkhai-kit-alkahest wheel into .dist/
 	-mkdir -p $(DIST_DIR)

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GIT_NAME   ?= simple-compute-market
 FOUNDRY_VERSION := v1.5.1
 DIST_DIR := ${CURDIR}/.dist
 
-.PHONY: build build-dev build-seller build-apicredits-service build-apicredits-storefront build-apicredits-sample-app test test-core test-provisioning test-provisioning-iac test-registry test-storefront test-vms-buyer test-apicredits test-apicredits-middleware test-kits dist dist-storefront-client dist-bare-metal dist-vms dist-storefront dist-policy dist-provisioning-operator-client dist-compute-provisioning dist-kit-resource-pools dist-apicredits-service dist-apicredits-storefront dist-apicredits-buyer dist-apicredits-middleware dist-apicredits-sample-app dist-registry-client dist-registry dist-identity dist-core dist-arkhai-core-buyer dist-arkhai-core-storefront dist-kit-site dist-alkahest dist-config dist-buyer dist-clean init init-prerequisites init-submodules init-zero-tier init-buyer init-storefront init-arkhai-core-registry push-runtime-artifacts push-images push-dev-images push-helm push-wheels push-cli clobber-wheels
+.PHONY: build build-dev build-seller build-apicredits-service build-apicredits-storefront build-apicredits-sample-app test test-core test-provisioning test-provisioning-iac test-registry test-storefront test-vms-buyer test-apicredits test-apicredits-middleware test-kits dist dist-storefront-client dist-bare-metal dist-vms dist-storefront dist-policy dist-provisioning-operator-client dist-compute-provisioning dist-kits dist-apicredits-service dist-apicredits-storefront dist-apicredits-buyer dist-apicredits-middleware dist-apicredits-sample-app dist-registry-client dist-registry dist-identity dist-core dist-arkhai-core-buyer dist-arkhai-core-storefront dist-alkahest dist-config dist-buyer dist-clean init init-prerequisites init-submodules init-zero-tier init-buyer init-storefront init-arkhai-core-registry push-runtime-artifacts push-images push-dev-images push-helm push-wheels push-cli clobber-wheels
 .PHONY: dist-apicredits-domain
 
 # ---------------------------------------------------------------------------
@@ -24,7 +24,7 @@ DIST_DIR := ${CURDIR}/.dist
 # to uv sync.  Further upgrade: publish .dist/ contents to GCP Artifact
 # Registry and switch to --index https://...gar.../simple.
 # ---------------------------------------------------------------------------
-dist: dist-storefront-client dist-identity dist-core dist-arkhai-core-buyer dist-arkhai-core-storefront dist-kit-site dist-kit-resource-pools dist-alkahest dist-config dist-bare-metal dist-vms dist-storefront dist-policy dist-provisioning-operator-client dist-compute-provisioning dist-apicredits-domain dist-apicredits-service dist-apicredits-storefront dist-apicredits-buyer dist-apicredits-middleware dist-apicredits-sample-app dist-registry-client dist-buyer
+dist: dist-storefront-client dist-identity dist-core dist-arkhai-core-buyer dist-arkhai-core-storefront dist-kits dist-alkahest dist-config dist-bare-metal dist-vms dist-storefront dist-policy dist-provisioning-operator-client dist-compute-provisioning dist-apicredits-domain dist-apicredits-service dist-apicredits-storefront dist-apicredits-buyer dist-apicredits-middleware dist-apicredits-sample-app dist-registry-client dist-buyer
 
 dist-storefront-client: ## Build arkhai-core-storefront-client wheel into .dist/
 	-mkdir -p $(DIST_DIR)
@@ -134,17 +134,8 @@ dist-arkhai-core-storefront: ## Build arkhai-core-storefront wheel into .dist/
 	@ls $(DIST_DIR)/arkhai_core_storefront-*-none-any.whl > /dev/null 2>&1 || \
 		(echo "ERROR: arkhai-core-storefront produced a platform-specific wheel — must build inside Docker" && exit 1)
 
-dist-kit-site: ## Build arkhai-kit-site wheel into .dist/
-	-mkdir -p $(DIST_DIR)
-	cd kit/site && $(MAKE) build DIST_DIR=$(DIST_DIR)
-	@ls $(DIST_DIR)/arkhai_kit_site-*-none-any.whl > /dev/null 2>&1 || \
-		(echo "ERROR: arkhai-kit-site produced a platform-specific wheel — must build inside Docker" && exit 1)
-
-dist-kit-resource-pools: ## Build arkhai-kit-resource-pools wheel into .dist/
-	-mkdir -p $(DIST_DIR)
-	cd kit/resource-pools && $(MAKE) build DIST_DIR=$(DIST_DIR)
-	@ls $(DIST_DIR)/arkhai_kit_resource_pools-*-none-any.whl > /dev/null 2>&1 || \
-		(echo "ERROR: arkhai-kit-resource-pools produced a platform-specific wheel — must build inside Docker" && exit 1)
+dist-kits: ## Build kit-owned wheels into .dist/
+	$(MAKE) -C kit dist DIST_DIR=$(DIST_DIR)
 
 dist-alkahest: ## Build arkhai-kit-alkahest wheel into .dist/
 	-mkdir -p $(DIST_DIR)
@@ -474,6 +465,13 @@ review-diff: ## Write a binary-safe HEAD-relative diff for review without changi
 	@OUTFILE="${CURDIR}/.snapshot/$(GIT_NAME)-${GIT_SUFFIX}.diff"; \
 	echo "Creating $$OUTFILE ..."; \
 	git diff --binary HEAD > "$$OUTFILE"; \
+	echo "Done: $$OUTFILE"
+
+last-diff: ## Write a binary-safe diff for the most recent commit.
+	@mkdir -p .snapshot
+	@OUTFILE="${CURDIR}/.snapshot/$(GIT_NAME)-${GIT_SUFFIX}-last.diff"; \
+	echo "Creating $$OUTFILE ..."; \
+	git diff --binary HEAD^ HEAD > "$$OUTFILE"; \
 	echo "Done: $$OUTFILE"
 
 review-wheelhouse: vendor-wheels ## Package vendored dependency wheels for offline review/test runs.

--- a/docs/development/ARCHITECTURE.md
+++ b/docs/development/ARCHITECTURE.md
@@ -33,6 +33,7 @@ The normative dependency and plugin contracts are in the [market composition spe
 | Plans, claims, heartbeats, and mechanism codecs | [Settlement servicing](../../openspec/specs/settlement-servicing/spec.md) |
 | Seller surfaces and listing publication | [Storefront publication](../../openspec/specs/storefront-publication/spec.md) |
 | Capacity authority, reservations, aggregation, and events | [Site capacity](../../openspec/specs/site-capacity/spec.md) |
+| Resource pool administration, provider configuration, and host membership | [Resource pool management](../../openspec/specs/resource-pool-management/spec.md) |
 | Scheduling, fulfillment, jobs, and lease release | [Physical provisioning](../../openspec/specs/physical-provisioning/spec.md) |
 | Buyer plugins, policies, aggregation, and recovery | [Buyer orchestration](../../openspec/specs/buyer-orchestration/spec.md) |
 | Deployment, persistence, migrations, and packaging | [Deployment and state](../../openspec/specs/deployment-state/spec.md) |

--- a/domains/vms/provisioning/service/pyproject.toml
+++ b/domains/vms/provisioning/service/pyproject.toml
@@ -10,7 +10,8 @@ description = "Async VM provisioning service"
 requires-python = ">=3.12"
 dependencies = [
     "arkhai-kit-site>=0.2.0",
-    "arkhai-compute-provisioning>=0.4.0",
+    "arkhai-kit-resource-pools>=0.1.0",
+    "arkhai-compute-provisioning>=0.5.0",
     "arkhai-core-storefront-client>=0.11.0",
     "arkhai-bare-metal>=0.1.0",
     "arkhai-vms-provisioning-operator-client>=0.3.0",

--- a/domains/vms/provisioning/service/src/app_runtime.py
+++ b/domains/vms/provisioning/service/src/app_runtime.py
@@ -65,6 +65,12 @@ def resolve_request_path_services() -> None:
     _container_module.resolved_executor_lease_service = container.executor_lease_service()
     _container_module.resolved_compute_contract_service = container.compute_contract_service()
     _container_module.resolved_resource_pool_service = container.resource_pool_service()
+    _container_module.resolved_physical_settlement_scheduler = (
+        container.physical_settlement_scheduler()
+    )
+    _container_module.resolved_capacity_reservation_watchdog = (
+        container.capacity_reservation_watchdog()
+    )
 
 
 def seed_inventory_if_empty() -> None:
@@ -229,6 +235,33 @@ def background_tasks() -> tuple[ComputeProvisioningBackgroundTask, ...]:
         )
     else:
         logger.info("Lease watchdog disabled (lease_watchdog_enabled=false)")
+
+    # Capacity reservation watchdog — only started when enabled in config
+    # (default: true). Every reserve/commit/release call already lazily
+    # sweeps expired holds; this only catches an otherwise-idle site.
+    reservation_watchdog_enabled = bool(
+        getattr(settings, "capacity_reservation_watchdog_enabled", True)
+    )
+    if reservation_watchdog_enabled:
+        tasks.append(
+            ComputeProvisioningBackgroundTask(
+                "capacity-reservation-watchdog",
+                lambda: _container_module.resolved_capacity_reservation_watchdog.run(),
+                "Capacity reservation watchdog started (interval=%ds)",
+                (
+                    getattr(
+                        settings,
+                        "capacity_reservation_watchdog_poll_interval_seconds",
+                        60,
+                    ),
+                ),
+            )
+        )
+    else:
+        logger.info(
+            "Capacity reservation watchdog disabled "
+            "(capacity_reservation_watchdog_enabled=false)"
+        )
 
     return tuple(tasks)
 

--- a/domains/vms/provisioning/service/src/container.py
+++ b/domains/vms/provisioning/service/src/container.py
@@ -39,20 +39,6 @@ def _resolved_job_queue():
     return resolved_job_queue
 
 
-def _pool_has_active_binding(pool_id: str) -> bool:
-    """Late-bound lookup for ResourcePoolService's disable_pool guardrail.
-
-    resource_pool_service and physical_settlement_scheduler each depend on
-    being constructible without the other (the scheduler reads pools; the
-    pool service's guardrail reads bindings), so this indirection — rather
-    than a constructor dependency in either direction — avoids a circular
-    DI graph, mirroring _resolved_job_queue's pattern above.
-    """
-    if resolved_physical_settlement_scheduler is None:
-        return False
-    return resolved_physical_settlement_scheduler.has_active_binding(pool_id)
-
-
 def _make_ansible_service(cfg):
     """Return ProgrammableMockAnsibleService when ACTIVE_PROFILES includes 'mock'."""
     import os
@@ -148,7 +134,6 @@ class Container(containers.DeclarativeContainer):
         ResourcePoolService,
         session_factory=session_factory,
         handlers=providers.Dict(ansible=ansible_pool_config_handler),
-        active_binding_check=_pool_has_active_binding,
     )
 
     job_service = providers.Singleton(

--- a/domains/vms/provisioning/service/src/container.py
+++ b/domains/vms/provisioning/service/src/container.py
@@ -4,6 +4,7 @@ from dependency_injector import containers, providers
 from compute_provisioning.lease_lifecycle import LeaseLifecycleService
 from compute_provisioning.executor_leases import ExecutorLeaseService
 from compute_provisioning.release import ExecutorReleaseDispatcher
+from market_resource_pools import ResourcePoolService
 from market_site.authority import LedgerSiteAuthority
 from market_site.ledger import CapacityLedgerService
 
@@ -19,14 +20,15 @@ from services.deal_event_sink import StorefrontLifecycleEventSink, notify_storef
 from services.host_operations_service import HostOperationsService
 from services.host_service import HostService
 from services.job_service import AnsibleJobService
+from services.capacity_reservation_watchdog import CapacityReservationWatchdog
 from services.lease_watchdog import LeaseWatchdog
+from services.physical_settlement_scheduler import PhysicalSettlementScheduler
 from services.release_executors import (
     BARE_METAL_EXECUTOR_KIND,
     BareMetalReleaseExecutor,
     VM_EXECUTOR_KIND,
     VmReleaseExecutor,
 )
-from services.resource_pool_service import ResourcePoolService
 from services.system_service import SystemService
 from services.vm_operations_service import VmOperationsService
 
@@ -35,6 +37,20 @@ def _resolved_job_queue():
     if resolved_job_queue is None:
         raise RuntimeError("Job queue is not initialised")
     return resolved_job_queue
+
+
+def _pool_has_active_binding(pool_id: str) -> bool:
+    """Late-bound lookup for ResourcePoolService's disable_pool guardrail.
+
+    resource_pool_service and physical_settlement_scheduler each depend on
+    being constructible without the other (the scheduler reads pools; the
+    pool service's guardrail reads bindings), so this indirection — rather
+    than a constructor dependency in either direction — avoids a circular
+    DI graph, mirroring _resolved_job_queue's pattern above.
+    """
+    if resolved_physical_settlement_scheduler is None:
+        return False
+    return resolved_physical_settlement_scheduler.has_active_binding(pool_id)
 
 
 def _make_ansible_service(cfg):
@@ -132,6 +148,7 @@ class Container(containers.DeclarativeContainer):
         ResourcePoolService,
         session_factory=session_factory,
         handlers=providers.Dict(ansible=ansible_pool_config_handler),
+        active_binding_check=_pool_has_active_binding,
     )
 
     job_service = providers.Singleton(
@@ -159,6 +176,19 @@ class Container(containers.DeclarativeContainer):
     capacity_ledger_service = providers.Singleton(
         CapacityLedgerService,
         session_factory=session_factory,
+    )
+
+    physical_settlement_scheduler = providers.Singleton(
+        PhysicalSettlementScheduler,
+        pool_service=resource_pool_service,
+        capacity_ledger=capacity_ledger_service,
+        session_factory=session_factory,
+    )
+
+    capacity_reservation_watchdog = providers.Singleton(
+        CapacityReservationWatchdog,
+        capacity_ledger_service=capacity_ledger_service,
+        settings=config,
     )
 
     site_authority = providers.Singleton(
@@ -257,3 +287,5 @@ resolved_bare_metal_operations_service: "BareMetalOperationsService | None" = No
 resolved_executor_lease_service: "ExecutorLeaseService | None" = None
 resolved_compute_contract_service = None
 resolved_resource_pool_service: "ResourcePoolService | None" = None
+resolved_physical_settlement_scheduler: "PhysicalSettlementScheduler | None" = None
+resolved_capacity_reservation_watchdog: "CapacityReservationWatchdog | None" = None

--- a/domains/vms/provisioning/service/src/controllers/pools_controller.py
+++ b/domains/vms/provisioning/service/src/controllers/pools_controller.py
@@ -35,7 +35,7 @@ from compute_provisioning import (
     PoolUpdate,
     PoolValidateResponse,
 )
-from services.resource_pool_service import (
+from market_resource_pools import (
     PoolAlreadyExistsError,
     PoolNotFoundError,
     PoolValidationError,

--- a/domains/vms/provisioning/service/src/db/database.py
+++ b/domains/vms/provisioning/service/src/db/database.py
@@ -51,6 +51,12 @@ def run_migrations(
     migrations haven't been applied. See ARCHITECTURE.md § Schema Migration
     Execution.
     """
+    # Resource-pool tables must be created before this service's own Base:
+    # ansible_pool_configs (on Base) has a ForeignKey("resource_pools.id"),
+    # and SQLAlchemy's cross-metadata FK resolution during create_all needs
+    # the referenced table to already exist.
+    from market_resource_pools.db import Base as PoolsBase
+    PoolsBase.metadata.create_all(bind=engine)
     Base.metadata.create_all(bind=engine)
     # Site-authority ledger tables ride the shared market_site
     # metadata (db.models re-exports the classes).

--- a/domains/vms/provisioning/service/src/db/migrations.py
+++ b/domains/vms/provisioning/service/src/db/migrations.py
@@ -246,7 +246,9 @@ def _migrate_resource_pools_and_hosts_pool_id(
     open-ended business-logic seeding (that stays in app_runtime's YAML
     pool-definitions import).
     """
-    Base.metadata.tables["resource_pools"].create(bind=engine, checkfirst=True)
+    from market_resource_pools.db import Base as PoolsBase
+
+    PoolsBase.metadata.tables["resource_pools"].create(bind=engine, checkfirst=True)
     Base.metadata.tables["ansible_pool_configs"].create(bind=engine, checkfirst=True)
 
     with Session(engine) as session:

--- a/domains/vms/provisioning/service/src/db/models.py
+++ b/domains/vms/provisioning/service/src/db/models.py
@@ -94,46 +94,12 @@ class Credential(Base):
     job = relationship("AnsibleJob", back_populates="credentials")
 
 
-DEFAULT_POOL_ID = "default"
-
-
-class ResourcePool(Base):
-    """Provisioning-owned grouping of physical resources eligible for
-    settlement (see ARCHITECTURE.md § Technical Terms — "Resource Pool").
-
-    This is infrastructure routing/scheduling metadata, distinct from any
-    storefront-side capacity pool concept — there is no FK between the two
-    layers, only explicit configuration/attribute mapping.
-
-    id:
-        Operator-chosen slug (e.g. "hetzner-eu-central"). Not a UUID — pool
-        ids appear in YAML definitions and are meant to be human-legible.
-    enabled:
-        False pools are excluded from scheduling eligibility once a
-        scheduler exists (no scheduler exists yet). Delete is soft —
-        disable — by default; pools are never hard-deleted by the admin
-        API so that hosts.pool_id and any future settlement records
-        referencing this id remain resolvable.
-    policy_tags:
-        Free-form tag map (e.g. {"region": "eu", "provider": "hetzner"})
-        used for tag-filtered pool lookup. Not consumed by a scheduler yet.
-    """
-
-    __tablename__ = "resource_pools"
-
-    id = Column(String, primary_key=True)
-    label = Column(String, nullable=False)
-    provider = Column(String, nullable=False)
-    enabled = Column(Boolean, nullable=False, default=True)
-    policy_tags = Column(JSON, nullable=False, default=dict)
-    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
-    updated_at = Column(
-        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
-    )
-
-    ansible_config = relationship(
-        "AnsiblePoolConfig", back_populates="pool", uselist=False, cascade="all, delete-orphan"
-    )
+# Provider-neutral resource-pool identity now lives in the shared
+# market_resource_pools package (kit); re-exported here because the
+# service's modules and tests reach all persistence models through
+# db.models. The table rides market_resource_pools' own metadata —
+# init_db creates it alongside this service's own Base and market_site's.
+from market_resource_pools import DEFAULT_POOL_ID, ResourcePool  # noqa: F401
 
 
 class AnsiblePoolConfig(Base):
@@ -146,16 +112,19 @@ class AnsiblePoolConfig(Base):
     records. Only the "ansible" provider is implemented; other providers
     (kubernetes, gcp, ...) would get their own side table, not new columns
     here.
+
+    No ORM ``relationship()`` back to ``ResourcePool``: that model now lives
+    in a different declarative registry (``market_resource_pools``), so
+    navigation is by explicit ``pool_id`` lookup — which is how
+    ``PoolConfigHandler`` implementations already read/write this table.
     """
 
     __tablename__ = "ansible_pool_configs"
 
-    pool_id = Column(String, ForeignKey("resource_pools.id"), primary_key=True)
+    pool_id = Column(String, ForeignKey(ResourcePool.__table__.c.id), primary_key=True)
     playbook_path = Column(String, nullable=False)
     inventory_group = Column(String, nullable=False)
     extra_vars = Column(JSON, nullable=False, default=dict)
-
-    pool = relationship("ResourcePool", back_populates="ansible_config")
 
 
 class Host(Base):
@@ -204,7 +173,7 @@ class Host(Base):
     enabled = Column(Boolean, nullable=False, default=True)
     pool_id = Column(
         String,
-        ForeignKey("resource_pools.id"),
+        ForeignKey(ResourcePool.__table__.c.id),
         nullable=False,
         default=DEFAULT_POOL_ID,
         server_default=DEFAULT_POOL_ID,

--- a/domains/vms/provisioning/service/src/services/capacity_reservation_watchdog.py
+++ b/domains/vms/provisioning/service/src/services/capacity_reservation_watchdog.py
@@ -1,0 +1,52 @@
+"""Capacity-reservation expiry watchdog.
+
+CapacityReservationWatchdog is a thin asyncio timer that calls
+CapacityLedgerService.expire_due_holds() on a configurable interval,
+mirroring LeaseWatchdog exactly. All logic lives in CapacityLedgerService;
+the watchdog only owns the scheduling. Every reserve/commit/release call
+already lazily sweeps expired holds, so this exists only to reclaim a hold
+left uncommitted at an otherwise-idle site (see
+CapacityLedgerService.expire_due_holds's docstring).
+
+Started as an asyncio background task in main.py lifespan:
+
+    watchdog = CapacityReservationWatchdog(capacity_ledger_service, settings)
+    asyncio.create_task(watchdog.run(), name="capacity-reservation-watchdog")
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class CapacityReservationWatchdog:
+    """Periodic timer that delegates to CapacityLedgerService.expire_due_holds().
+
+    All hold-expiry logic lives in CapacityLedgerService. This class only
+    owns the asyncio scheduling and graceful shutdown.
+    """
+
+    def __init__(self, capacity_ledger_service, settings) -> None:
+        self._svc = capacity_ledger_service
+        self._settings = settings
+
+    async def run(self) -> None:
+        """Run the watchdog loop until cancelled."""
+        interval = getattr(
+            self._settings, "capacity_reservation_watchdog_poll_interval_seconds", 60
+        )
+        logger.info("[CAPACITY_RESERVATION_WATCHDOG] Started (interval=%ds)", interval)
+        while True:
+            try:
+                await asyncio.sleep(interval)
+                self._svc.expire_due_holds()
+            except asyncio.CancelledError:
+                logger.info("[CAPACITY_RESERVATION_WATCHDOG] Cancelled, shutting down")
+                break
+            except Exception as exc:
+                logger.exception(
+                    "[CAPACITY_RESERVATION_WATCHDOG] Unhandled error in cycle: %s", exc
+                )

--- a/domains/vms/provisioning/service/src/services/deterministic_round_robin_policy.py
+++ b/domains/vms/provisioning/service/src/services/deterministic_round_robin_policy.py
@@ -1,0 +1,46 @@
+"""Deterministic round-robin policy for eligible settlement candidates."""
+
+from __future__ import annotations
+
+from compute_provisioning import (
+    NoEligibleSettlementResourceError,
+    SettlementCandidate,
+    SettlementRequirement,
+)
+
+
+class DeterministicRoundRobinPolicy:
+    """Round-robin across eligible pools, then resources within that pool."""
+
+    def __init__(self) -> None:
+        self._last_pool_id: str | None = None
+        self._last_resource_by_pool: dict[str, str] = {}
+
+    @staticmethod
+    def _next_after(values: list[str], previous: str | None) -> str:
+        if not values:
+            raise NoEligibleSettlementResourceError("no eligible values")
+        if previous not in values:
+            return values[0]
+        return values[(values.index(previous) + 1) % len(values)]
+
+    def select(
+        self,
+        *,
+        requirement: SettlementRequirement,
+        candidates: list[SettlementCandidate],
+    ) -> SettlementCandidate:
+        del requirement
+        by_pool: dict[str, list[SettlementCandidate]] = {}
+        for candidate in candidates:
+            by_pool.setdefault(candidate.pool_id, []).append(candidate)
+        pool_id = self._next_after(sorted(by_pool), self._last_pool_id)
+        resources = sorted(by_pool[pool_id], key=lambda item: item.resource_id)
+        resource_id = self._next_after(
+            [item.resource_id for item in resources],
+            self._last_resource_by_pool.get(pool_id),
+        )
+        selected = next(item for item in resources if item.resource_id == resource_id)
+        self._last_pool_id = pool_id
+        self._last_resource_by_pool[pool_id] = resource_id
+        return selected

--- a/domains/vms/provisioning/service/src/services/physical_settlement_scheduler.py
+++ b/domains/vms/provisioning/service/src/services/physical_settlement_scheduler.py
@@ -1,0 +1,231 @@
+"""Physical settlement resource selection.
+
+Binds an already-reserved capacity allocation to exactly one durable,
+idempotent settlement resource. See
+openspec/changes/pools-2-physical-settlement-scheduler/design.md for the
+full design rationale (scheduler/provider split, naming, algorithm).
+
+Persistence is intentionally process-local this round (see that design's
+"No persistence this change" decision) — bindings live in an in-memory
+dict keyed by allocation_id. pools-3 replaces this with a durable
+SettlementRecord extending the same key.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+from compute_provisioning.physical_settlement import (
+    PhysicalSettlementRequest,
+    SettlementResource,
+)
+from market_resource_pools import ResourcePoolService
+from market_site.ledger import CapacityLedgerService
+
+from db.models import Host
+
+
+class NoEligiblePoolError(Exception):
+    """No enabled, non-exhausted pool can satisfy the request."""
+
+
+class ResourceNotFoundError(Exception):
+    """An explicitly-requested resource_id does not exist or isn't eligible."""
+
+
+class PhysicalSettlementScheduler:
+    """Selects and durably (for this process's lifetime) binds settlement resources.
+
+    Dimension-agnostic bottleneck-normalized selection: for each eligible
+    pool, utilization is the maximum of (used_units / total_units) across
+    whatever ``resource_type`` values that pool's resources actually have —
+    not a fixed CPU/RAM/GPU/disk set, since the site ledger's resource model
+    doesn't have fixed dimensions (see design.md's "Discovery" note carried
+    into this session's plan). The pool with the lowest bottleneck
+    utilization is selected.
+    """
+
+    def __init__(
+        self,
+        pool_service: ResourcePoolService,
+        capacity_ledger: CapacityLedgerService,
+        session_factory: Any,
+    ) -> None:
+        self._pool_service = pool_service
+        self._capacity_ledger = capacity_ledger
+        self._session_factory = session_factory
+        self._lock = threading.Lock()
+        self._bindings: dict[str, SettlementResource] = {}
+
+    def has_active_binding(self, pool_id: str) -> bool:
+        """Used by ResourcePoolService's disable_pool guardrail."""
+        with self._lock:
+            return any(
+                resource.pool_id == pool_id for resource in self._bindings.values()
+            )
+
+    def select_resource(
+        self, request: PhysicalSettlementRequest
+    ) -> SettlementResource:
+        """Atomically bind request.allocation_id to a settlement resource.
+
+        Repeated calls for the same allocation_id return the existing
+        binding rather than selecting another resource.
+        """
+        with self._lock:
+            existing = self._bindings.get(request.allocation_id)
+            if existing is not None:
+                return existing
+
+            if request.resource_id is not None:
+                resource = self._bind_explicit_resource(request)
+            else:
+                resource = self._bind_pool_selected_resource(request)
+
+            self._bindings[request.allocation_id] = resource
+            return resource
+
+    # ------------------------------------------------------------------
+    # Explicit resource_id path
+    # ------------------------------------------------------------------
+
+    def _bind_explicit_resource(
+        self, request: PhysicalSettlementRequest
+    ) -> SettlementResource:
+        for payload in self._capacity_ledger.list_resources():
+            if payload["resource_id"] != request.resource_id:
+                continue
+            if not payload.get("enabled"):
+                raise ResourceNotFoundError(
+                    f"resource '{request.resource_id}' is disabled"
+                )
+            pool_id = self._pool_id_for(payload)
+            return SettlementResource(
+                settlement_resource_id=payload["resource_id"],
+                pool_id=pool_id or "",
+                resource_kind=payload["resource_type"],
+                provider=self._provider_for_pool(pool_id),
+                attributes=payload.get("attributes") or {},
+            )
+        raise ResourceNotFoundError(
+            f"resource '{request.resource_id}' does not exist"
+        )
+
+    # ------------------------------------------------------------------
+    # Fungible pool-selection path
+    # ------------------------------------------------------------------
+
+    def _bind_pool_selected_resource(
+        self, request: PhysicalSettlementRequest
+    ) -> SettlementResource:
+        eligible_pool_ids = {
+            pool.id
+            for pool in self._pool_service.list_pools(enabled_only=True)
+            if request.pool_id is None or pool.id == request.pool_id
+        }
+        if not eligible_pool_ids:
+            raise NoEligiblePoolError(
+                "no enabled pool matches this request"
+                if request.pool_id is None
+                else f"pool '{request.pool_id}' does not exist or is disabled"
+            )
+
+        by_pool = self._group_resources_by_pool(eligible_pool_ids)
+        best_pool_id: str | None = None
+        best_utilization: float | None = None
+        best_resource: dict[str, Any] | None = None
+
+        for pool_id in eligible_pool_ids:
+            resources = by_pool.get(pool_id, [])
+            candidate = next(
+                (r for r in resources if r.get("enabled") and r["available_units"] > 0),
+                None,
+            )
+            if candidate is None:
+                continue
+            utilization = self._pool_bottleneck_utilization(resources)
+            if best_utilization is None or utilization < best_utilization:
+                best_pool_id, best_utilization, best_resource = (
+                    pool_id,
+                    utilization,
+                    candidate,
+                )
+
+        if best_pool_id is None or best_resource is None:
+            raise NoEligiblePoolError(
+                "every eligible pool is disabled or exhausted"
+            )
+
+        return SettlementResource(
+            settlement_resource_id=best_resource["resource_id"],
+            pool_id=best_pool_id,
+            resource_kind=best_resource["resource_type"],
+            provider=self._provider_for_pool(best_pool_id),
+            attributes=best_resource.get("attributes") or {},
+        )
+
+    @staticmethod
+    def _pool_bottleneck_utilization(resources: list[dict[str, Any]]) -> float:
+        totals: dict[str, int] = {}
+        useds: dict[str, int] = {}
+        for r in resources:
+            if not r.get("enabled"):
+                continue
+            rtype = r["resource_type"]
+            total = int(r["value"])
+            available = int(r["available_units"])
+            totals[rtype] = totals.get(rtype, 0) + total
+            useds[rtype] = useds.get(rtype, 0) + max(total - available, 0)
+        if not totals:
+            return 1.0
+        return max(
+            (useds[rtype] / totals[rtype]) if totals[rtype] else 1.0
+            for rtype in totals
+        )
+
+    def _group_resources_by_pool(
+        self, eligible_pool_ids: set[str]
+    ) -> dict[str, list[dict[str, Any]]]:
+        resources = self._capacity_ledger.list_resources()
+        # attributes["vm_host"] identifies the physical host a resource rides
+        # on (legacy naming; conceptually "the host name" for any executor
+        # kind sharing this Host table). Hostless resources (e.g. an
+        # api-credits market's quota rows) never join to a pool and are
+        # correctly excluded from pool-based scheduling.
+        host_names = {
+            r["attributes"].get("vm_host")
+            for r in resources
+            if r.get("attributes")
+        }
+        host_names.discard(None)
+        with self._session_factory() as db:
+            hosts = (
+                db.query(Host).filter(Host.name.in_(host_names)).all()
+                if host_names
+                else []
+            )
+        pool_by_host = {h.name: h.pool_id for h in hosts}
+
+        grouped: dict[str, list[dict[str, Any]]] = {}
+        for r in resources:
+            host_name = (r.get("attributes") or {}).get("vm_host")
+            pool_id = pool_by_host.get(host_name)
+            if pool_id is None or pool_id not in eligible_pool_ids:
+                continue
+            grouped.setdefault(pool_id, []).append(r)
+        return grouped
+
+    def _pool_id_for(self, resource_payload: dict[str, Any]) -> str | None:
+        host_name = (resource_payload.get("attributes") or {}).get("vm_host")
+        if host_name is None:
+            return None
+        with self._session_factory() as db:
+            host = db.query(Host).filter(Host.name == host_name).one_or_none()
+        return host.pool_id if host else None
+
+    def _provider_for_pool(self, pool_id: str | None) -> str:
+        if pool_id is None:
+            return ""
+        pool = self._pool_service.get_pool(pool_id)
+        return pool.provider if pool else ""

--- a/domains/vms/provisioning/service/src/services/physical_settlement_scheduler.py
+++ b/domains/vms/provisioning/service/src/services/physical_settlement_scheduler.py
@@ -1,231 +1,194 @@
-"""Physical settlement resource selection.
-
-Binds an already-reserved capacity allocation to exactly one durable,
-idempotent settlement resource. See
-openspec/changes/pools-2-physical-settlement-scheduler/design.md for the
-full design rationale (scheduler/provider split, naming, algorithm).
-
-Persistence is intentionally process-local this round (see that design's
-"No persistence this change" decision) — bindings live in an in-memory
-dict keyed by allocation_id. pools-3 replaces this with a durable
-SettlementRecord extending the same key.
-"""
+"""Deterministic, executor-neutral capacity settlement scheduling."""
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 import threading
 from typing import Any
 
-from compute_provisioning.physical_settlement import (
+from compute_provisioning import (
+    CapacityReservationExpiredError,
+    NoEligibleSettlementResourceError,
     PhysicalSettlementRequest,
+    SettlementCandidate,
+    SettlementEntityNotFoundError,
+    SettlementRequestMismatchError,
+    SettlementRequirement,
     SettlementResource,
+    SettlementSchedulingPolicy,
 )
 from market_resource_pools import ResourcePoolService
 from market_site.ledger import CapacityLedgerService
-
-from db.models import Host
-
-
-class NoEligiblePoolError(Exception):
-    """No enabled, non-exhausted pool can satisfy the request."""
-
-
-class ResourceNotFoundError(Exception):
-    """An explicitly-requested resource_id does not exist or isn't eligible."""
+from services.deterministic_round_robin_policy import DeterministicRoundRobinPolicy
 
 
 class PhysicalSettlementScheduler:
-    """Selects and durably (for this process's lifetime) binds settlement resources.
+    """Creates one Capacity Settlement Assignment per unchanged reservation.
 
-    Dimension-agnostic bottleneck-normalized selection: for each eligible
-    pool, utilization is the maximum of (used_units / total_units) across
-    whatever ``resource_type`` values that pool's resources actually have —
-    not a fixed CPU/RAM/GPU/disk set, since the site ledger's resource model
-    doesn't have fixed dimensions (see design.md's "Discovery" note carried
-    into this session's plan). The pool with the lowest bottleneck
-    utilization is selected.
+    The in-memory assignment and cursor repositories are an intermediate
+    implementation boundary. They are deliberately named for the domain
+    concepts they approximate so durable repositories can replace them
+    without changing scheduler policy or public contracts.
     """
+
+    _ACTIVE_STATES = {"reserved", "committed", "leased", "unmanaged"}
 
     def __init__(
         self,
         pool_service: ResourcePoolService,
         capacity_ledger: CapacityLedgerService,
-        session_factory: Any,
+        session_factory: Any | None = None,
+        policy: SettlementSchedulingPolicy | None = None,
     ) -> None:
+        del session_factory
         self._pool_service = pool_service
         self._capacity_ledger = capacity_ledger
-        self._session_factory = session_factory
+        self._policy = policy or DeterministicRoundRobinPolicy()
         self._lock = threading.Lock()
-        self._bindings: dict[str, SettlementResource] = {}
+        self._capacity_settlement_assignments: dict[str, SettlementResource] = {}
 
-    def has_active_binding(self, pool_id: str) -> bool:
-        """Used by ResourcePoolService's disable_pool guardrail."""
+    def get_settlement_assignment(self, allocation_id: str) -> SettlementResource | None:
         with self._lock:
-            return any(
-                resource.pool_id == pool_id for resource in self._bindings.values()
-            )
+            return self._capacity_settlement_assignments.get(allocation_id)
 
-    def select_resource(
-        self, request: PhysicalSettlementRequest
+    def record_settlement_assignment(
+        self, allocation_id: str, resource: SettlementResource
     ) -> SettlementResource:
-        """Atomically bind request.allocation_id to a settlement resource.
+        self._capacity_settlement_assignments[allocation_id] = resource
+        return resource
 
-        Repeated calls for the same allocation_id return the existing
-        binding rather than selecting another resource.
-        """
+    def select_resource(self, request: PhysicalSettlementRequest) -> SettlementResource:
         with self._lock:
-            existing = self._bindings.get(request.allocation_id)
+            allocation = self._require_valid_allocation(request)
+            existing = self._capacity_settlement_assignments.get(request.allocation_id)
             if existing is not None:
+                if request.resource_id and request.resource_id != existing.settlement_resource_id:
+                    raise SettlementRequestMismatchError(
+                        "explicit resource does not match the existing Capacity Settlement Assignment"
+                    )
                 return existing
 
+            requirement = self._requirement(allocation, request)
+            candidates = self._eligible_candidates(requirement, allocation)
             if request.resource_id is not None:
-                resource = self._bind_explicit_resource(request)
+                selected = next(
+                    (item for item in candidates if item.resource_id == request.resource_id),
+                    None,
+                )
+                if selected is None:
+                    raise NoEligibleSettlementResourceError(
+                        f"resource '{request.resource_id}' is not eligible for settlement"
+                    )
             else:
-                resource = self._bind_pool_selected_resource(request)
-
-            self._bindings[request.allocation_id] = resource
-            return resource
-
-    # ------------------------------------------------------------------
-    # Explicit resource_id path
-    # ------------------------------------------------------------------
-
-    def _bind_explicit_resource(
-        self, request: PhysicalSettlementRequest
-    ) -> SettlementResource:
-        for payload in self._capacity_ledger.list_resources():
-            if payload["resource_id"] != request.resource_id:
-                continue
-            if not payload.get("enabled"):
-                raise ResourceNotFoundError(
-                    f"resource '{request.resource_id}' is disabled"
-                )
-            pool_id = self._pool_id_for(payload)
-            return SettlementResource(
-                settlement_resource_id=payload["resource_id"],
-                pool_id=pool_id or "",
-                resource_kind=payload["resource_type"],
-                provider=self._provider_for_pool(pool_id),
-                attributes=payload.get("attributes") or {},
-            )
-        raise ResourceNotFoundError(
-            f"resource '{request.resource_id}' does not exist"
-        )
-
-    # ------------------------------------------------------------------
-    # Fungible pool-selection path
-    # ------------------------------------------------------------------
-
-    def _bind_pool_selected_resource(
-        self, request: PhysicalSettlementRequest
-    ) -> SettlementResource:
-        eligible_pool_ids = {
-            pool.id
-            for pool in self._pool_service.list_pools(enabled_only=True)
-            if request.pool_id is None or pool.id == request.pool_id
-        }
-        if not eligible_pool_ids:
-            raise NoEligiblePoolError(
-                "no enabled pool matches this request"
-                if request.pool_id is None
-                else f"pool '{request.pool_id}' does not exist or is disabled"
-            )
-
-        by_pool = self._group_resources_by_pool(eligible_pool_ids)
-        best_pool_id: str | None = None
-        best_utilization: float | None = None
-        best_resource: dict[str, Any] | None = None
-
-        for pool_id in eligible_pool_ids:
-            resources = by_pool.get(pool_id, [])
-            candidate = next(
-                (r for r in resources if r.get("enabled") and r["available_units"] > 0),
-                None,
-            )
-            if candidate is None:
-                continue
-            utilization = self._pool_bottleneck_utilization(resources)
-            if best_utilization is None or utilization < best_utilization:
-                best_pool_id, best_utilization, best_resource = (
-                    pool_id,
-                    utilization,
-                    candidate,
+                selected = self._policy.select(
+                    requirement=requirement,
+                    candidates=candidates,
                 )
 
-        if best_pool_id is None or best_resource is None:
-            raise NoEligiblePoolError(
-                "every eligible pool is disabled or exhausted"
+            resource = SettlementResource(
+                settlement_resource_id=selected.resource_id,
+                pool_id=selected.pool_id,
+                resource_kind=selected.resource_kind,
+                provider=selected.provider,
+                attributes=selected.attributes,
             )
+            return self.record_settlement_assignment(request.allocation_id, resource)
 
-        return SettlementResource(
-            settlement_resource_id=best_resource["resource_id"],
-            pool_id=best_pool_id,
-            resource_kind=best_resource["resource_type"],
-            provider=self._provider_for_pool(best_pool_id),
-            attributes=best_resource.get("attributes") or {},
-        )
+    def _require_valid_allocation(self, request: PhysicalSettlementRequest) -> dict[str, Any]:
+        allocation = self._capacity_ledger.get_allocation(request.allocation_id)
+        if allocation is None:
+            raise SettlementEntityNotFoundError(
+                f"capacity allocation '{request.allocation_id}' does not exist"
+            )
+        if allocation.get("state") not in self._ACTIVE_STATES:
+            raise SettlementRequestMismatchError(
+                f"capacity allocation '{request.allocation_id}' is not active"
+            )
+        expires = allocation.get("hold_expires_at")
+        if expires:
+            expiry = datetime.fromisoformat(str(expires).replace("Z", "+00:00"))
+            if expiry.tzinfo is None:
+                expiry = expiry.replace(tzinfo=timezone.utc)
+            if expiry <= datetime.now(timezone.utc):
+                raise CapacityReservationExpiredError(
+                    f"capacity allocation '{request.allocation_id}' has expired"
+                )
+        deal_ref = allocation.get("deal_ref") or {}
+        known_agreement = deal_ref.get("agreement_id") or deal_ref.get("deal_id")
+        if known_agreement is not None and known_agreement != request.agreement_id:
+            raise SettlementRequestMismatchError(
+                "agreement_id does not match the capacity reservation"
+            )
+        known_market = deal_ref.get("market")
+        if known_market is not None and known_market != request.market:
+            raise SettlementRequestMismatchError("market does not match the capacity reservation")
+        known_terms = deal_ref.get("terms")
+        if known_terms is not None and dict(known_terms) != request.terms:
+            raise SettlementRequestMismatchError("terms do not match the capacity reservation")
+        return allocation
 
     @staticmethod
-    def _pool_bottleneck_utilization(resources: list[dict[str, Any]]) -> float:
-        totals: dict[str, int] = {}
-        useds: dict[str, int] = {}
-        for r in resources:
-            if not r.get("enabled"):
-                continue
-            rtype = r["resource_type"]
-            total = int(r["value"])
-            available = int(r["available_units"])
-            totals[rtype] = totals.get(rtype, 0) + total
-            useds[rtype] = useds.get(rtype, 0) + max(total - available, 0)
-        if not totals:
-            return 1.0
-        return max(
-            (useds[rtype] / totals[rtype]) if totals[rtype] else 1.0
-            for rtype in totals
+    def _requirement(
+        allocation: dict[str, Any], request: PhysicalSettlementRequest
+    ) -> SettlementRequirement:
+        deal_ref = allocation.get("deal_ref") or {}
+        resource_kind = (
+            deal_ref.get("resource_kind")
+            or request.terms.get("resource_kind")
+            or "compute.gpu"
+        )
+        attributes = dict(request.terms.get("attributes") or {})
+        return SettlementRequirement(
+            resource_kind=resource_kind,
+            units=max(int(allocation.get("units") or 1), 1),
+            attributes=attributes,
         )
 
-    def _group_resources_by_pool(
-        self, eligible_pool_ids: set[str]
-    ) -> dict[str, list[dict[str, Any]]]:
-        resources = self._capacity_ledger.list_resources()
-        # attributes["vm_host"] identifies the physical host a resource rides
-        # on (legacy naming; conceptually "the host name" for any executor
-        # kind sharing this Host table). Hostless resources (e.g. an
-        # api-credits market's quota rows) never join to a pool and are
-        # correctly excluded from pool-based scheduling.
-        host_names = {
-            r["attributes"].get("vm_host")
-            for r in resources
-            if r.get("attributes")
-        }
-        host_names.discard(None)
-        with self._session_factory() as db:
-            hosts = (
-                db.query(Host).filter(Host.name.in_(host_names)).all()
-                if host_names
-                else []
-            )
-        pool_by_host = {h.name: h.pool_id for h in hosts}
-
-        grouped: dict[str, list[dict[str, Any]]] = {}
-        for r in resources:
-            host_name = (r.get("attributes") or {}).get("vm_host")
-            pool_id = pool_by_host.get(host_name)
-            if pool_id is None or pool_id not in eligible_pool_ids:
+    def _eligible_candidates(
+        self,
+        requirement: SettlementRequirement,
+        allocation: dict[str, Any],
+    ) -> list[SettlementCandidate]:
+        pools = {pool.id: pool for pool in self._pool_service.list_pools(enabled_only=True)}
+        candidates: list[SettlementCandidate] = []
+        for payload in self._capacity_ledger.list_resources():
+            attributes = dict(payload.get("attributes") or {})
+            pool_id = attributes.get("pool_id")
+            if not isinstance(pool_id, str) or pool_id not in pools:
                 continue
-            grouped.setdefault(pool_id, []).append(r)
-        return grouped
+            if not payload.get("enabled"):
+                continue
+            if payload.get("resource_type") != requirement.resource_kind:
+                continue
+            available_units = int(payload.get("available_units") or 0)
+            # The current ledger reserves against a concrete line item before
+            # POOLS-2 scheduling. Credit this allocation's own held units back
+            # during eligibility evaluation; POOLS-3 persistence will move the
+            # concrete claim into the assignment transaction.
+            if payload.get("resource_id") == allocation.get("resource_id"):
+                available_units += requirement.units
+            if available_units < requirement.units:
+                continue
+            if any(attributes.get(key) != value for key, value in requirement.attributes.items()):
+                continue
+            pool = pools[pool_id]
+            candidates.append(
+                SettlementCandidate(
+                    resource_id=payload["resource_id"],
+                    pool_id=pool_id,
+                    resource_kind=payload["resource_type"],
+                    available_units=available_units,
+                    provider=pool.provider,
+                    attributes=attributes,
+                )
+            )
+        if not candidates:
+            raise NoEligibleSettlementResourceError(
+                "no enabled pooled resource can satisfy the capacity reservation"
+            )
+        return candidates
 
-    def _pool_id_for(self, resource_payload: dict[str, Any]) -> str | None:
-        host_name = (resource_payload.get("attributes") or {}).get("vm_host")
-        if host_name is None:
-            return None
-        with self._session_factory() as db:
-            host = db.query(Host).filter(Host.name == host_name).one_or_none()
-        return host.pool_id if host else None
 
-    def _provider_for_pool(self, pool_id: str | None) -> str:
-        if pool_id is None:
-            return ""
-        pool = self._pool_service.get_pool(pool_id)
-        return pool.provider if pool else ""
+# Compatibility aliases for callers transitioning from the POOLS-2 draft.
+NoEligiblePoolError = NoEligibleSettlementResourceError
+ResourceNotFoundError = SettlementEntityNotFoundError

--- a/domains/vms/provisioning/service/src/settings.toml
+++ b/domains/vms/provisioning/service/src/settings.toml
@@ -125,6 +125,8 @@ default_pool_inventory_group = "kvm_hosts"
 lease_watchdog_enabled = true
 lease_watchdog_poll_interval_seconds = 60
 lease_watchdog_grace_period_seconds = 300
+capacity_reservation_watchdog_enabled = true
+capacity_reservation_watchdog_poll_interval_seconds = 60
 storefront_url = ""
 # Shared secret with the storefront. Dual purpose: signs the outbound
 # lease-watchdog callback to the storefront, and gates every inbound request

--- a/domains/vms/provisioning/service/src/tests/integration/conftest.py
+++ b/domains/vms/provisioning/service/src/tests/integration/conftest.py
@@ -221,6 +221,9 @@ def db_engine():
         connect_args={"check_same_thread": False},
         poolclass=StaticPool,
     )
+    # resource_pools must exist before Base's ansible_pool_configs FK resolves.
+    from market_resource_pools.db import Base as PoolsBase
+    PoolsBase.metadata.create_all(bind=engine)
     Base.metadata.create_all(bind=engine)
     # Site-ledger tables ride market_site's own metadata.
     from market_site.db import Base as SiteBase
@@ -357,8 +360,12 @@ async def client_and_queue(
         settings=mock_settings,
     )
 
-    from services.resource_pool_service import ResourcePoolService
-    resource_pool_service = ResourcePoolService(session_factory=session_factory)
+    from market_resource_pools import ResourcePoolService
+    from services.ansible_pool_config_handler import AnsiblePoolConfigHandler
+    resource_pool_service = ResourcePoolService(
+        session_factory=session_factory,
+        handlers={"ansible": AnsiblePoolConfigHandler()},
+    )
 
     job_service = AnsibleJobService(
         settings=mock_settings,
@@ -369,6 +376,24 @@ async def client_and_queue(
 
     from market_site.ledger import CapacityLedgerService
     capacity_ledger_service = CapacityLedgerService(session_factory=session_factory)
+
+    from services.physical_settlement_scheduler import PhysicalSettlementScheduler
+    physical_settlement_scheduler = PhysicalSettlementScheduler(
+        pool_service=resource_pool_service,
+        capacity_ledger=capacity_ledger_service,
+        session_factory=session_factory,
+    )
+    # Late-bound, same as container.py's _pool_has_active_binding: the
+    # guardrail needs the scheduler, the scheduler needs the pool service.
+    resource_pool_service.active_binding_check = (
+        physical_settlement_scheduler.has_active_binding
+    )
+
+    from services.capacity_reservation_watchdog import CapacityReservationWatchdog
+    capacity_reservation_watchdog = CapacityReservationWatchdog(
+        capacity_ledger_service=capacity_ledger_service,
+        settings=mock_settings,
+    )
 
     from market_site.authority import LedgerSiteAuthority
     site_authority = LedgerSiteAuthority(capacity_ledger_service)
@@ -439,6 +464,8 @@ async def client_and_queue(
     app.container.lease_lifecycle_service.override(lease_lifecycle_service)
     app.container.capacity_ledger_service.override(capacity_ledger_service)
     app.container.resource_pool_service.override(resource_pool_service)
+    app.container.physical_settlement_scheduler.override(physical_settlement_scheduler)
+    app.container.capacity_reservation_watchdog.override(capacity_reservation_watchdog)
 
     # Wire resolved module-level variables
     _container_module.resolved_job_service = job_service
@@ -451,6 +478,12 @@ async def client_and_queue(
     _container_module.resolved_lease_lifecycle_service = lease_lifecycle_service
     _container_module.resolved_capacity_ledger_service = capacity_ledger_service
     _container_module.resolved_resource_pool_service = resource_pool_service
+    _container_module.resolved_physical_settlement_scheduler = (
+        physical_settlement_scheduler
+    )
+    _container_module.resolved_capacity_reservation_watchdog = (
+        capacity_reservation_watchdog
+    )
 
     _container_module.resolved_job_queue = job_queue
     _container_module.resolved_vm_operations_service = app.container.vm_operations_service()

--- a/domains/vms/provisioning/service/src/tests/integration/conftest.py
+++ b/domains/vms/provisioning/service/src/tests/integration/conftest.py
@@ -383,11 +383,6 @@ async def client_and_queue(
         capacity_ledger=capacity_ledger_service,
         session_factory=session_factory,
     )
-    # Late-bound, same as container.py's _pool_has_active_binding: the
-    # guardrail needs the scheduler, the scheduler needs the pool service.
-    resource_pool_service.active_binding_check = (
-        physical_settlement_scheduler.has_active_binding
-    )
 
     from services.capacity_reservation_watchdog import CapacityReservationWatchdog
     capacity_reservation_watchdog = CapacityReservationWatchdog(

--- a/domains/vms/provisioning/service/src/tests/integration/test_pools_api.py
+++ b/domains/vms/provisioning/service/src/tests/integration/test_pools_api.py
@@ -151,13 +151,48 @@ class TestDeletePool:
             await client.delete_pool("does-not-exist")
         assert exc_info.value.status_code == 404
 
-    async def test_delete_default_pool_returns_400(self, client_and_queue):
+    async def test_delete_default_pool_disables_but_keeps_it_resolvable(
+        self, client_and_queue
+    ):
+        """`default` can be disabled like any other pool it just can never
+        be hard-deleted or stop being the fallback for hosts that omit pool_id.
+        See openspec/changes/pools-2-physical-settlement-scheduler/design.md,
+        decision 8."""
         client, _ = client_and_queue
 
-        with pytest.raises(ProvisioningError) as exc_info:
-            await client.delete_pool("default")
+        # The test fixture seeds "default" as a bare ResourcePool row with
+        # no matching Ansible side-table config (unlike the real migration
+        # seed). Give it one first — otherwise any update, not just
+        # disable, would 400 on missing provider_config.
+        await client.replace_pool(
+            "default",
+            PoolReplace(
+                label="Default Pool",
+                provider="ansible",
+                enabled=True,
+                policy_tags={},
+                provider_config=_ANSIBLE_CONFIG,
+            ),
+        )
 
-        assert exc_info.value.status_code == 400
+        deleted = await client.delete_pool("default")
+        assert deleted.enabled is False
+
+        # Still resolvable via GET — not gone.
+        pool = await client.get_pool("default")
+        assert pool.enabled is False
+
+        # Still the fallback for hosts that omit pool_id.
+        host = await client.register_host(
+            HostCreate(
+                name="kvm1",
+                kvm_host="10.0.0.1",
+                ssh_user="ubuntu",
+                ssh_key_type="path",
+                ssh_key_value="/key",
+            )
+        )
+        assert host.pool_id == "default"
 
 
 class TestImportAndValidatePools:

--- a/domains/vms/provisioning/service/src/tests/unit/services/test_bare_metal_lease_service.py
+++ b/domains/vms/provisioning/service/src/tests/unit/services/test_bare_metal_lease_service.py
@@ -8,6 +8,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
+from market_resource_pools.db import Base as PoolsBase
 from market_site.db import Base as SiteBase
 from market_site.ledger import (
     ALLOCATION_MODE_EXCLUSIVE,
@@ -28,6 +29,8 @@ def ledger() -> CapacityLedgerService:
         connect_args={"check_same_thread": False},
         poolclass=StaticPool,
     )
+    # resource_pools must exist before Base's ansible_pool_configs FK resolves.
+    PoolsBase.metadata.create_all(bind=engine)
     Base.metadata.create_all(bind=engine)
     SiteBase.metadata.create_all(bind=engine)
     session_factory = sessionmaker(bind=engine)

--- a/domains/vms/provisioning/service/src/tests/unit/services/test_host_service.py
+++ b/domains/vms/provisioning/service/src/tests/unit/services/test_host_service.py
@@ -40,6 +40,9 @@ def db_engine():
         connect_args={"check_same_thread": False},
         poolclass=StaticPool,
     )
+    # resource_pools must exist before Base's ansible_pool_configs FK resolves.
+    from market_resource_pools.db import Base as PoolsBase
+    PoolsBase.metadata.create_all(bind=engine)
     Base.metadata.create_all(bind=engine)
     # HostService requires pool_id to reference an existing pool. The real
     # migration always seeds "default" before hosts.pool_id can be NOT

--- a/domains/vms/provisioning/service/src/tests/unit/services/test_ledger_lease_lifecycle.py
+++ b/domains/vms/provisioning/service/src/tests/unit/services/test_ledger_lease_lifecycle.py
@@ -40,6 +40,9 @@ def session_factory():
         connect_args={"check_same_thread": False},
         poolclass=StaticPool,
     )
+    # resource_pools must exist before Base's ansible_pool_configs FK resolves.
+    from market_resource_pools.db import Base as PoolsBase
+    PoolsBase.metadata.create_all(bind=engine)
     Base.metadata.create_all(bind=engine)
     # Site-ledger tables ride market_site's own metadata.
     from market_site.db import Base as SiteBase

--- a/domains/vms/provisioning/service/src/tests/unit/services/test_physical_settlement_scheduler.py
+++ b/domains/vms/provisioning/service/src/tests/unit/services/test_physical_settlement_scheduler.py
@@ -1,238 +1,176 @@
-"""Unit tests for PhysicalSettlementScheduler.
-
-Covers: idempotency by allocation_id, disabled/exhausted pool exclusion,
-explicit resource_id binding without substitution, no-match errors, and
-dimension-agnostic bottleneck-normalized pool selection.
-"""
+"""Unit tests for deterministic Capacity Settlement Assignment scheduling."""
 
 from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
-from compute_provisioning import PhysicalSettlementRequest
-from db.models import Base, Host
+from compute_provisioning import (
+    CapacityReservationExpiredError,
+    NoEligibleSettlementResourceError,
+    PhysicalSettlementRequest,
+    SettlementEntityNotFoundError,
+    SettlementRequestMismatchError,
+)
 from market_resource_pools import PoolCreate, ResourcePoolService
 from market_resource_pools.db import Base as PoolsBase
 from market_site.db import Base as SiteBase
 from market_site.ledger import CapacityLedgerService
-from services.physical_settlement_scheduler import (
-    NoEligiblePoolError,
-    PhysicalSettlementScheduler,
-    ResourceNotFoundError,
-)
+from services.physical_settlement_scheduler import PhysicalSettlementScheduler
 
 
-class _StubPoolConfigHandler:
+class _Handler:
     provider = "ansible"
-
-    def validate_config(self, config):
-        return dict(config)
-
-    def validate_config_problems(self, config):
-        return dict(config), ()
-
-    def read_config(self, db, pool_id):
-        return {}
-
-    def replace_config(self, db, pool_id, config):
-        pass
-
-    def delete_config(self, db, pool_id):
-        pass
+    def validate_config(self, config): return dict(config)
+    def validate_config_problems(self, config): return dict(config), ()
+    def read_config(self, db, pool_id): return {}
+    def replace_config(self, db, pool_id, config): pass
+    def delete_config(self, db, pool_id): pass
 
 
 @pytest.fixture
-def session_factory():
+def services():
     engine = create_engine(
         "sqlite:///:memory:",
         connect_args={"check_same_thread": False},
         poolclass=StaticPool,
     )
-    # resource_pools must exist before Base's Host.pool_id FK resolves.
     PoolsBase.metadata.create_all(bind=engine)
-    Base.metadata.create_all(bind=engine)
     SiteBase.metadata.create_all(bind=engine)
-    return sessionmaker(bind=engine)
+    factory = sessionmaker(bind=engine)
+    pools = ResourcePoolService(factory, {"ansible": _Handler()})
+    ledger = CapacityLedgerService(factory)
+    scheduler = PhysicalSettlementScheduler(pools, ledger)
+    return pools, ledger, scheduler
 
 
-@pytest.fixture
-def pool_service(session_factory):
-    return ResourcePoolService(
-        session_factory=session_factory,
-        handlers={"ansible": _StubPoolConfigHandler()},
+def _pool(pools, pool_id: str, enabled: bool = True):
+    pools.create_pool(PoolCreate(
+        id=pool_id, label=pool_id, provider="ansible", enabled=enabled,
+        provider_config={},
+    ))
+
+
+def _resource(ledger, resource_id: str, pool_id: str, *, units: int = 4, enabled=True):
+    ledger.register_resource(
+        resource_id=resource_id,
+        resource_type="compute.gpu",
+        total_units=units,
+        enabled=enabled,
+        attributes={"pool_id": pool_id},
     )
 
 
-@pytest.fixture
-def capacity_ledger(session_factory):
-    return CapacityLedgerService(session_factory=session_factory)
+def _reserve(ledger, agreement="agreement-1", **deal):
+    ref = {"agreement_id": agreement, "market": "vms", **deal}
+    result = ledger.reserve(claim={"gpu_count": 1}, deal_ref=ref)
+    assert result is not None
+    return result["allocation_id"]
 
 
-@pytest.fixture
-def scheduler(pool_service, capacity_ledger, session_factory):
-    return PhysicalSettlementScheduler(
-        pool_service=pool_service,
-        capacity_ledger=capacity_ledger,
-        session_factory=session_factory,
-    )
-
-
-def _add_host(session_factory, name: str, pool_id: str) -> None:
-    with session_factory() as db:
-        db.add(Host(
-            name=name, kvm_host="10.0.0.1", ssh_user="ubuntu",
-            ssh_key_type="path", ssh_key_value="/key", pool_id=pool_id,
-        ))
-        db.commit()
-
-
-def _request(allocation_id="alloc-1", **kwargs) -> PhysicalSettlementRequest:
+def _request(allocation_id: str, **kwargs):
     return PhysicalSettlementRequest(
-        allocation_id=allocation_id, agreement_id="agree-1", market="vms", **kwargs
+        allocation_id=allocation_id,
+        agreement_id=kwargs.pop("agreement_id", "agreement-1"),
+        market="vms",
+        **kwargs,
     )
 
 
-class TestIdempotency:
-    def test_repeated_calls_return_the_same_binding(
-        self, scheduler, pool_service, capacity_ledger, session_factory
-    ):
-        pool_service.create_pool(
-            PoolCreate(id="pool-a", label="A", provider="ansible", provider_config={})
-        )
-        _add_host(session_factory, "kvm1", "pool-a")
-        capacity_ledger.register_resource(
-            resource_id="kvm1", total_units=4, attributes={"vm_host": "kvm1"},
-        )
-
-        first = scheduler.select_resource(_request())
-        second = scheduler.select_resource(_request())
-        assert first == second
-        assert first.settlement_resource_id == "kvm1"
-        assert first.pool_id == "pool-a"
+def test_unknown_allocation_is_rejected(services):
+    _, _, scheduler = services
+    with pytest.raises(SettlementEntityNotFoundError):
+        scheduler.select_resource(_request("missing"))
 
 
-class TestPoolExclusion:
-    def test_disabled_pool_is_excluded(
-        self, scheduler, pool_service, capacity_ledger, session_factory
-    ):
-        pool_service.create_pool(
-            PoolCreate(id="pool-a", label="A", provider="ansible", provider_config={})
-        )
-        pool_service.disable_pool("pool-a")
-        _add_host(session_factory, "kvm1", "pool-a")
-        capacity_ledger.register_resource(
-            resource_id="kvm1", total_units=4, attributes={"vm_host": "kvm1"},
-        )
-
-        with pytest.raises(NoEligiblePoolError):
-            scheduler.select_resource(_request())
-
-    def test_exhausted_pool_is_excluded(
-        self, scheduler, pool_service, capacity_ledger, session_factory
-    ):
-        pool_service.create_pool(
-            PoolCreate(id="pool-a", label="A", provider="ansible", provider_config={})
-        )
-        _add_host(session_factory, "kvm1", "pool-a")
-        capacity_ledger.register_resource(
-            resource_id="kvm1", total_units=1, attributes={"vm_host": "kvm1"},
-        )
-        capacity_ledger.reserve(claim={"gpu_count": 1}, deal_ref={"escrow_uid": "0x1"})
-
-        with pytest.raises(NoEligiblePoolError):
-            scheduler.select_resource(_request())
-
-    def test_explicit_pool_id_restricts_selection(
-        self, scheduler, pool_service, capacity_ledger, session_factory
-    ):
-        pool_service.create_pool(
-            PoolCreate(id="pool-a", label="A", provider="ansible", provider_config={})
-        )
-        pool_service.create_pool(
-            PoolCreate(id="pool-b", label="B", provider="ansible", provider_config={})
-        )
-        _add_host(session_factory, "kvm1", "pool-a")
-        _add_host(session_factory, "kvm2", "pool-b")
-        capacity_ledger.register_resource(
-            resource_id="kvm1", total_units=4, attributes={"vm_host": "kvm1"},
-        )
-        capacity_ledger.register_resource(
-            resource_id="kvm2", total_units=4, attributes={"vm_host": "kvm2"},
-        )
-
-        bound = scheduler.select_resource(_request(pool_id="pool-b"))
-        assert bound.pool_id == "pool-b"
-        assert bound.settlement_resource_id == "kvm2"
+def test_agreement_mismatch_is_rejected(services):
+    pools, ledger, scheduler = services
+    _pool(pools, "pool-a")
+    _resource(ledger, "r1", "pool-a")
+    allocation_id = _reserve(ledger)
+    with pytest.raises(SettlementRequestMismatchError):
+        scheduler.select_resource(_request(allocation_id, agreement_id="other"))
 
 
-class TestExplicitResourceId:
-    def test_binds_exactly_the_requested_resource(
-        self, scheduler, pool_service, capacity_ledger, session_factory
-    ):
-        pool_service.create_pool(
-            PoolCreate(id="pool-a", label="A", provider="ansible", provider_config={})
-        )
-        _add_host(session_factory, "kvm1", "pool-a")
-        capacity_ledger.register_resource(
-            resource_id="kvm1", total_units=4, attributes={"vm_host": "kvm1"},
-        )
-
-        bound = scheduler.select_resource(_request(resource_id="kvm1"))
-        assert bound.settlement_resource_id == "kvm1"
-        assert bound.pool_id == "pool-a"
-
-    def test_unknown_resource_id_raises(self, scheduler):
-        with pytest.raises(ResourceNotFoundError):
-            scheduler.select_resource(_request(resource_id="does-not-exist"))
-
-    def test_disabled_resource_raises(
-        self, scheduler, pool_service, capacity_ledger, session_factory
-    ):
-        pool_service.create_pool(
-            PoolCreate(id="pool-a", label="A", provider="ansible", provider_config={})
-        )
-        _add_host(session_factory, "kvm1", "pool-a")
-        capacity_ledger.register_resource(
-            resource_id="kvm1", total_units=4, attributes={"vm_host": "kvm1"},
-            enabled=False,
-        )
-
-        with pytest.raises(ResourceNotFoundError):
-            scheduler.select_resource(_request(resource_id="kvm1"))
+def test_expired_reservation_is_rejected(services):
+    pools, ledger, scheduler = services
+    _pool(pools, "pool-a")
+    _resource(ledger, "r1", "pool-a")
+    result = ledger.reserve(
+        claim={"gpu_count": 1},
+        deal_ref={"agreement_id": "agreement-1", "market": "vms"},
+        ttl_seconds=-1,
+    )
+    with pytest.raises((CapacityReservationExpiredError, SettlementRequestMismatchError)):
+        scheduler.select_resource(_request(result["allocation_id"]))
 
 
-class TestBottleneckNormalizedSelection:
-    def test_prefers_pool_with_lower_bottleneck_dimension(
-        self, scheduler, pool_service, capacity_ledger, session_factory
-    ):
-        """pool-a is 90% utilized on one resource_type; pool-b is 50%
-        utilized. Even though both pools have only one resource each,
-        this exercises the utilization comparison rather than a
-        first-match/round-robin fallback."""
-        pool_service.create_pool(
-            PoolCreate(id="pool-a", label="A", provider="ansible", provider_config={})
-        )
-        pool_service.create_pool(
-            PoolCreate(id="pool-b", label="B", provider="ansible", provider_config={})
-        )
-        _add_host(session_factory, "kvm1", "pool-a")
-        _add_host(session_factory, "kvm2", "pool-b")
-        capacity_ledger.register_resource(
-            resource_id="kvm1", total_units=10, attributes={"vm_host": "kvm1"},
-        )
-        capacity_ledger.register_resource(
-            resource_id="kvm2", total_units=10, attributes={"vm_host": "kvm2"},
-        )
-        # Reserve 9/10 on kvm1 (pool-a) — 90% utilized. Pinned by
-        # resource_id so the test doesn't depend on the ledger's own
-        # candidate-selection order between two equally-sized resources.
-        capacity_ledger.reserve(
-            claim={"gpu_count": 9, "resource_id": "kvm1"},
-            deal_ref={"escrow_uid": "0xa"},
-        )
+def test_retry_is_idempotent_and_does_not_rerun_policy(services):
+    pools, ledger, scheduler = services
+    _pool(pools, "pool-a")
+    _pool(pools, "pool-b")
+    _resource(ledger, "a1", "pool-a")
+    _resource(ledger, "b1", "pool-b")
+    allocation_id = _reserve(ledger)
+    first = scheduler.select_resource(_request(allocation_id))
+    second = scheduler.select_resource(_request(allocation_id))
+    assert first == second
 
-        bound = scheduler.select_resource(_request())
-        assert bound.pool_id == "pool-b"
+
+def test_round_robin_is_deterministic_across_pools(services):
+    pools, ledger, scheduler = services
+    _pool(pools, "pool-a")
+    _pool(pools, "pool-b")
+    _resource(ledger, "a1", "pool-a", units=10)
+    _resource(ledger, "b1", "pool-b", units=10)
+    ids = [_reserve(ledger, agreement=f"agreement-{i}") for i in range(1, 4)]
+    selected = [
+        scheduler.select_resource(_request(aid, agreement_id=f"agreement-{i}" )).pool_id
+        for i, aid in enumerate(ids, 1)
+    ]
+    assert selected == ["pool-a", "pool-b", "pool-a"]
+
+
+def test_round_robin_is_deterministic_within_pool(services):
+    pools, ledger, scheduler = services
+    _pool(pools, "pool-a")
+    _resource(ledger, "r1", "pool-a", units=10)
+    _resource(ledger, "r2", "pool-a", units=10)
+    ids = [_reserve(ledger, agreement=f"agreement-{i}") for i in range(1, 3)]
+    selected = [
+        scheduler.select_resource(_request(aid, agreement_id=f"agreement-{i}")).settlement_resource_id
+        for i, aid in enumerate(ids, 1)
+    ]
+    assert selected == ["r1", "r2"]
+
+
+def test_explicit_resource_bypasses_policy_not_eligibility(services):
+    pools, ledger, scheduler = services
+    _pool(pools, "pool-a", enabled=False)
+    _resource(ledger, "r1", "pool-a")
+    allocation_id = _reserve(ledger)
+    with pytest.raises(NoEligibleSettlementResourceError):
+        scheduler.select_resource(_request(allocation_id, resource_id="r1"))
+
+
+def test_resource_without_pool_is_not_schedulable(services):
+    pools, ledger, scheduler = services
+    _pool(pools, "pool-a")
+    ledger.register_resource(resource_id="orphan", total_units=4, attributes={})
+    allocation_id = _reserve(ledger)
+    with pytest.raises(NoEligibleSettlementResourceError):
+        scheduler.select_resource(_request(allocation_id))
+
+
+def test_disabling_pool_does_not_depend_on_existing_assignment(services):
+    pools, ledger, scheduler = services
+    _pool(pools, "pool-a")
+    _resource(ledger, "r1", "pool-a")
+    allocation_id = _reserve(ledger)
+    scheduler.select_resource(_request(allocation_id))
+    disabled = pools.disable_pool("pool-a")
+    assert disabled.enabled is False

--- a/domains/vms/provisioning/service/src/tests/unit/services/test_physical_settlement_scheduler.py
+++ b/domains/vms/provisioning/service/src/tests/unit/services/test_physical_settlement_scheduler.py
@@ -1,0 +1,238 @@
+"""Unit tests for PhysicalSettlementScheduler.
+
+Covers: idempotency by allocation_id, disabled/exhausted pool exclusion,
+explicit resource_id binding without substitution, no-match errors, and
+dimension-agnostic bottleneck-normalized pool selection.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from compute_provisioning import PhysicalSettlementRequest
+from db.models import Base, Host
+from market_resource_pools import PoolCreate, ResourcePoolService
+from market_resource_pools.db import Base as PoolsBase
+from market_site.db import Base as SiteBase
+from market_site.ledger import CapacityLedgerService
+from services.physical_settlement_scheduler import (
+    NoEligiblePoolError,
+    PhysicalSettlementScheduler,
+    ResourceNotFoundError,
+)
+
+
+class _StubPoolConfigHandler:
+    provider = "ansible"
+
+    def validate_config(self, config):
+        return dict(config)
+
+    def validate_config_problems(self, config):
+        return dict(config), ()
+
+    def read_config(self, db, pool_id):
+        return {}
+
+    def replace_config(self, db, pool_id, config):
+        pass
+
+    def delete_config(self, db, pool_id):
+        pass
+
+
+@pytest.fixture
+def session_factory():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    # resource_pools must exist before Base's Host.pool_id FK resolves.
+    PoolsBase.metadata.create_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    SiteBase.metadata.create_all(bind=engine)
+    return sessionmaker(bind=engine)
+
+
+@pytest.fixture
+def pool_service(session_factory):
+    return ResourcePoolService(
+        session_factory=session_factory,
+        handlers={"ansible": _StubPoolConfigHandler()},
+    )
+
+
+@pytest.fixture
+def capacity_ledger(session_factory):
+    return CapacityLedgerService(session_factory=session_factory)
+
+
+@pytest.fixture
+def scheduler(pool_service, capacity_ledger, session_factory):
+    return PhysicalSettlementScheduler(
+        pool_service=pool_service,
+        capacity_ledger=capacity_ledger,
+        session_factory=session_factory,
+    )
+
+
+def _add_host(session_factory, name: str, pool_id: str) -> None:
+    with session_factory() as db:
+        db.add(Host(
+            name=name, kvm_host="10.0.0.1", ssh_user="ubuntu",
+            ssh_key_type="path", ssh_key_value="/key", pool_id=pool_id,
+        ))
+        db.commit()
+
+
+def _request(allocation_id="alloc-1", **kwargs) -> PhysicalSettlementRequest:
+    return PhysicalSettlementRequest(
+        allocation_id=allocation_id, agreement_id="agree-1", market="vms", **kwargs
+    )
+
+
+class TestIdempotency:
+    def test_repeated_calls_return_the_same_binding(
+        self, scheduler, pool_service, capacity_ledger, session_factory
+    ):
+        pool_service.create_pool(
+            PoolCreate(id="pool-a", label="A", provider="ansible", provider_config={})
+        )
+        _add_host(session_factory, "kvm1", "pool-a")
+        capacity_ledger.register_resource(
+            resource_id="kvm1", total_units=4, attributes={"vm_host": "kvm1"},
+        )
+
+        first = scheduler.select_resource(_request())
+        second = scheduler.select_resource(_request())
+        assert first == second
+        assert first.settlement_resource_id == "kvm1"
+        assert first.pool_id == "pool-a"
+
+
+class TestPoolExclusion:
+    def test_disabled_pool_is_excluded(
+        self, scheduler, pool_service, capacity_ledger, session_factory
+    ):
+        pool_service.create_pool(
+            PoolCreate(id="pool-a", label="A", provider="ansible", provider_config={})
+        )
+        pool_service.disable_pool("pool-a")
+        _add_host(session_factory, "kvm1", "pool-a")
+        capacity_ledger.register_resource(
+            resource_id="kvm1", total_units=4, attributes={"vm_host": "kvm1"},
+        )
+
+        with pytest.raises(NoEligiblePoolError):
+            scheduler.select_resource(_request())
+
+    def test_exhausted_pool_is_excluded(
+        self, scheduler, pool_service, capacity_ledger, session_factory
+    ):
+        pool_service.create_pool(
+            PoolCreate(id="pool-a", label="A", provider="ansible", provider_config={})
+        )
+        _add_host(session_factory, "kvm1", "pool-a")
+        capacity_ledger.register_resource(
+            resource_id="kvm1", total_units=1, attributes={"vm_host": "kvm1"},
+        )
+        capacity_ledger.reserve(claim={"gpu_count": 1}, deal_ref={"escrow_uid": "0x1"})
+
+        with pytest.raises(NoEligiblePoolError):
+            scheduler.select_resource(_request())
+
+    def test_explicit_pool_id_restricts_selection(
+        self, scheduler, pool_service, capacity_ledger, session_factory
+    ):
+        pool_service.create_pool(
+            PoolCreate(id="pool-a", label="A", provider="ansible", provider_config={})
+        )
+        pool_service.create_pool(
+            PoolCreate(id="pool-b", label="B", provider="ansible", provider_config={})
+        )
+        _add_host(session_factory, "kvm1", "pool-a")
+        _add_host(session_factory, "kvm2", "pool-b")
+        capacity_ledger.register_resource(
+            resource_id="kvm1", total_units=4, attributes={"vm_host": "kvm1"},
+        )
+        capacity_ledger.register_resource(
+            resource_id="kvm2", total_units=4, attributes={"vm_host": "kvm2"},
+        )
+
+        bound = scheduler.select_resource(_request(pool_id="pool-b"))
+        assert bound.pool_id == "pool-b"
+        assert bound.settlement_resource_id == "kvm2"
+
+
+class TestExplicitResourceId:
+    def test_binds_exactly_the_requested_resource(
+        self, scheduler, pool_service, capacity_ledger, session_factory
+    ):
+        pool_service.create_pool(
+            PoolCreate(id="pool-a", label="A", provider="ansible", provider_config={})
+        )
+        _add_host(session_factory, "kvm1", "pool-a")
+        capacity_ledger.register_resource(
+            resource_id="kvm1", total_units=4, attributes={"vm_host": "kvm1"},
+        )
+
+        bound = scheduler.select_resource(_request(resource_id="kvm1"))
+        assert bound.settlement_resource_id == "kvm1"
+        assert bound.pool_id == "pool-a"
+
+    def test_unknown_resource_id_raises(self, scheduler):
+        with pytest.raises(ResourceNotFoundError):
+            scheduler.select_resource(_request(resource_id="does-not-exist"))
+
+    def test_disabled_resource_raises(
+        self, scheduler, pool_service, capacity_ledger, session_factory
+    ):
+        pool_service.create_pool(
+            PoolCreate(id="pool-a", label="A", provider="ansible", provider_config={})
+        )
+        _add_host(session_factory, "kvm1", "pool-a")
+        capacity_ledger.register_resource(
+            resource_id="kvm1", total_units=4, attributes={"vm_host": "kvm1"},
+            enabled=False,
+        )
+
+        with pytest.raises(ResourceNotFoundError):
+            scheduler.select_resource(_request(resource_id="kvm1"))
+
+
+class TestBottleneckNormalizedSelection:
+    def test_prefers_pool_with_lower_bottleneck_dimension(
+        self, scheduler, pool_service, capacity_ledger, session_factory
+    ):
+        """pool-a is 90% utilized on one resource_type; pool-b is 50%
+        utilized. Even though both pools have only one resource each,
+        this exercises the utilization comparison rather than a
+        first-match/round-robin fallback."""
+        pool_service.create_pool(
+            PoolCreate(id="pool-a", label="A", provider="ansible", provider_config={})
+        )
+        pool_service.create_pool(
+            PoolCreate(id="pool-b", label="B", provider="ansible", provider_config={})
+        )
+        _add_host(session_factory, "kvm1", "pool-a")
+        _add_host(session_factory, "kvm2", "pool-b")
+        capacity_ledger.register_resource(
+            resource_id="kvm1", total_units=10, attributes={"vm_host": "kvm1"},
+        )
+        capacity_ledger.register_resource(
+            resource_id="kvm2", total_units=10, attributes={"vm_host": "kvm2"},
+        )
+        # Reserve 9/10 on kvm1 (pool-a) — 90% utilized. Pinned by
+        # resource_id so the test doesn't depend on the ledger's own
+        # candidate-selection order between two equally-sized resources.
+        capacity_ledger.reserve(
+            claim={"gpu_count": 9, "resource_id": "kvm1"},
+            deal_ref={"escrow_uid": "0xa"},
+        )
+
+        bound = scheduler.select_resource(_request())
+        assert bound.pool_id == "pool-b"

--- a/domains/vms/provisioning/service/src/tests/unit/services/test_resource_pool_service.py
+++ b/domains/vms/provisioning/service/src/tests/unit/services/test_resource_pool_service.py
@@ -1,0 +1,4 @@
+DELETE THIS FILE
+
+ResourcePoolService tests moved to kit/resource-pools/tests/unit.
+This tombstone is intentionally included so the obsolete file is deleted manually.

--- a/domains/vms/provisioning/service/src/tests/unit/services/test_resource_pool_service.py
+++ b/domains/vms/provisioning/service/src/tests/unit/services/test_resource_pool_service.py
@@ -1,4 +1,0 @@
-DELETE THIS FILE
-
-ResourcePoolService tests moved to kit/resource-pools/tests/unit.
-This tombstone is intentionally included so the obsolete file is deleted manually.

--- a/domains/vms/provisioning/service/src/tests/unit/test_database.py
+++ b/domains/vms/provisioning/service/src/tests/unit/test_database.py
@@ -5,7 +5,7 @@ from sqlalchemy.pool import StaticPool
 
 from db.database import run_migrations
 from db.migrations import SchemaDriftError, check_schema_version
-from db.models import AnsibleJob, DEFAULT_POOL_ID, Host, ResourcePool
+from db.models import AnsibleJob, AnsiblePoolConfig, DEFAULT_POOL_ID, Host, ResourcePool
 
 
 def _sqlite_memory_engine():
@@ -132,9 +132,18 @@ def test_run_migrations_applies_versioned_migrations_to_old_sqlite_schema():
         assert default_pool.label == "Default Pool"
         assert default_pool.provider == "ansible"
         assert default_pool.enabled is True
-        assert default_pool.ansible_config.playbook_path == "/configured/playbook.yaml"
-        assert default_pool.ansible_config.inventory_group == "legacy_hosts"
-        assert default_pool.ansible_config.extra_vars == {}
+
+        # No ORM relationship crosses the resource_pools/ansible_pool_configs
+        # boundary — ResourcePool and AnsiblePoolConfig now live in separate
+        # declarative registries (market_resource_pools vs. this service's
+        # own Base), so navigation is by explicit pool_id lookup, matching
+        # how PoolConfigHandler implementations already read this table.
+        ansible_config = session.query(AnsiblePoolConfig).filter(
+            AnsiblePoolConfig.pool_id == DEFAULT_POOL_ID
+        ).one()
+        assert ansible_config.playbook_path == "/configured/playbook.yaml"
+        assert ansible_config.inventory_group == "legacy_hosts"
+        assert ansible_config.extra_vars == {}
 
     with engine.begin() as connection:
         migration_ids = {

--- a/domains/vms/provisioning/service/uv.lock
+++ b/domains/vms/provisioning/service/uv.lock
@@ -142,39 +142,64 @@ wheels = [
 
 [[package]]
 name = "arkhai-bare-metal"
-version = "0.1.0"
+version = "0.2.0"
 source = { registry = "../../../../.dist" }
 dependencies = [
+    { name = "arkhai-core" },
     { name = "pydantic" },
 ]
-sdist = { path = "arkhai_bare_metal-0.1.0.tar.gz" }
 wheels = [
-    { path = "arkhai_bare_metal-0.1.0-py3-none-any.whl" },
+    { path = "arkhai_bare_metal-0.2.0-py3-none-any.whl" },
 ]
 
 [[package]]
 name = "arkhai-compute-provisioning"
-version = "0.4.0"
+version = "0.5.0"
 source = { registry = "../../../../.dist" }
 dependencies = [
+    { name = "arkhai-kit-resource-pools" },
     { name = "arkhai-kit-site" },
     { name = "httpx" },
     { name = "pydantic" },
 ]
 wheels = [
-    { path = "arkhai_compute_provisioning-0.4.0-py3-none-any.whl" },
+    { path = "arkhai_compute_provisioning-0.5.0-py3-none-any.whl" },
+]
+
+[[package]]
+name = "arkhai-core"
+version = "0.2.0"
+source = { registry = "../../../../.dist" }
+dependencies = [
+    { name = "pydantic" },
+]
+wheels = [
+    { path = "arkhai_core-0.2.0-py3-none-any.whl" },
 ]
 
 [[package]]
 name = "arkhai-core-storefront-client"
-version = "0.15.0"
+version = "0.16.0"
 source = { registry = "../../../../.dist" }
 dependencies = [
     { name = "eth-account" },
     { name = "httpx" },
 ]
 wheels = [
-    { path = "arkhai_core_storefront_client-0.15.0-py3-none-any.whl" },
+    { path = "arkhai_core_storefront_client-0.16.0-py3-none-any.whl" },
+]
+
+[[package]]
+name = "arkhai-kit-resource-pools"
+version = "0.1.0"
+source = { registry = "../../../../.dist" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "sqlalchemy" },
+]
+wheels = [
+    { path = "arkhai_kit_resource_pools-0.1.0-py3-none-any.whl" },
 ]
 
 [[package]]
@@ -199,6 +224,7 @@ dependencies = [
     { name = "arkhai-bare-metal" },
     { name = "arkhai-compute-provisioning" },
     { name = "arkhai-core-storefront-client" },
+    { name = "arkhai-kit-resource-pools" },
     { name = "arkhai-kit-site" },
     { name = "arkhai-vms-provisioning-operator-client" },
     { name = "cachetools" },
@@ -227,8 +253,9 @@ dev = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.9" },
     { name = "arkhai-bare-metal", specifier = ">=0.1.0" },
-    { name = "arkhai-compute-provisioning", specifier = ">=0.4.0" },
+    { name = "arkhai-compute-provisioning", specifier = ">=0.5.0" },
     { name = "arkhai-core-storefront-client", specifier = ">=0.11.0" },
+    { name = "arkhai-kit-resource-pools", specifier = ">=0.1.0" },
     { name = "arkhai-kit-site", specifier = ">=0.2.0" },
     { name = "arkhai-vms-provisioning-operator-client", specifier = ">=0.3.0" },
     { name = "cachetools", specifier = ">=5.3" },
@@ -909,9 +936,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/32/f2ce6d4cac3e55bc6173f92dbe627e782e1850f89d986c3606feb63aafa7/greenlet-3.5.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:db2910d3c809444e0a20147361f343fe2798e106af8d9d8506f5305302655a9f", size = 286228, upload-time = "2026-04-27T12:20:34.421Z" },
     { url = "https://files.pythonhosted.org/packages/b7/aa/caed9e5adf742315fc7be2a84196373aab4816e540e38ba0d76cb7584d68/greenlet-3.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ec9ea74e7268ace7f9aab1b1a4e730193fc661b39a993cd91c606c32d4a3628", size = 601775, upload-time = "2026-04-27T12:52:41.045Z" },
     { url = "https://files.pythonhosted.org/packages/c7/af/90ae08497400a941595d12774447f752d3dfe0fbb012e35b76bc5c0ff37e/greenlet-3.5.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54d243512da35485fc7a6bf3c178fdda6327a9d6506fcdd62b1abd1e41b2927b", size = 614436, upload-time = "2026-04-27T12:59:41.595Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/e9/4eeadf8cb3403ac274245ba75f07844abc7fa5f6787583fc9156ba741e0f/greenlet-3.5.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:41353ec2ecedf7aa8f682753a41919f8718031a6edac46b8d3dc7ed9e1ceb136", size = 620610, upload-time = "2026-04-27T13:02:39.194Z" },
     { url = "https://files.pythonhosted.org/packages/2b/e0/2e13df68f367e2f9960616927d60857dd7e56aaadd59a47c644216b2f920/greenlet-3.5.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d280a7f5c331622c69f97eb167f33577ff2d1df282c41cd15907fc0a3ca198c", size = 611388, upload-time = "2026-04-27T12:25:28.008Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/ef/f913b3c0eb7d26d86a2401c5e1546c9d46b657efee724b06f6f4ac5d8824/greenlet-3.5.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:58c1c374fe2b3d852f9b6b11a7dff4c85404e51b9a596fd9e89cf904eb09866d", size = 422775, upload-time = "2026-04-27T13:05:14.261Z" },
     { url = "https://files.pythonhosted.org/packages/82/f7/393c64055132ac0d488ef6be549253b7e6274194863967ddc0bc8f5b87b8/greenlet-3.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1eb67d5adefb5bd2e182d42678a328979a209e4e82eb93575708185d31d1f588", size = 1570768, upload-time = "2026-04-27T12:53:28.099Z" },
     { url = "https://files.pythonhosted.org/packages/b8/4b/eaf7735253522cf56d1b74d672a58f54fc114702ceaf05def59aae72f6e1/greenlet-3.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2628d6c86f6cb0cb45e0c3c54058bbec559f57eaae699447748cb3928150577e", size = 1635983, upload-time = "2026-04-27T12:25:26.903Z" },
     { url = "https://files.pythonhosted.org/packages/4c/fe/4fb3a0805bd5165da5ebf858da7cc01cce8061674106d2cf5bdab32cbfde/greenlet-3.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:d4d9f0624c775f2dfc56ba54d515a8c771044346852a918b405914f6b19d7fd8", size = 238840, upload-time = "2026-04-27T12:23:54.806Z" },
@@ -919,9 +944,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/58/fc576f99037ce19c5aa16628e4c3226b6d1419f72a62c79f5f40576e6eb3/greenlet-3.5.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:5a5ed18de6a0f6cc7087f1563f6bd93fc7df1c19165ca01e9bde5a5dc281d106", size = 285066, upload-time = "2026-04-27T12:23:05.033Z" },
     { url = "https://files.pythonhosted.org/packages/4a/ba/b28ddbe6bfad6a8ac196ef0e8cff37bc65b79735995b9e410923fffeeb70/greenlet-3.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a717fbc46d8a354fa675f7c1e813485b6ba3885f9bef0cd56e5ba27d758ff5b", size = 604414, upload-time = "2026-04-27T12:52:42.358Z" },
     { url = "https://files.pythonhosted.org/packages/09/06/4b69f8f0b67603a8be2790e55107a190b376f2627fe0eaf5695d85ffb3cd/greenlet-3.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ddc090c5c1792b10246a78e8c2163ebbe04cf877f9d785c230a7b27b39ad038e", size = 617349, upload-time = "2026-04-27T12:59:43.32Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/15/a643b4ecd09969e30b8a150d5919960caae0abe4f5af75ab040b1ab85e78/greenlet-3.5.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4964101b8585c144cbda5532b1aa644255126c08a265dae90c16e7a0e63aaa9d", size = 623234, upload-time = "2026-04-27T13:02:40.611Z" },
     { url = "https://files.pythonhosted.org/packages/8a/17/a3918541fd0ddefe024a69de6d16aa7b46d36ac19562adaa63c7fa180eff/greenlet-3.5.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2094acd54b272cb6eae8c03dd87b3fa1820a4cef18d6889c378d503500a1dc13", size = 613927, upload-time = "2026-04-27T12:25:30.28Z" },
-    { url = "https://files.pythonhosted.org/packages/77/18/3b13d5ef1275b0ffaf933b05efa21408ac4ca95823c7411d79682e4fdcff/greenlet-3.5.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:7022615368890680e67b9965d33f5773aade330d5343bbe25560135aaa849eae", size = 425243, upload-time = "2026-04-27T13:05:15.689Z" },
     { url = "https://files.pythonhosted.org/packages/ee/e1/bd0af6213c7dd33175d8a462d4c1fe1175124ebed4855bc1475a5b5242c2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5e05ba267789ea87b5a155cf0e810b1ab88bf18e9e8740813945ceb8ee4350ba", size = 1570893, upload-time = "2026-04-27T12:53:29.483Z" },
     { url = "https://files.pythonhosted.org/packages/9b/2a/0789702f864f5382cb476b93d7a9c823c10472658102ccd65f415747d2e2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0ecec963079cd58cbd14723582384f11f166fd58883c15dcbfb342e0bc9b5846", size = 1636060, upload-time = "2026-04-27T12:25:28.845Z" },
     { url = "https://files.pythonhosted.org/packages/b2/8f/22bf9df92bbff0eb07842b60f7e63bf7675a9742df628437a9f02d09137f/greenlet-3.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:728d9667d8f2f586644b748dbd9bb67e50d6a9381767d1357714ea6825bb3bf5", size = 238740, upload-time = "2026-04-27T12:24:01.341Z" },
@@ -929,9 +952,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/94/5e/a70f31e3e8d961c4ce589c15b28e4225d63704e431a23932a3808cbcc867/greenlet-3.5.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:f35807464c4c58c55f0d31dfa83c541a5615d825c2fe3d2b95360cf7c4e3c0a8", size = 285564, upload-time = "2026-04-27T12:23:08.555Z" },
     { url = "https://files.pythonhosted.org/packages/af/a6/046c0a28e21833e4086918218cfb3d8bed51c075a1b700f20b9d7861c0f4/greenlet-3.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55fa7ea52771be44af0de27d8b80c02cd18c2c3cddde6c847ecebdf72418b6a1", size = 651166, upload-time = "2026-04-27T12:52:43.644Z" },
     { url = "https://files.pythonhosted.org/packages/47/f8/4af27f71c5ff32a7fbc516adb46370d9c4ae2bc7bd3dc7d066ac542b4b15/greenlet-3.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a97e4821aa710603f94de0da25f25096454d78ffdace5dc77f3a006bc01abba3", size = 663792, upload-time = "2026-04-27T12:59:44.93Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/89/2dadb89793c37ee8b4c237857188293e9060dc085f19845c292e00f8e091/greenlet-3.5.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bf2d8a80bec89ab46221ae45c5373d5ba0bd36c19aa8508e85c6cd7e5106cd37", size = 668086, upload-time = "2026-04-27T13:02:42.314Z" },
     { url = "https://files.pythonhosted.org/packages/a3/59/1bd6d7428d6ed9106efbb8c52310c60fd04f6672490f452aeaa3829aa436/greenlet-3.5.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f52a464e4ed91780bdfbbdd2b97197f3accaa629b98c200f4dffada759f3ae7", size = 660933, upload-time = "2026-04-27T12:25:33.276Z" },
-    { url = "https://files.pythonhosted.org/packages/82/35/75722be7e26a2af4cbd2dc35b0ed382dacf9394b7e75551f76ed1abe87f2/greenlet-3.5.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:1bae92a1dd94c5f9d9493c3a212dd874c202442047cf96446412c862feca83a2", size = 470799, upload-time = "2026-04-27T13:05:17.094Z" },
     { url = "https://files.pythonhosted.org/packages/83/e4/b903e5a5fae1e8a28cdd32a0cfbfd560b668c25b692f67768822ddc5f40f/greenlet-3.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:762612baf1161ccb8437c0161c668a688223cba28e1bf038f4eb47b13e39ccdf", size = 1618401, upload-time = "2026-04-27T12:53:31.062Z" },
     { url = "https://files.pythonhosted.org/packages/0e/e3/5ec408a329acb854fb607a122e1ee5fb3ff649f9a97952948a90803c0d8e/greenlet-3.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:57a43c6079a89713522bc4bcb9f75070ecf5d3dbad7792bfe42239362cbf2a16", size = 1682038, upload-time = "2026-04-27T12:25:31.838Z" },
     { url = "https://files.pythonhosted.org/packages/91/20/6b165108058767ee643c55c5c4904d591a830ee2b3c7dbd359828fbc829f/greenlet-3.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:3bc59be3945ae9750b9e7d45067d01ae3fe90ea5f9ade99239dabdd6e28a5033", size = 239835, upload-time = "2026-04-27T12:24:54.136Z" },
@@ -939,9 +960,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/78/a8/4522939255bb5409af4e87132f915446bf3622c2c292d14d3c38d128ae82/greenlet-3.5.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:a10a732421ab4fec934783ce3e54763470d0181db6e3468f9103a275c3ed1853", size = 293614, upload-time = "2026-04-27T12:24:12.874Z" },
     { url = "https://files.pythonhosted.org/packages/15/5e/8744c52e2c027b5a8772a01561934c8835f869733e101f62075c60430340/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fc391b1566f2907d17aaebe78f8855dc45675159a775fcf9e61f8ee0078e87f", size = 650723, upload-time = "2026-04-27T12:52:45.412Z" },
     { url = "https://files.pythonhosted.org/packages/00/ef/7b4c39c03cf46ceca512c5d3f914afd85aa30b2cc9a93015b0dd73e4be6c/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:680bd0e7ad5e8daa8a4aa89f68fd6adc834b8a8036dc256533f7e08f4a4b01f7", size = 656529, upload-time = "2026-04-27T12:59:46.295Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/5c/0602239503b124b70e39355cbdb39361ecfe65b87a5f2f63752c32f5286f/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1aa4ce8debcd4ea7fb2e150f3036588c41493d1d52c43538924ae1819003f4ce", size = 657015, upload-time = "2026-04-27T13:02:43.973Z" },
     { url = "https://files.pythonhosted.org/packages/0b/b5/c7768f352f5c010f92064d0063f987e7dc0cd290a6d92a34109015ce4aa1/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddb36c7d6c9c0a65f18c7258634e0c416c6ab59caac8c987b96f80c2ebda0112", size = 654364, upload-time = "2026-04-27T12:25:35.64Z" },
-    { url = "https://files.pythonhosted.org/packages/38/51/8699f865f125dc952384cb432b0f7138aa4d8f2969a7d12d0df5b94d054d/greenlet-3.5.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:728a73687e39ae9ca34e4694cbf2f049d3fbc7174639468d0f67200a97d8f9e2", size = 488275, upload-time = "2026-04-27T13:05:18.28Z" },
     { url = "https://files.pythonhosted.org/packages/ef/d0/079ebe12e4b1fc758857ce5be1a5e73f06870f2101e52611d1e71925ce54/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e5ddf316ced87539144621453c3aef229575825fe60c604e62bedc4003f372b2", size = 1614204, upload-time = "2026-04-27T12:53:32.618Z" },
     { url = "https://files.pythonhosted.org/packages/6d/89/6c2fb63df3596552d20e58fb4d96669243388cf680cff222758812c7bfaa/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4a448128607be0de65342dc9b31be7f948ef4cc0bc8832069350abefd310a8f2", size = 1675480, upload-time = "2026-04-27T12:25:34.168Z" },
     { url = "https://files.pythonhosted.org/packages/15/32/77ee8a6c1564fc345a491a4e85b3bf360e4cf26eac98c4532d2fdb96e01f/greenlet-3.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d60097128cb0a1cab9ea541186ea13cd7b847b8449a7787c2e2350da0cb82d86", size = 245324, upload-time = "2026-04-27T12:24:40.295Z" },

--- a/domains/vms/storefront/uv.lock
+++ b/domains/vms/storefront/uv.lock
@@ -29,48 +29,31 @@ name = "aiohttp"
 version = "3.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohappyeyeballs", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "aiosignal", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "attrs", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "frozenlist", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "multidict", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "propcache", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typing-extensions", marker = "(python_full_version < '3.13' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "yarl", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "aiohappyeyeballs" },
+    { name = "aiosignal" },
+    { name = "attrs" },
+    { name = "frozenlist" },
+    { name = "multidict" },
+    { name = "propcache" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "yarl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/82/78/8ea7308cac6934de8c74a14f3d5f65d1c89287426688be79538d0e5c013d/aiohttp-3.14.1.tar.gz", hash = "sha256:307f2cff90a764d329e77040603fa032db89c5c24fdad50c4c15334cba744035", size = 7955794, upload-time = "2026-06-07T21:09:35.529Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1d/21/151624b51cd92553d95424daf4bf19f19ce9be9002d19253e7e7ce67197b/aiohttp-3.14.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d35143e27778b4bb0fb189562d7f275bff79c62ab8e98459717c0ea617ff2480", size = 757402, upload-time = "2026-06-07T21:06:40.311Z" },
     { url = "https://files.pythonhosted.org/packages/55/b2/2aac325583aaa1353045f96dffa586d8a34e8322e14a7ba49cffeb103ab4/aiohttp-3.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:27fd7c91e51729b4f7e1577865fa6d34c9adccbc39aabe9000285b48af9f0ec2", size = 512448, upload-time = "2026-06-07T21:06:43.813Z" },
     { url = "https://files.pythonhosted.org/packages/8a/72/a60607cb849faa8af8a356c9329ea2eb6f395d49e82cc82ccba1fd8deb8f/aiohttp-3.14.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:64c567bf9eaf664280116a8688f63016e6b32db2505908e2bdaca1b6438142f2", size = 1766854, upload-time = "2026-06-07T21:06:45.391Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/d3/d9fe1c9ec7557ab4d0d82bebaa728c6418f0b93295ec2f4ab015f7710cc7/aiohttp-3.14.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:f5e6ff2bdbb8f4cd3fbe41f99e25bbcd58e3bf9f13d3dd31a11e7917251cc77a", size = 1740884, upload-time = "2026-06-07T21:06:47.413Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/dc/f2cecfaf9337ba3e63f181500814ff502aa3d00d9c7ec93a9d23d10a27b2/aiohttp-3.14.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2f73e01dc37122325caf079982621262f96d74823c179038a82fddfc50359264", size = 1810034, upload-time = "2026-06-07T21:06:50.165Z" },
-    { url = "https://files.pythonhosted.org/packages/66/d7/2ff65c5e65c0d7476daf7e15c032e0805e36811185b9623e3238ad6c763e/aiohttp-3.14.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bb2c0c80d431c0d03f2c7dbf125150fedd4f0de17366a7ca33f7ccb822391842", size = 1904054, upload-time = "2026-06-07T21:06:52.035Z" },
     { url = "https://files.pythonhosted.org/packages/20/9c/d445818389df371f56d141d881153ba23183c4735a03f7356ffb43f7757d/aiohttp-3.14.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3e6fc1a85fa7194a1a7d19f44e8609180f4a8eb5fa4c7ed8b4355f080fad235c", size = 1790278, upload-time = "2026-06-07T21:06:54.049Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/aa/bf04cb4d865fc6101c2229a294ad744973b72e513fdc5a6b791e6983d72a/aiohttp-3.14.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:686b6c0d3911ec387b444ddf5dc62fb7f7c0a7d5186a7861626496a5ab4aff95", size = 1591795, upload-time = "2026-06-07T21:06:55.911Z" },
     { url = "https://files.pythonhosted.org/packages/dc/b4/4dac0038960427ba832f6609dfb4ea5437d7fd80c72001b9e48f834f428b/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c6fa4dc7ad6f8109c70bb1499e589f76b0b792baf39f9b017eb92c8a81d0a199", size = 1728397, upload-time = "2026-06-07T21:06:57.777Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/f9/7cd4e8ad7aa3b75f17d56bb5498dd604a93d4e6eece822ba0568c413fff0/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:87a5eea1b2a5e21e1ebdbb33ad4165359189327e63fc4e4894693e7f821ac817", size = 1766504, upload-time = "2026-06-07T21:07:00.009Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/df/fc01d9fcad0f73fed3f3d361f1f94f975947b50dff82919f6dc2bf4316cc/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1c1421eb01d4fd608d88cc8290211d177a58532b55ad94076fb349c5bf467f0a", size = 1777806, upload-time = "2026-06-07T21:07:02.064Z" },
-    { url = "https://files.pythonhosted.org/packages/41/09/47e2d090bddcc8fb4ccb4c314aadc32d7c5d9bb55f50f6ad1c92fc15d501/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:34b257ec41345c1e8f2df68fa908a7952f5de932723871eb633ecbbff396c9a4", size = 1580707, upload-time = "2026-06-07T21:07:03.942Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/36/f1a4ce904ae0b6930cfe9afc96d0896f7ec1a620c400405d63783bb95a9c/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:de538791a80e5d862addbc183f70f0158ac9b9bb872bb147f1fd2a683691e087", size = 1798121, upload-time = "2026-06-07T21:07:05.987Z" },
     { url = "https://files.pythonhosted.org/packages/70/0a/e0075ce9ca0279ee1d4f0c0b85f54fea02ebc83c3007651a72bece658fec/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6f71173be42d3241d428f760122febb748de0623f44308a6f120d0dd9ec572e3", size = 1767580, upload-time = "2026-06-07T21:07:07.873Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/97/bd137012dd97e1649162b099135a80e1fd59aaa807b2430fc448d1029aff/aiohttp-3.14.1-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:b3a03285a7f9c7b016324574a6d92a1c895da6b978cb8f1deee3ac72bc6da178", size = 506882, upload-time = "2026-06-07T21:07:15.501Z" },
     { url = "https://files.pythonhosted.org/packages/fe/22/a73ccbf9dbd6e26dda0b24d5fd5db7da92ee3383a79f47677ffb834c5c5b/aiohttp-3.14.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:915fbb7b41b115192259f8c9ae58f3ddc444d2b5579917270211858e606a4afd", size = 485841, upload-time = "2026-06-07T21:07:19.555Z" },
     { url = "https://files.pythonhosted.org/packages/3b/b9/57ed8eaf596321c2ad747bd480fb1700dbd7177c60dfc9e4c187f629662e/aiohttp-3.14.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:7fb4bdf95b0561a79f259f9d28fbc109728c5ee7f27aff6391f0ca703a329abe", size = 492088, upload-time = "2026-06-07T21:07:21.581Z" },
     { url = "https://files.pythonhosted.org/packages/78/c0/5ebe5270a7c140d7c6f79dcb018640225f14d406c149e4eec04a7d82fe71/aiohttp-3.14.1-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:1b9748363260121d2927704f5d4fc498150669ca3ae93625986ee89c8f80dcd4", size = 501564, upload-time = "2026-06-07T21:07:23.388Z" },
     { url = "https://files.pythonhosted.org/packages/75/7f/8cdaa24fc7983865e0915153b96a9ac5bcdd3548d64c5a27d17cecccad2d/aiohttp-3.14.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:86a6dab78b0e43e2897a3bbe15745aa60dc5423ca437b7b0b164c069bf91b876", size = 751998, upload-time = "2026-06-07T21:07:25.046Z" },
     { url = "https://files.pythonhosted.org/packages/ab/01/a2d5f96cd4e74424864d30bc0a7e44d0a12dacdcfa91b5b2d1bd3dca6bf3/aiohttp-3.14.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:317acd9f8602858dc7d59679812c376c7f0b97bcbbf16e0d6237f54141d8a8a6", size = 508657, upload-time = "2026-06-07T21:07:29.252Z" },
     { url = "https://files.pythonhosted.org/packages/e8/ed/3c0fb5c500fdd8e7ebc10d1889c04384fffa1a9163eac1356088ca9da1b1/aiohttp-3.14.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bd869c427324e5cb15195793de951295710db28be7d818247f3097b4ab5d4b96", size = 1757907, upload-time = "2026-06-07T21:07:31.03Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/ab/d4c924d9bd5be3050c226612413ce68cb54c70d2c31b661bfc8d9a5b6a70/aiohttp-3.14.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:93b032b5ec3255473c143627d21a69ac74ae12f7f33974cb587c564d11b1066f", size = 1737565, upload-time = "2026-06-07T21:07:33.031Z" },
-    { url = "https://files.pythonhosted.org/packages/19/2a/37326821ff779084020cdc33224d20b19f42f4183a500ff92022a739eda7/aiohttp-3.14.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f234b4deb12f3ad59127e037bc57c40c21e45b45282df7d3a55a0f409f595296", size = 1799018, upload-time = "2026-06-07T21:07:35.003Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/4f/6e947ba73e4ce09070761c05ed3a8ceb7c21f5e46798671d8b2aac0e4626/aiohttp-3.14.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9af6779bfb46abf124068327abcdf9ce95c9ef8287a3e8da76ccf2d0f16c28fa", size = 1894416, upload-time = "2026-06-07T21:07:36.956Z" },
     { url = "https://files.pythonhosted.org/packages/9d/6e/dbf1d0625dc711fb2851f4f3c3055c39ed58bae92082d8c627dbe6013736/aiohttp-3.14.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:faccab372e66bc76d5731525e7f1143c922271725b9d38c9f97edcc66266b451", size = 1783881, upload-time = "2026-06-07T21:07:39.063Z" },
-    { url = "https://files.pythonhosted.org/packages/44/c2/5e25098a67268ed369483ae7d1a58bd0a13d03aab860d2a0e4a6eb25b046/aiohttp-3.14.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f380468b09d2a81633ee863b0ec5648d364bd17bb8ecfb8c2f387f7ac1faf42c", size = 1587572, upload-time = "2026-06-07T21:07:41.058Z" },
     { url = "https://files.pythonhosted.org/packages/2a/bd/cf9cee17e140f942a3de73e658a543aa8fbf35a5fc67a9d2538d52d77f0b/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:97e704dcd26271f5bda3fa07c3ce0fb76d6d3f8659f4baa1a24442cc9ba177ca", size = 1722137, upload-time = "2026-06-07T21:07:43.014Z" },
-    { url = "https://files.pythonhosted.org/packages/89/6d/5684f8c59045c96f81a18cefbc1fbbd79d25b88f1c622f2a5c5c08fcb632/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:269b76ac5394092b95bc4a098f4fc6c191c083c3bd12775d1e30e663132f6a09", size = 1755953, upload-time = "2026-06-07T21:07:45.933Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/40/35caf3170f8359760740a7d9aa0fff2e344bef98e1d1186f5a0f6dec17e6/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5c0b3e614340c889d575451696374c9d17affd54cd607ca0babed8f8c37b9397", size = 1766479, upload-time = "2026-06-07T21:07:48.047Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/a1/b0c61e7a137f0d81de49a82023a6df73c3c16d6fefb0f8e4a93d21639002/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:5663ee9257cfa1add7253a7da3035a02f31b6600ec48261585e1800a81533080", size = 1580077, upload-time = "2026-06-07T21:07:50.069Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/41/194ea4623693009fcefebef7aef63c141754f153e9cd0d39d3b9e36c175c/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:603a2c834142172ffddc054067f5ec0ca65d57a0aa98a71bc81952573208e345", size = 1791688, upload-time = "2026-06-07T21:07:52.106Z" },
     { url = "https://files.pythonhosted.org/packages/ba/45/4de841f005cfe1fd63e2a2fe011262c515e2a62aa6994b15947e7d717ac9/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cb21957bb8aca671c1765e32f58164cf0c50e6bf41c0bbbd16da20732ecaf588", size = 1761094, upload-time = "2026-06-07T21:07:54.113Z" },
 ]
 
@@ -79,8 +62,8 @@ name = "aiosignal"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "frozenlist", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typing-extensions", marker = "(python_full_version < '3.13' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "frozenlist" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
 wheels = [
@@ -124,8 +107,8 @@ name = "anyio"
 version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "idna", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typing-extensions", marker = "(python_full_version < '3.13' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
@@ -146,7 +129,7 @@ name = "argon2-cffi"
 version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "argon2-cffi-bindings", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "argon2-cffi-bindings" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/89/ce5af8a7d472a67cc819d5d998aa8c82c5d860608c4db9f46f1162d7dab9/argon2_cffi-25.1.0.tar.gz", hash = "sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1", size = 45706, upload-time = "2025-06-03T06:55:32.073Z" }
 wheels = [
@@ -158,7 +141,7 @@ name = "argon2-cffi-bindings"
 version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "cffi" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5c/2d/db8af0df73c1cf454f71b2bbe5e356b8c1f8041c979f505b3d3186e520a9/argon2_cffi_bindings-25.1.0.tar.gz", hash = "sha256:b957f3e6ea4d55d820e40ff76f450952807013d361a65d7f28acc0acbf29229d", size = 1783441, upload-time = "2025-07-30T10:02:05.147Z" }
 wheels = [
@@ -175,8 +158,8 @@ name = "arkhai-bare-metal"
 version = "0.2.0"
 source = { registry = "../../../.dist" }
 dependencies = [
-    { name = "arkhai-core", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pydantic", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "arkhai-core" },
+    { name = "pydantic" },
 ]
 wheels = [
     { path = "arkhai_bare_metal-0.2.0-py3-none-any.whl" },
@@ -184,15 +167,16 @@ wheels = [
 
 [[package]]
 name = "arkhai-compute-provisioning"
-version = "0.3.0"
+version = "0.5.0"
 source = { registry = "../../../.dist" }
 dependencies = [
-    { name = "arkhai-kit-site", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "httpx", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pydantic", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "arkhai-kit-resource-pools" },
+    { name = "arkhai-kit-site" },
+    { name = "httpx" },
+    { name = "pydantic" },
 ]
 wheels = [
-    { path = "arkhai_compute_provisioning-0.3.0-py3-none-any.whl" },
+    { path = "arkhai_compute_provisioning-0.5.0-py3-none-any.whl" },
 ]
 
 [[package]]
@@ -200,7 +184,7 @@ name = "arkhai-core"
 version = "0.2.0"
 source = { registry = "../../../.dist" }
 dependencies = [
-    { name = "pydantic", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pydantic" },
 ]
 wheels = [
     { path = "arkhai_core-0.2.0-py3-none-any.whl" },
@@ -211,8 +195,8 @@ name = "arkhai-core-registry-client"
 version = "0.10.0"
 source = { registry = "../../../.dist" }
 dependencies = [
-    { name = "eth-account", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "httpx", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "eth-account" },
+    { name = "httpx" },
 ]
 wheels = [
     { path = "arkhai_core_registry_client-0.10.0-py3-none-any.whl" },
@@ -223,13 +207,13 @@ name = "arkhai-core-storefront"
 version = "0.2.0"
 source = { registry = "../../../.dist" }
 dependencies = [
-    { name = "arkhai-core", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "arkhai-core-registry-client", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "arkhai-kit-config", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "arkhai-kit-identity", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "arkhai-kit-policy", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "httpx", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pydantic", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "arkhai-core" },
+    { name = "arkhai-core-registry-client" },
+    { name = "arkhai-kit-config" },
+    { name = "arkhai-kit-identity" },
+    { name = "arkhai-kit-policy" },
+    { name = "httpx" },
+    { name = "pydantic" },
 ]
 wheels = [
     { path = "arkhai_core_storefront-0.2.0-py3-none-any.whl" },
@@ -240,8 +224,8 @@ name = "arkhai-core-storefront-client"
 version = "0.16.0"
 source = { registry = "../../../.dist" }
 dependencies = [
-    { name = "eth-account", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "httpx", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "eth-account" },
+    { name = "httpx" },
 ]
 wheels = [
     { path = "arkhai_core_storefront_client-0.16.0-py3-none-any.whl" },
@@ -252,8 +236,8 @@ name = "arkhai-kit-alkahest"
 version = "0.1.1"
 source = { registry = "../../../.dist" }
 dependencies = [
-    { name = "pydantic", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "web3", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pydantic" },
+    { name = "web3" },
 ]
 wheels = [
     { path = "arkhai_kit_alkahest-0.1.1-py3-none-any.whl" },
@@ -264,8 +248,8 @@ name = "arkhai-kit-config"
 version = "0.1.0"
 source = { registry = "../../../.dist" }
 dependencies = [
-    { name = "arkhai-kit-alkahest", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "eth-account", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "arkhai-kit-alkahest" },
+    { name = "eth-account" },
 ]
 wheels = [
     { path = "arkhai_kit_config-0.1.0-py3-none-any.whl" },
@@ -276,8 +260,8 @@ name = "arkhai-kit-identity"
 version = "0.1.0"
 source = { registry = "../../../.dist" }
 dependencies = [
-    { name = "eth-account", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pydantic", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "eth-account" },
+    { name = "pydantic" },
 ]
 wheels = [
     { path = "arkhai_kit_identity-0.1.0-py3-none-any.whl" },
@@ -288,11 +272,24 @@ name = "arkhai-kit-policy"
 version = "0.1.1"
 source = { registry = "../../../.dist" }
 dependencies = [
-    { name = "pydantic", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typer", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pydantic" },
+    { name = "typer" },
 ]
 wheels = [
     { path = "arkhai_kit_policy-0.1.1-py3-none-any.whl" },
+]
+
+[[package]]
+name = "arkhai-kit-resource-pools"
+version = "0.1.0"
+source = { registry = "../../../.dist" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "sqlalchemy" },
+]
+wheels = [
+    { path = "arkhai_kit_resource_pools-0.1.0-py3-none-any.whl" },
 ]
 
 [[package]]
@@ -300,9 +297,9 @@ name = "arkhai-kit-site"
 version = "0.2.0"
 source = { registry = "../../../.dist" }
 dependencies = [
-    { name = "fastapi", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pydantic", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "sqlalchemy", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "fastapi" },
+    { name = "pydantic" },
+    { name = "sqlalchemy" },
 ]
 wheels = [
     { path = "arkhai_kit_site-0.2.0-py3-none-any.whl" },
@@ -313,8 +310,8 @@ name = "arkhai-vms"
 version = "0.2.0"
 source = { registry = "../../../.dist" }
 dependencies = [
-    { name = "arkhai-core", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pydantic", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "arkhai-core" },
+    { name = "pydantic" },
 ]
 wheels = [
     { path = "arkhai_vms-0.2.0-py3-none-any.whl" },
@@ -325,56 +322,56 @@ name = "arkhai-vms-storefront"
 version = "0.3.0"
 source = { editable = "." }
 dependencies = [
-    { name = "alkahest-py", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "arkhai-bare-metal", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "arkhai-compute-provisioning", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "arkhai-core", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "arkhai-core-registry-client", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "arkhai-core-storefront", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "arkhai-core-storefront-client", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "arkhai-kit-alkahest", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "arkhai-kit-config", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "arkhai-kit-identity", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "arkhai-kit-policy", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "arkhai-vms", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "dynaconf", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "eth-account", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "fastapi", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "fastapi-utils", extra = ["all"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "google-cloud-logging", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "httpx", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "opentelemetry-exporter-gcp-trace", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "psycopg2-binary", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "python-multipart", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "rich", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typer", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "uvicorn", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "web3", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "websockets", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "alkahest-py" },
+    { name = "arkhai-bare-metal" },
+    { name = "arkhai-compute-provisioning" },
+    { name = "arkhai-core" },
+    { name = "arkhai-core-registry-client" },
+    { name = "arkhai-core-storefront" },
+    { name = "arkhai-core-storefront-client" },
+    { name = "arkhai-kit-alkahest" },
+    { name = "arkhai-kit-config" },
+    { name = "arkhai-kit-identity" },
+    { name = "arkhai-kit-policy" },
+    { name = "arkhai-vms" },
+    { name = "dynaconf" },
+    { name = "eth-account" },
+    { name = "fastapi" },
+    { name = "fastapi-utils", extra = ["all"] },
+    { name = "google-cloud-logging" },
+    { name = "httpx" },
+    { name = "opentelemetry-exporter-gcp-trace" },
+    { name = "psycopg2-binary" },
+    { name = "python-multipart" },
+    { name = "rich" },
+    { name = "typer" },
+    { name = "uvicorn" },
+    { name = "web3" },
+    { name = "websockets" },
 ]
 
 [package.optional-dependencies]
 jupyter = [
-    { name = "jupyter", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "jupyter" },
 ]
 lint = [
-    { name = "codespell", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "mypy", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "ruff", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "types-pyyaml", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "types-requests", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "codespell" },
+    { name = "mypy" },
+    { name = "ruff" },
+    { name = "types-pyyaml" },
+    { name = "types-requests" },
 ]
 rl = [
-    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
-    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'linux'" },
+    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'linux'" },
 ]
 
 [package.dev-dependencies]
 dev = [
-    { name = "nest-asyncio", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pytest", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pytest-asyncio", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "wandb", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nest-asyncio" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "wandb" },
 ]
 
 [package.metadata]
@@ -428,8 +425,8 @@ name = "arrow"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "python-dateutil", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "tzdata", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "python-dateutil" },
+    { name = "tzdata" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/33/032cdc44182491aa708d06a68b62434140d8c50820a087fac7af37703357/arrow-1.4.0.tar.gz", hash = "sha256:ed0cc050e98001b8779e84d461b0098c4ac597e88704a655582b21d116e526d7", size = 152931, upload-time = "2025-10-18T17:46:46.761Z" }
 wheels = [
@@ -477,8 +474,8 @@ name = "beautifulsoup4"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "soupsieve", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
 wheels = [
@@ -493,21 +490,13 @@ sdist = { url = "https://files.pythonhosted.org/packages/fc/47/b5da717e7bbe97a6d
 wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/53/22bfffd13dd0a266f90011338b24eec45f25c91d37155bb2aa330351e17d/bitarray-3.8.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ff2ca039a161d49a8c713f5380def315c6f793df5fe348b94782b1dbee37a644", size = 145999, upload-time = "2026-04-02T16:26:56.849Z" },
     { url = "https://files.pythonhosted.org/packages/5d/dc/60aff29c88b648e18248921001cf9d7169abeda4d8db96f2dc1a24ed98ca/bitarray-3.8.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df3ffa6ef88166bb36f5d1492e71e664868b9b8b6afd55821e0ac0cb96625441", size = 335945, upload-time = "2026-04-02T16:26:58.403Z" },
-    { url = "https://files.pythonhosted.org/packages/83/c8/225380610a01ae0d8f2f5256e531bae7135b2ade6f4607156424718ec43a/bitarray-3.8.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:478b9f0ea86f957624dd2b159066855716f78db94666e9b04babe85fc013e01b", size = 364213, upload-time = "2026-04-02T16:26:59.742Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/df/83899be9a74ec5878972e8b636f645ef1771e146c6425a161fdafdd74aaa/bitarray-3.8.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e127b2e7fc533728295196f9265d12834530f475bc6cd6f74619df415d04b8b1", size = 375409, upload-time = "2026-04-02T16:27:01.081Z" },
     { url = "https://files.pythonhosted.org/packages/6c/93/38bc15cb097107d220a942eb66dc50882496d7da54f41e5eea6c31b1c443/bitarray-3.8.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6ef49462a615de062dcac8281944d0b036fe1e9c96a6c690bf6cf5e4b5488f0e", size = 343645, upload-time = "2026-04-02T16:27:02.577Z" },
     { url = "https://files.pythonhosted.org/packages/5a/c3/75fae6991946f8bf643ec50233432ea81b5b65bfdb2918b09d7e37605380/bitarray-3.8.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4da256fc567a57ded2a4aa962fc9e9d430ab740e5c67be9e98a63ef4eb467f2f", size = 333844, upload-time = "2026-04-02T16:27:03.963Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/7e/649e7c3bb12ba938c387bcad6a6c0b84312663c9807ec1457888936690d8/bitarray-3.8.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:b46b7aec9272fd81c984e723e599957629a91204120b3e7f0933f138e0792fdf", size = 361267, upload-time = "2026-04-02T16:27:05.361Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/5f/db0fb71a7c6c3ef047b84256157e96fa35e10ed8b79b80e892d354ab37f6/bitarray-3.8.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:2dc07dab252c63c4f6600e200b26fa05207db6b650d41ae88ab0cec4d6c59459", size = 359373, upload-time = "2026-04-02T16:27:07.106Z" },
     { url = "https://files.pythonhosted.org/packages/b6/b6/a082d84cba7ba509b48d160034f6a2d31df6bf4fff0471801e888bba96c9/bitarray-3.8.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:29c8c10a49d6a9586f592116618b99c3dabcb24d881b7a649e0691ef87f314c4", size = 340633, upload-time = "2026-04-02T16:27:08.794Z" },
     { url = "https://files.pythonhosted.org/packages/23/fe/f70b150ea9a330daecc546a5a63576ba2d6b3bacc1ccde42abc9dd35a1ad/bitarray-3.8.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b3118ec012a799456f7fca6cc002c078590578b7640fbaab52d8ecb9a651f1c1", size = 146001, upload-time = "2026-04-02T16:27:17.041Z" },
     { url = "https://files.pythonhosted.org/packages/78/49/2c637658851ea0408c7375f5f278c0ebb69cbe861f8fcc9477db14ee7fa2/bitarray-3.8.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2762db8049b230520358ac742cbc57bceaacebe34e5d25c096f2b4bc3887a3a8", size = 335162, upload-time = "2026-04-02T16:27:18.587Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/3c/ae665a0b2d6183cc706c03b683b7f9ad53195731379ab82dfa537e73f70f/bitarray-3.8.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5b67b869f860eb19055e2560844d8c7d0935245938935bdb764b3e683e2014e2", size = 363031, upload-time = "2026-04-02T16:27:19.98Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/ee/7b7c37fbb15209525f0daff1a51a042c035e931ebd526aabb483fdc7a476/bitarray-3.8.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0a661f3492462e7adf8a054fb7414a22fc8251f1e18b9d8cbcf008d2dc85f012", size = 374623, upload-time = "2026-04-02T16:27:21.468Z" },
     { url = "https://files.pythonhosted.org/packages/96/dd/26a17534742561974e5b2a3448d70fd8d370ed885bd88bbbb36bdd022875/bitarray-3.8.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:300e3026d17ae3328320ba78d3165bdb1c43d0dfdbc461a69ebbdc005d9ce0b3", size = 342850, upload-time = "2026-04-02T16:27:22.814Z" },
     { url = "https://files.pythonhosted.org/packages/58/f1/97410e88a8b441c1a6e5841c651e483787c3c87f2b98c1d2421aee23790d/bitarray-3.8.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ad5a71c1ef4a2e404c2c888db09226c821d9d14eff8813e1da873572f5fbb89d", size = 333109, upload-time = "2026-04-02T16:27:24.271Z" },
-    { url = "https://files.pythonhosted.org/packages/64/1a/74a3af2d314ec6a035ae8f139491ace4fc8b3362bfdc86aee652b8f15be5/bitarray-3.8.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:78cbda57a2808d994517b53571eaa2d9299359f63aa71cf4bc94210169aad8b1", size = 360334, upload-time = "2026-04-02T16:27:25.999Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/86/01ea58ca9795401489f9de662ef9ba759d6712870696a5806441b2c14224/bitarray-3.8.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:89c7c125a0913d71ba9cc1fa8e14c7cfe1517b1c1f45416e1f9babcedd3b545d", size = 358674, upload-time = "2026-04-02T16:27:27.597Z" },
     { url = "https://files.pythonhosted.org/packages/68/c9/14587fd3c712047af60a875889ad69926386c3fdbf8061e9baf23d12d997/bitarray-3.8.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7875abfd90f2ae3aa22d50f3fa1c93bbae456458cc73d3179b838f07bed1fc10", size = 339689, upload-time = "2026-04-02T16:27:29.14Z" },
 ]
 
@@ -516,7 +505,7 @@ name = "bleach"
 version = "6.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "webencodings", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "webencodings" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/3c/e12ac860709702bd5ebeb9b56a4fe334f1001246ee1b8f2b7ee28912df7d/bleach-6.4.0.tar.gz", hash = "sha256:4202482733d85cedd04e59fcb2f89f4e4c7c385a78d3c3c23c30446843a37452", size = 204857, upload-time = "2026-06-05T13:01:13.734Z" }
 wheels = [
@@ -525,7 +514,7 @@ wheels = [
 
 [package.optional-dependencies]
 css = [
-    { name = "tinycss2", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "tinycss2" },
 ]
 
 [[package]]
@@ -542,21 +531,17 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "(implementation_name != 'PyPy' and platform_machine == 'arm64' and sys_platform == 'darwin') or (implementation_name != 'PyPy' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name != 'PyPy' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
     { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
     { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
     { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
     { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
     { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
     { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
     { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
     { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
     { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
@@ -570,29 +555,13 @@ sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c764272
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
     { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
-    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
     { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
     { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
-    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
     { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
     { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
     { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
-    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
     { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
     { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
-    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
     { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
     { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
 ]
@@ -647,7 +616,7 @@ name = "cryptography"
 version = "48.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "(platform_machine == 'arm64' and platform_python_implementation != 'PyPy' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux')" },
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/12/45/870e7f4bef50e5f53b9f51d4428aee5290eedf58ba443f16b1ebb7ab8e66/cryptography-48.0.1.tar.gz", hash = "sha256:266f4ee051abb2f725b74ef8072b521ce1feacf685a3364fa6a6b45548db791a", size = 832989, upload-time = "2026-06-09T22:32:31.8Z" }
 wheels = [
@@ -655,11 +624,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/85/6379d42181bfc713094f081360fc5784d6c816b599d45e7f082502d173ce/cryptography-48.0.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:32143b24adb918f078134e1e230f1eb8cc04886b92c28b5f0041aaf3e5699225", size = 4696243, upload-time = "2026-06-09T22:32:33.446Z" },
     { url = "https://files.pythonhosted.org/packages/9c/87/c85d147b53323c7eb4d850920c8901377323c2a0ff8d79c262d4fee89aa2/cryptography-48.0.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f0d27a5696721ef7a672b8c810f6aded391058e0b9486e63e6d93baf765da691", size = 4713235, upload-time = "2026-06-09T22:31:40.141Z" },
     { url = "https://files.pythonhosted.org/packages/79/58/67cbf8cf1ee7c54b439ca07bbecf8362c07afc11a3724fea70f745784add/cryptography-48.0.1-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:eb86ce1af36fe65041b6db9a8bb064ee621a7e5fded0f80d475ec243477cd242", size = 4702323, upload-time = "2026-06-09T22:31:42.191Z" },
-    { url = "https://files.pythonhosted.org/packages/89/c6/24266ac10c47f6cd2a865f4446062b466da1d1f10b27189eac00e61bf0c9/cryptography-48.0.1-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:b024e784ad6c077ee0147b35ea9cbfc1e34e1fd4c1dcca214c2794d73a12df08", size = 5300085, upload-time = "2026-06-09T22:31:58.703Z" },
     { url = "https://files.pythonhosted.org/packages/d2/bb/cc4b78784f97efc8c5874c2a9743708d172be6663024b34a0467885ae0c8/cryptography-48.0.1-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3752f2dbc8f07a30aad2932c986cea495b03bb554887828225da104f732852b6", size = 4746137, upload-time = "2026-06-09T22:31:31.01Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/52/0c44de3f5267f8fbe8e835138017522a333436166e406f0db9b9e6e3033f/cryptography-48.0.1-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:bd81490cd5801d755cf97bb68ac191f14b708470b1c7cf4580f669b9c9264cd8", size = 4333867, upload-time = "2026-06-09T22:32:28.096Z" },
     { url = "https://files.pythonhosted.org/packages/9a/2e/772d7adbfa931537bc401640b7cac9976bff689bda187833e5d63b428e49/cryptography-48.0.1-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:66fd0771e7b9c6dcd44cf1120690d2338d16d72795cf40cae2786a39eba65429", size = 4701805, upload-time = "2026-06-09T22:31:38.284Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/a3/b06844f303873493c963caf581c04df31c7035e0c1b0f02c4814d319ec80/cryptography-48.0.1-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:3fd2ca57062b241c856670b073487d2e86c4637937ca5601e48f97bf8e11fc8f", size = 5258461, upload-time = "2026-06-09T22:31:04.187Z" },
     { url = "https://files.pythonhosted.org/packages/9f/13/8b765e2e12b07c74941caadb9d1c8fdc006c4dfbf2b8f2d610519758954d/cryptography-48.0.1-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:0ee6ea481db1ab889cba043ec1eda17bb9c1ea79db6722f779c3667f9f70322f", size = 4745488, upload-time = "2026-06-09T22:32:30.07Z" },
     { url = "https://files.pythonhosted.org/packages/2e/aa/48972bce55049b32a94f4907eda4d75fa385aad8a39506cc2fc72196ecf0/cryptography-48.0.1-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f2ceef93cb096aa3c4cc4b5c94ca6131f9196d28c64d6111533402a9b2054d41", size = 4830256, upload-time = "2026-06-09T22:31:43.868Z" },
     { url = "https://files.pythonhosted.org/packages/47/a2/e5079a032fb85cf6005046ca92bbd78b0c82dad2b5751ab8c311659da06f/cryptography-48.0.1-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9bd3f92d76217892b15df84ca256c2c113d386fdda7a7d8691aeeced976507c6", size = 4979117, upload-time = "2026-06-09T22:31:05.845Z" },
@@ -667,11 +633,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/d9/45f309a7e4e5f3f8f121d6d3be9e94024a7726ec598d6e08ae04edb2f04d/cryptography-48.0.1-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48fe40804d4caa2288f24e70ca8c64c42dd826da0ad7e4f1b41b2128d679e6c8", size = 4690196, upload-time = "2026-06-09T22:31:54.74Z" },
     { url = "https://files.pythonhosted.org/packages/5f/9f/a1bc8bcc798811b8527eb374bbccf30a3f3e806829d967118222bf1125eb/cryptography-48.0.1-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:86be3b1b0b6bf09482fb50a979c508d2950ed95f5621ec77f4e385962006b83a", size = 4696782, upload-time = "2026-06-09T22:31:45.615Z" },
     { url = "https://files.pythonhosted.org/packages/66/c2/81a4fb4e4373c500bb526bc337ac5719dd31dd15b970b84a238168c6aa08/cryptography-48.0.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4ab0a343c807bbcd90c971cd1ecf072937cd01847a9e002bef88fb47ac6be577", size = 4696618, upload-time = "2026-06-09T22:31:11.564Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/0b/aa68b221dde92d09cb29a024ede17550ee21e77a404e59fc093c82bb51e1/cryptography-48.0.1-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9621de99d2da096006b629979efd8ae7eb2d8b822488d0c89ee4000c306c59b1", size = 5289970, upload-time = "2026-06-09T22:31:20.368Z" },
     { url = "https://files.pythonhosted.org/packages/78/13/fba657f958d2af66ea959a4ba01212632089249d34af1ae48054136344d7/cryptography-48.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:88c852a0ae366e262e5a1744b685e6a433dc8788dd2a277e418bf4904203609d", size = 4731873, upload-time = "2026-06-09T22:31:22.253Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/4c/9a964756d24a26b3e34dfcb16f961b89838786e6700b635b0d1e3adff4b6/cryptography-48.0.1-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:43c5835e2cb98c8733d86f57d6fc879b613f5c3478607281c3e36daffc6dd8a6", size = 4330804, upload-time = "2026-06-09T22:31:36.56Z" },
     { url = "https://files.pythonhosted.org/packages/4b/0f/a10f3a6eb12950a10e3a874070283aa2dd5875b2bfd15fad8a3e17b3f13e/cryptography-48.0.1-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:fe0180af5bf9236518a087e35bf2d9a347d5f5f51e63c579d683ddff424e3d46", size = 4696217, upload-time = "2026-06-09T22:31:13.351Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/6f/5cd12f951165ea73ef85266775d97e4c763b2474ccfd816dd69d3a18d6f8/cryptography-48.0.1-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:b7a2d1a937a738a881737cec135a38bb61470589b17515b9f73f571d0ae10401", size = 5245252, upload-time = "2026-06-09T22:32:02.193Z" },
     { url = "https://files.pythonhosted.org/packages/68/ab/8aaa12e4516ec4464033ab79b6f3b592bd5a92102467c4ace8a0d970203f/cryptography-48.0.1-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:b74ca3b8e5ecdd833bf6a002ca41b4793bb27fb8f1c06ffaf2643c9e9140e31b", size = 4731388, upload-time = "2026-06-09T22:32:04.019Z" },
     { url = "https://files.pythonhosted.org/packages/1b/24/50027ea4dca85ec1f40688f3c24fb32ccacd520583c9592c3cc95628e6fb/cryptography-48.0.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:2c37f2461406063b417837f5f3daab668652acd82423efcd7f0a9f04be972de1", size = 4824186, upload-time = "2026-06-09T22:32:18.707Z" },
     { url = "https://files.pythonhosted.org/packages/52/41/04cb5eb17085ade6f50cc611fb657df6a0f5885350de8764ece89c050197/cryptography-48.0.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:86fe77abb1bd87afb251d4d02ada7ecf53a32cee9b67d976abb2e45a13297475", size = 4964539, upload-time = "2026-06-09T22:31:18.793Z" },
@@ -682,23 +645,15 @@ name = "cytoolz"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "toolz", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "toolz" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bd/d4/16916f3dc20a3f5455b63c35dcb260b3716f59ce27a93586804e70e431d5/cytoolz-1.1.0.tar.gz", hash = "sha256:13a7bf254c3c0d28b12e2290b82aed0f0977a4c2a2bf84854fcdc7796a29f3b0", size = 642510, upload-time = "2025-10-19T00:44:56.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/ec/01426224f7acf60183d3921b25e1a8e71713d3d39cb464d64ac7aace6ea6/cytoolz-1.1.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:99f8e134c9be11649342853ec8c90837af4089fc8ff1e8f9a024a57d1fa08514", size = 1327800, upload-time = "2025-10-19T00:40:48.674Z" },
     { url = "https://files.pythonhosted.org/packages/ab/72/c0f766d63ed2f9ea8dc8e1628d385d99b41fb834ce17ac3669e3f91e115d/cytoolz-1.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:945580dc158c557172fca899a35a99a16fbcebf6db0c77cb6621084bc82189f9", size = 991169, upload-time = "2025-10-19T00:40:52.887Z" },
     { url = "https://files.pythonhosted.org/packages/25/73/9b25bb7ed8d419b9d6ff2ae0b3d06694de79a3f98f5169a1293ff7ad3a3f/cytoolz-1.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:82779049f352fb3ab5e8c993ab45edbb6e02efb1f17f0b50f4972c706cc51d76", size = 2824951, upload-time = "2025-10-19T00:40:56.137Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/93/9c787f7c909e75670fff467f2504725d06d8c3f51d6dfe22c55a08c8ccd4/cytoolz-1.1.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:7d3e405e435320e08c5a1633afaf285a392e2d9cef35c925d91e2a31dfd7a688", size = 2679635, upload-time = "2025-10-19T00:40:57.799Z" },
-    { url = "https://files.pythonhosted.org/packages/50/aa/9ee92c302cccf7a41a7311b325b51ebeff25d36c1f82bdc1bbe3f58dc947/cytoolz-1.1.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:923df8f5591e0d20543060c29909c149ab1963a7267037b39eee03a83dbc50a8", size = 2938352, upload-time = "2025-10-19T00:40:59.49Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/a3/3b58c5c1692c3bacd65640d0d5c7267a7ebb76204f7507aec29de7063d2f/cytoolz-1.1.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:25db9e4862f22ea0ae2e56c8bec9fc9fd756b655ae13e8c7b5625d7ed1c582d4", size = 3022121, upload-time = "2025-10-19T00:41:01.209Z" },
     { url = "https://files.pythonhosted.org/packages/e1/93/c647bc3334355088c57351a536c2d4a83dd45f7de591fab383975e45bff9/cytoolz-1.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c7a98deb11ccd8e5d9f9441ef2ff3352aab52226a2b7d04756caaa53cd612363", size = 2857656, upload-time = "2025-10-19T00:41:03.456Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/c2/43fea146bf4141deea959e19dcddf268c5ed759dec5c2ed4a6941d711933/cytoolz-1.1.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dce4ee9fc99104bc77efdea80f32ca5a650cd653bcc8a1d984a931153d3d9b58", size = 2551284, upload-time = "2025-10-19T00:41:05.347Z" },
     { url = "https://files.pythonhosted.org/packages/6f/df/cdc7a81ce5cfcde7ef523143d545635fc37e80ccacce140ae58483a21da3/cytoolz-1.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:80d6da158f7d20c15819701bbda1c041f0944ede2f564f5c739b1bc80a9ffb8b", size = 2721673, upload-time = "2025-10-19T00:41:07.528Z" },
-    { url = "https://files.pythonhosted.org/packages/45/be/f8524bb9ad8812ad375e61238dcaa3177628234d1b908ad0b74e3657cafd/cytoolz-1.1.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:3b5c5a192abda123ad45ef716ec9082b4cf7d95e9ada8291c5c2cc5558be858b", size = 2722884, upload-time = "2025-10-19T00:41:09.698Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/dd/88619f9c8d2b682562c0c886bbb7c35720cb83fda2ac9a41bdd14073d9bd/cytoolz-1.1.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:e7e29a1a03f00b4322196cfe8e2c38da9a6c8d573566052c586df83aacc5663c", size = 2839661, upload-time = "2025-10-19T00:41:13.053Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/8d/4478ebf471ee78dd496d254dc0f4ad729cd8e6ba8257de4f0a98a2838ef2/cytoolz-1.1.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:5291b117d71652a817ec164e7011f18e6a51f8a352cc9a70ed5b976c51102fda", size = 2547095, upload-time = "2025-10-19T00:41:16.054Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/68/f1dea33367b0b3f64e199c230a14a6b6f243c189020effafd31e970ca527/cytoolz-1.1.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:8caef62f846a9011676c51bda9189ae394cdd6bb17f2946ecaedc23243268320", size = 2870901, upload-time = "2025-10-19T00:41:17.727Z" },
     { url = "https://files.pythonhosted.org/packages/4a/9a/33591c09dfe799b8fb692cf2ad383e2c41ab6593cc960b00d1fc8a145655/cytoolz-1.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:de425c5a8e3be7bb3a195e19191d28d9eb3c2038046064a92edc4505033ec9cb", size = 2765422, upload-time = "2025-10-19T00:41:20.075Z" },
     { url = "https://files.pythonhosted.org/packages/71/4a/b3ddb3ee44fe0045e95dd973746f93f033b6f92cce1fc3cbbe24b329943c/cytoolz-1.1.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:76c9b58555300be6dde87a41faf1f97966d79b9a678b7a526fcff75d28ef4945", size = 976728, upload-time = "2025-10-19T00:41:26.5Z" },
     { url = "https://files.pythonhosted.org/packages/42/21/a3681434aa425875dd828bb515924b0f12c37a55c7d2bc5c0c5de3aeb0b4/cytoolz-1.1.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:d1d638b10d3144795655e9395566ce35807df09219fd7cacd9e6acbdef67946a", size = 986057, upload-time = "2025-10-19T00:41:28.911Z" },
@@ -706,30 +661,14 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/be/b0/e50621d21e939338c97faab651f58ea7fa32101226a91de79ecfb89d71e1/cytoolz-1.1.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2a9a464542912d3272f6dccc5142df057c71c6a5cbd30439389a732df401afb7", size = 1317534, upload-time = "2025-10-19T00:41:32.625Z" },
     { url = "https://files.pythonhosted.org/packages/e1/53/5f4deb0ff958805309d135d899c764364c1e8a632ce4994bd7c45fb98df2/cytoolz-1.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56161f0ab60dc4159ec343509abaf809dc88e85c7e420e354442c62e3e7cbb77", size = 986118, upload-time = "2025-10-19T00:41:35.7Z" },
     { url = "https://files.pythonhosted.org/packages/59/8a/acc6e39a84e930522b965586ad3a36694f9bf247b23188ee0eb47b1c9ed1/cytoolz-1.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1842636b6e034f229bf084c2bcdcfd36c8437e752eefd2c74ce9e2f10415cb6e", size = 2813020, upload-time = "2025-10-19T00:41:39.935Z" },
-    { url = "https://files.pythonhosted.org/packages/db/f5/0083608286ad1716eda7c41f868e85ac549f6fd6b7646993109fa0bdfd98/cytoolz-1.1.0-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:823df012ab90d2f2a0f92fea453528539bf71ac1879e518524cd0c86aa6df7b9", size = 2669312, upload-time = "2025-10-19T00:41:41.55Z" },
-    { url = "https://files.pythonhosted.org/packages/47/a8/d16080b575520fe5da00cede1ece4e0a4180ec23f88dcdc6a2f5a90a7f7f/cytoolz-1.1.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2f1fcf9e7e7b3487883ff3f815abc35b89dcc45c4cf81c72b7ee457aa72d197b", size = 2922147, upload-time = "2025-10-19T00:41:43.252Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/bc/716c9c1243701e58cad511eb3937fd550e645293c5ed1907639c5d66f194/cytoolz-1.1.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4cdb3fa1772116827f263f25b0cdd44c663b6701346a56411960534a06c082de", size = 2981602, upload-time = "2025-10-19T00:41:45.354Z" },
     { url = "https://files.pythonhosted.org/packages/14/bc/571b232996846b27f4ac0c957dc8bf60261e9b4d0d01c8d955e82329544e/cytoolz-1.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d1b5c95041741b81430454db65183e133976f45ac3c03454cfa8147952568529", size = 2830103, upload-time = "2025-10-19T00:41:47.959Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/55/c594afb46ecd78e4b7e1fb92c947ed041807875661ceda73baaf61baba4f/cytoolz-1.1.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b2079fd9f1a65f4c61e6278c8a6d4f85edf30c606df8d5b32f1add88cbbe2286", size = 2533802, upload-time = "2025-10-19T00:41:49.683Z" },
     { url = "https://files.pythonhosted.org/packages/93/83/1edcf95832555a78fc43b975f3ebe8ceadcc9664dd47fd33747a14df5069/cytoolz-1.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a92a320d72bef1c7e2d4c6d875125cf57fc38be45feb3fac1bfa64ea401f54a4", size = 2706071, upload-time = "2025-10-19T00:41:51.386Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/df/035a408df87f25cfe3611557818b250126cd2281b2104cd88395de205583/cytoolz-1.1.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:06d1c79aa51e6a92a90b0e456ebce2288f03dd6a76c7f582bfaa3eda7692e8a5", size = 2707575, upload-time = "2025-10-19T00:41:53.305Z" },
-    { url = "https://files.pythonhosted.org/packages/30/7a/2c3d60682b26058d435416c4e90d4a94db854de5be944dfd069ed1be648a/cytoolz-1.1.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:964b248edc31efc50a65e9eaa0c845718503823439d2fa5f8d2c7e974c2b5409", size = 2819605, upload-time = "2025-10-19T00:41:58.257Z" },
-    { url = "https://files.pythonhosted.org/packages/45/92/19b722a1d83cc443fbc0c16e0dc376f8a451437890d3d9ee370358cf0709/cytoolz-1.1.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c9ff2b3c57c79b65cb5be14a18c6fd4a06d5036fb3f33e973a9f70e9ac13ca28", size = 2533559, upload-time = "2025-10-19T00:42:00.324Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/15/fa3b7891da51115204416f14192081d3dea0eaee091f123fdc1347de8dd1/cytoolz-1.1.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:22290b73086af600042d99f5ce52a43d4ad9872c382610413176e19fc1d4fd2d", size = 2839171, upload-time = "2025-10-19T00:42:01.881Z" },
     { url = "https://files.pythonhosted.org/packages/46/40/d3519d5cd86eebebf1e8b7174ec32dfb6ecec67b48b0cfb92bf226659b5a/cytoolz-1.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a2ade74fccd080ea793382968913ee38d7a35c921df435bbf0a6aeecf0d17574", size = 2743379, upload-time = "2025-10-19T00:42:03.809Z" },
     { url = "https://files.pythonhosted.org/packages/c4/ba/4a53acc60f59030fcaf48c7766e3c4c81bd997379425aa45b129396557b5/cytoolz-1.1.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:9e2cd93b28f667c5870a070ab2b8bb4397470a85c4b204f2454b0ad001cd1ca3", size = 1372336, upload-time = "2025-10-19T00:42:12.104Z" },
     { url = "https://files.pythonhosted.org/packages/c9/95/4561c4e0ad1c944f7673d6d916405d68080f10552cfc5d69a1cf2475a9a1/cytoolz-1.1.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:53a3262bf221f19437ed544bf8c0e1980c81ac8e2a53d87a9bc075dba943d36f", size = 1020610, upload-time = "2025-10-19T00:42:15.877Z" },
     { url = "https://files.pythonhosted.org/packages/4a/29/7cab6c609b4514ac84cca2f7dca6c509977a8fc16d27c3a50e97f105fa6a/cytoolz-1.1.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a5a8755c4104ee4e3d5ba434c543b5f85fdee6a1f1df33d93f518294da793a60", size = 3108951, upload-time = "2025-10-19T00:42:19.363Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/71/1d1103b819458679277206ad07d78ca6b31c4bb88d6463fd193e19bfb270/cytoolz-1.1.0-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4d96ff3d381423af1b105295f97de86d1db51732c9566eb37378bab6670c5010", size = 2807149, upload-time = "2025-10-19T00:42:20.964Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/d4/3d83a05a21e7d2ed2b9e6daf489999c29934b005de9190272b8a2e3735d0/cytoolz-1.1.0-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0ec96b3d537cdf47d4e76ded199f7440715f4c71029b45445cff92c1248808c2", size = 3111608, upload-time = "2025-10-19T00:42:22.684Z" },
-    { url = "https://files.pythonhosted.org/packages/51/88/96f68354c3d4af68de41f0db4fe41a23b96a50a4a416636cea325490cfeb/cytoolz-1.1.0-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:208e2f2ef90a32b0acbff3303d90d89b13570a228d491d2e622a7883a3c68148", size = 3179373, upload-time = "2025-10-19T00:42:24.395Z" },
     { url = "https://files.pythonhosted.org/packages/ce/50/ed87a5cd8e6f27ffbb64c39e9730e18ec66c37631db2888ae711909f10c9/cytoolz-1.1.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d416a81bb0bd517558668e49d30a7475b5445f9bbafaab7dcf066f1e9adba36", size = 3003120, upload-time = "2025-10-19T00:42:26.18Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/a7/acde155b050d6eaa8e9c7845c98fc5fb28501568e78e83ebbf44f8855274/cytoolz-1.1.0-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f32e94c91ffe49af04835ee713ebd8e005c85ebe83e7e1fdcc00f27164c2d636", size = 2703225, upload-time = "2025-10-19T00:42:27.93Z" },
     { url = "https://files.pythonhosted.org/packages/1b/b6/9d518597c5bdea626b61101e8d2ff94124787a42259dafd9f5fc396f346a/cytoolz-1.1.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:15d0c6405efc040499c46df44056a5c382f551a7624a41cf3e4c84a96b988a15", size = 2956033, upload-time = "2025-10-19T00:42:29.993Z" },
-    { url = "https://files.pythonhosted.org/packages/89/7a/93e5f860926165538c85e1c5e1670ad3424f158df810f8ccd269da652138/cytoolz-1.1.0-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:bf069c5381d757debae891401b88b3a346ba3a28ca45ba9251103b282463fad8", size = 2862950, upload-time = "2025-10-19T00:42:31.803Z" },
-    { url = "https://files.pythonhosted.org/packages/71/ca/adfa1fb7949478135a37755cb8e88c20cd6b75c22a05f1128f05f3ab2c60/cytoolz-1.1.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:3e3872c21170f8341656f8692f8939e8800dcee6549ad2474d4c817bdefd62cd", size = 2979049, upload-time = "2025-10-19T00:42:35.377Z" },
-    { url = "https://files.pythonhosted.org/packages/70/4c/7bf47a03a4497d500bc73d4204e2d907771a017fa4457741b2a1d7c09319/cytoolz-1.1.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:b9ddeff8e8fd65eb1fcefa61018100b2b627e759ea6ad275d2e2a93ffac147bf", size = 2699492, upload-time = "2025-10-19T00:42:37.133Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/e7/3d034b0e4817314f07aa465d5864e9b8df9d25cb260a53dd84583e491558/cytoolz-1.1.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:02feeeda93e1fa3b33414eb57c2b0aefd1db8f558dd33fdfcce664a0f86056e4", size = 2995646, upload-time = "2025-10-19T00:42:38.912Z" },
     { url = "https://files.pythonhosted.org/packages/c1/62/be357181c71648d9fe1d1ce91cd42c63457dcf3c158e144416fd51dced83/cytoolz-1.1.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:d08154ad45349162b6c37f12d5d1b2e6eef338e657b85e1621e4e6a4a69d64cb", size = 2919481, upload-time = "2025-10-19T00:42:40.85Z" },
 ]
 
@@ -778,9 +717,9 @@ name = "eth-abi"
 version = "5.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "eth-typing", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "eth-utils", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "parsimonious", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "eth-typing" },
+    { name = "eth-utils" },
+    { name = "parsimonious" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/00/71/d9e1380bd77fd22f98b534699af564f189b56d539cc2b9dab908d4e4c242/eth_abi-5.2.0.tar.gz", hash = "sha256:178703fa98c07d8eecd5ae569e7e8d159e493ebb6eeb534a8fe973fbc4e40ef0", size = 49797, upload-time = "2025-01-14T16:29:34.629Z" }
 wheels = [
@@ -792,16 +731,16 @@ name = "eth-account"
 version = "0.13.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "bitarray", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "ckzg", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "eth-abi", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "eth-keyfile", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "eth-keys", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "eth-rlp", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "eth-utils", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "hexbytes", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pydantic", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "rlp", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "bitarray" },
+    { name = "ckzg" },
+    { name = "eth-abi" },
+    { name = "eth-keyfile" },
+    { name = "eth-keys" },
+    { name = "eth-rlp" },
+    { name = "eth-utils" },
+    { name = "hexbytes" },
+    { name = "pydantic" },
+    { name = "rlp" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/74/cf/20f76a29be97339c969fd765f1237154286a565a1d61be98e76bb7af946a/eth_account-0.13.7.tar.gz", hash = "sha256:5853ecbcbb22e65411176f121f5f24b8afeeaf13492359d254b16d8b18c77a46", size = 935998, upload-time = "2025-04-21T21:11:21.204Z" }
 wheels = [
@@ -819,7 +758,7 @@ wheels = [
 
 [package.optional-dependencies]
 pycryptodome = [
-    { name = "pycryptodome", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pycryptodome" },
 ]
 
 [[package]]
@@ -827,9 +766,9 @@ name = "eth-keyfile"
 version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "eth-keys", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "eth-utils", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pycryptodome", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "eth-keys" },
+    { name = "eth-utils" },
+    { name = "pycryptodome" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/35/66/dd823b1537befefbbff602e2ada88f1477c5b40ec3731e3d9bc676c5f716/eth_keyfile-0.8.1.tar.gz", hash = "sha256:9708bc31f386b52cca0969238ff35b1ac72bd7a7186f2a84b86110d3c973bec1", size = 12267, upload-time = "2024-04-23T20:28:53.862Z" }
 wheels = [
@@ -841,8 +780,8 @@ name = "eth-keys"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "eth-typing", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "eth-utils", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "eth-typing" },
+    { name = "eth-utils" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/11/1ed831c50bd74f57829aa06e58bd82a809c37e070ee501c953b9ac1f1552/eth_keys-0.7.0.tar.gz", hash = "sha256:79d24fd876201df67741de3e3fefb3f4dbcbb6ace66e47e6fe662851a4547814", size = 30166, upload-time = "2025-04-07T17:40:21.697Z" }
 wheels = [
@@ -854,9 +793,9 @@ name = "eth-rlp"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "eth-utils", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "hexbytes", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "rlp", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "eth-utils" },
+    { name = "hexbytes" },
+    { name = "rlp" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7f/ea/ad39d001fa9fed07fad66edb00af701e29b48be0ed44a3bcf58cb3adf130/eth_rlp-2.2.0.tar.gz", hash = "sha256:5e4b2eb1b8213e303d6a232dfe35ab8c29e2d3051b86e8d359def80cd21db83d", size = 7720, upload-time = "2025-02-04T21:51:08.134Z" }
 wheels = [
@@ -868,7 +807,7 @@ name = "eth-typing"
 version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/37/e7/06c5af99ad40494f6d10126a9030ff4eb14c5b773f2a4076017efb0a163a/eth_typing-6.0.0.tar.gz", hash = "sha256:315dd460dc0b71c15a6cd51e3c0b70d237eec8771beb844144f3a1fb4adb2392", size = 21852, upload-time = "2026-03-25T16:41:57.444Z" }
 wheels = [
@@ -880,11 +819,11 @@ name = "eth-utils"
 version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cytoolz", marker = "(implementation_name == 'cpython' and platform_machine == 'arm64' and sys_platform == 'darwin') or (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "eth-hash", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "eth-typing", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pydantic", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "toolz", marker = "(implementation_name == 'pypy' and platform_machine == 'arm64' and sys_platform == 'darwin') or (implementation_name == 'pypy' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'pypy' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "cytoolz", marker = "implementation_name == 'cpython'" },
+    { name = "eth-hash" },
+    { name = "eth-typing" },
+    { name = "pydantic" },
+    { name = "toolz", marker = "implementation_name == 'pypy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e9/1b/0b8548da7b31eba87ed58bca1d0de5dcb13a6c113e02c09019ec5a6716ed/eth_utils-6.0.0.tar.gz", hash = "sha256:eb54b2f82dd300d3142c49a89da195e823f5e5284d43203593f87c67bad92a96", size = 123457, upload-time = "2026-03-25T17:11:51.433Z" }
 wheels = [
@@ -905,9 +844,9 @@ name = "fastapi"
 version = "0.115.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "starlette", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ca/53/8c38a874844a8b0fa10dd8adf3836ac154082cf88d3f22b544e9ceea0a15/fastapi-0.115.14.tar.gz", hash = "sha256:b1de15cdc1c499a4da47914db35d0e4ef8f1ce62b624e94e0e5824421df99739", size = 296263, upload-time = "2025-06-26T15:29:08.21Z" }
 wheels = [
@@ -919,9 +858,9 @@ name = "fastapi-utils"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "fastapi", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "psutil", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pydantic", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "fastapi" },
+    { name = "psutil" },
+    { name = "pydantic" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/dd/af/57c949675176acf389d94fbccd369b486579a952637fc6fb104f1bc3d0c3/fastapi_utils-0.8.0.tar.gz", hash = "sha256:eca834e80c09f85df30004fe5e861981262b296f60c93d5a1a1416fe4c784140", size = 16496, upload-time = "2024-11-11T08:30:03.852Z" }
 wheels = [
@@ -930,9 +869,9 @@ wheels = [
 
 [package.optional-dependencies]
 all = [
-    { name = "pydantic-settings", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "sqlalchemy", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typing-inspect", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pydantic-settings" },
+    { name = "sqlalchemy" },
+    { name = "typing-inspect" },
 ]
 
 [[package]]
@@ -972,37 +911,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/94/5c8a2b50a496b11dd519f4a24cb5496cf125681dd99e94c604ccdea9419a/frozenlist-1.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f833670942247a14eafbb675458b4e61c82e002a148f49e68257b79296e865c4", size = 50448, upload-time = "2025-10-06T05:36:08.78Z" },
     { url = "https://files.pythonhosted.org/packages/6a/bd/d91c5e39f490a49df14320f4e8c80161cfcce09f1e2cde1edd16a551abb3/frozenlist-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:494a5952b1c597ba44e0e78113a7266e656b9794eec897b19ead706bd7074383", size = 242411, upload-time = "2025-10-06T05:36:09.801Z" },
     { url = "https://files.pythonhosted.org/packages/8f/83/f61505a05109ef3293dfb1ff594d13d64a2324ac3482be2cedc2be818256/frozenlist-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96f423a119f4777a4a056b66ce11527366a8bb92f54e541ade21f2374433f6d4", size = 243014, upload-time = "2025-10-06T05:36:11.394Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/cb/cb6c7b0f7d4023ddda30cf56b8b17494eb3a79e3fda666bf735f63118b35/frozenlist-1.8.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3462dd9475af2025c31cc61be6652dfa25cbfb56cbbf52f4ccfe029f38decaf8", size = 234909, upload-time = "2025-10-06T05:36:12.598Z" },
-    { url = "https://files.pythonhosted.org/packages/31/c5/cd7a1f3b8b34af009fb17d4123c5a778b44ae2804e3ad6b86204255f9ec5/frozenlist-1.8.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c4c800524c9cd9bac5166cd6f55285957fcfc907db323e193f2afcd4d9abd69b", size = 250049, upload-time = "2025-10-06T05:36:14.065Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/01/2f95d3b416c584a1e7f0e1d6d31998c4a795f7544069ee2e0962a4b60740/frozenlist-1.8.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d6a5df73acd3399d893dafc71663ad22534b5aa4f94e8a2fabfe856c3c1b6a52", size = 256485, upload-time = "2025-10-06T05:36:15.39Z" },
     { url = "https://files.pythonhosted.org/packages/ce/03/024bf7720b3abaebcff6d0793d73c154237b85bdf67b7ed55e5e9596dc9a/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:405e8fe955c2280ce66428b3ca55e12b3c4e9c336fb2103a4937e891c69a4a29", size = 237619, upload-time = "2025-10-06T05:36:16.558Z" },
-    { url = "https://files.pythonhosted.org/packages/69/fa/f8abdfe7d76b731f5d8bd217827cf6764d4f1d9763407e42717b4bed50a0/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:908bd3f6439f2fef9e85031b59fd4f1297af54415fb60e4254a95f75b3cab3f3", size = 250320, upload-time = "2025-10-06T05:36:17.821Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/3c/b051329f718b463b22613e269ad72138cc256c540f78a6de89452803a47d/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:294e487f9ec720bd8ffcebc99d575f7eff3568a08a253d1ee1a0378754b74143", size = 246820, upload-time = "2025-10-06T05:36:19.046Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/ae/58282e8f98e444b3f4dd42448ff36fa38bef29e40d40f330b22e7108f565/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:74c51543498289c0c43656701be6b077f4b265868fa7f8a8859c197006efb608", size = 250518, upload-time = "2025-10-06T05:36:20.763Z" },
     { url = "https://files.pythonhosted.org/packages/8f/96/007e5944694d66123183845a106547a15944fbbb7154788cbf7272789536/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:776f352e8329135506a1d6bf16ac3f87bc25b28e765949282dcc627af36123aa", size = 239096, upload-time = "2025-10-06T05:36:22.129Z" },
     { url = "https://files.pythonhosted.org/packages/2d/40/0832c31a37d60f60ed79e9dfb5a92e1e2af4f40a16a29abcc7992af9edff/frozenlist-1.8.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8d92f1a84bb12d9e56f818b3a746f3efba93c1b63c8387a73dde655e1e42282a", size = 85717, upload-time = "2025-10-06T05:36:27.341Z" },
     { url = "https://files.pythonhosted.org/packages/0c/ab/6e5080ee374f875296c4243c381bbdef97a9ac39c6e3ce1d5f7d42cb78d6/frozenlist-1.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f21f00a91358803399890ab167098c131ec2ddd5f8f5fd5fe9c9f2c6fcd91e40", size = 49417, upload-time = "2025-10-06T05:36:29.877Z" },
     { url = "https://files.pythonhosted.org/packages/d5/4e/e4691508f9477ce67da2015d8c00acd751e6287739123113a9fca6f1604e/frozenlist-1.8.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fb30f9626572a76dfe4293c7194a09fb1fe93ba94c7d4f720dfae3b646b45027", size = 234391, upload-time = "2025-10-06T05:36:31.301Z" },
     { url = "https://files.pythonhosted.org/packages/40/76/c202df58e3acdf12969a7895fd6f3bc016c642e6726aa63bd3025e0fc71c/frozenlist-1.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eaa352d7047a31d87dafcacbabe89df0aa506abb5b1b85a2fb91bc3faa02d822", size = 233048, upload-time = "2025-10-06T05:36:32.531Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/c0/8746afb90f17b73ca5979c7a3958116e105ff796e718575175319b5bb4ce/frozenlist-1.8.0-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:03ae967b4e297f58f8c774c7eabcce57fe3c2434817d4385c50661845a058121", size = 226549, upload-time = "2025-10-06T05:36:33.706Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/eb/4c7eefc718ff72f9b6c4893291abaae5fbc0c82226a32dcd8ef4f7a5dbef/frozenlist-1.8.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f6292f1de555ffcc675941d65fffffb0a5bcd992905015f85d0592201793e0e5", size = 239833, upload-time = "2025-10-06T05:36:34.947Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/4e/e5c02187cf704224f8b21bee886f3d713ca379535f16893233b9d672ea71/frozenlist-1.8.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:29548f9b5b5e3460ce7378144c3010363d8035cea44bc0bf02d57f5a685e084e", size = 245363, upload-time = "2025-10-06T05:36:36.534Z" },
     { url = "https://files.pythonhosted.org/packages/1f/96/cb85ec608464472e82ad37a17f844889c36100eed57bea094518bf270692/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ec3cc8c5d4084591b4237c0a272cc4f50a5b03396a47d9caaf76f5d7b38a4f11", size = 229314, upload-time = "2025-10-06T05:36:38.582Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/6f/4ae69c550e4cee66b57887daeebe006fe985917c01d0fff9caab9883f6d0/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:517279f58009d0b1f2e7c1b130b377a349405da3f7621ed6bfae50b10adf20c1", size = 243365, upload-time = "2025-10-06T05:36:40.152Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/58/afd56de246cf11780a40a2c28dc7cbabbf06337cc8ddb1c780a2d97e88d8/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:db1e72ede2d0d7ccb213f218df6a078a9c09a7de257c2fe8fcef16d5925230b1", size = 237763, upload-time = "2025-10-06T05:36:41.355Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/36/cdfaf6ed42e2644740d4a10452d8e97fa1c062e2a8006e4b09f1b5fd7d63/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:b4dec9482a65c54a5044486847b8a66bf10c9cb4926d42927ec4e8fd5db7fed8", size = 240110, upload-time = "2025-10-06T05:36:42.716Z" },
     { url = "https://files.pythonhosted.org/packages/03/a8/9ea226fbefad669f11b52e864c55f0bd57d3c8d7eb07e9f2e9a0b39502e1/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:21900c48ae04d13d416f0e1e0c4d81f7931f73a9dfa0b7a8746fb2fe7dd970ed", size = 233717, upload-time = "2025-10-06T05:36:44.251Z" },
     { url = "https://files.pythonhosted.org/packages/d2/5c/3bbfaa920dfab09e76946a5d2833a7cbdf7b9b4a91c714666ac4855b88b4/frozenlist-1.8.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:e25ac20a2ef37e91c1b39938b591457666a0fa835c7783c3a8f33ea42870db94", size = 89235, upload-time = "2025-10-06T05:36:48.78Z" },
     { url = "https://files.pythonhosted.org/packages/1e/bb/a6d12b7ba4c3337667d0e421f7181c82dda448ce4e7ad7ecd249a16fa806/frozenlist-1.8.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4e0c11f2cc6717e0a741f84a527c52616140741cd812a50422f83dc31749fb52", size = 51725, upload-time = "2025-10-06T05:36:50.851Z" },
     { url = "https://files.pythonhosted.org/packages/bc/71/d1fed0ffe2c2ccd70b43714c6cab0f4188f09f8a67a7914a6b46ee30f274/frozenlist-1.8.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b3210649ee28062ea6099cfda39e147fa1bc039583c8ee4481cb7811e2448c51", size = 284533, upload-time = "2025-10-06T05:36:51.898Z" },
     { url = "https://files.pythonhosted.org/packages/c9/1f/fb1685a7b009d89f9bf78a42d94461bc06581f6e718c39344754a5d9bada/frozenlist-1.8.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:581ef5194c48035a7de2aefc72ac6539823bb71508189e5de01d60c9dcd5fa65", size = 292506, upload-time = "2025-10-06T05:36:53.101Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/3b/b991fe1612703f7e0d05c0cf734c1b77aaf7c7d321df4572e8d36e7048c8/frozenlist-1.8.0-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3ef2d026f16a2b1866e1d86fc4e1291e1ed8a387b2c333809419a2f8b3a77b82", size = 274161, upload-time = "2025-10-06T05:36:54.309Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/ec/c5c618767bcdf66e88945ec0157d7f6c4a1322f1473392319b7a2501ded7/frozenlist-1.8.0-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5500ef82073f599ac84d888e3a8c1f77ac831183244bfd7f11eaa0289fb30714", size = 294676, upload-time = "2025-10-06T05:36:55.566Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/ce/3934758637d8f8a88d11f0585d6495ef54b2044ed6ec84492a91fa3b27aa/frozenlist-1.8.0-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:50066c3997d0091c411a66e710f4e11752251e6d2d73d70d8d5d4c76442a199d", size = 300638, upload-time = "2025-10-06T05:36:56.758Z" },
     { url = "https://files.pythonhosted.org/packages/fc/4f/a7e4d0d467298f42de4b41cbc7ddaf19d3cfeabaf9ff97c20c6c7ee409f9/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:5c1c8e78426e59b3f8005e9b19f6ff46e5845895adbde20ece9218319eca6506", size = 283067, upload-time = "2025-10-06T05:36:57.965Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/48/c7b163063d55a83772b268e6d1affb960771b0e203b632cfe09522d67ea5/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:eefdba20de0d938cec6a89bd4d70f346a03108a19b9df4248d3cf0d88f1b0f51", size = 292101, upload-time = "2025-10-06T05:36:59.237Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/d0/2366d3c4ecdc2fd391e0afa6e11500bfba0ea772764d631bbf82f0136c9d/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:cf253e0e1c3ceb4aaff6df637ce033ff6535fb8c70a764a8f46aafd3d6ab798e", size = 289901, upload-time = "2025-10-06T05:37:00.811Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/94/daff920e82c1b70e3618a2ac39fbc01ae3e2ff6124e80739ce5d71c9b920/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:032efa2674356903cd0261c4317a561a6850f3ac864a63fc1583147fb05a79b0", size = 289395, upload-time = "2025-10-06T05:37:02.115Z" },
     { url = "https://files.pythonhosted.org/packages/e3/20/bba307ab4235a09fdcd3cc5508dbabd17c4634a1af4b96e0f69bfe551ebd/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6da155091429aeba16851ecb10a9104a108bcd32f6c1642867eadaee401c1c41", size = 283659, upload-time = "2025-10-06T05:37:03.711Z" },
     { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
 ]
@@ -1021,7 +942,7 @@ name = "gitdb"
 version = "4.0.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "smmap", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "smmap" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", size = 394684, upload-time = "2025-01-02T07:20:46.413Z" }
 wheels = [
@@ -1033,7 +954,7 @@ name = "gitpython"
 version = "3.1.50"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "gitdb", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "gitdb" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
 wheels = [
@@ -1045,11 +966,11 @@ name = "google-api-core"
 version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "google-auth", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "googleapis-common-protos", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "proto-plus", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "protobuf", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "requests", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c6/22/155cadf1d49272a9cf48f3168c0f3874fa13397297e611a5ea00cd093880/google_api_core-2.31.0.tar.gz", hash = "sha256:2be84ee0f584c48e6bde1b36766e23348b361fb7e55e56135fc76ce1c397f9c2", size = 176492, upload-time = "2026-06-03T14:52:17.257Z" }
 wheels = [
@@ -1058,8 +979,8 @@ wheels = [
 
 [package.optional-dependencies]
 grpc = [
-    { name = "grpcio", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "grpcio-status", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "grpcio" },
+    { name = "grpcio-status" },
 ]
 
 [[package]]
@@ -1067,8 +988,8 @@ name = "google-auth"
 version = "2.53.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pyasn1-modules", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c6/ad/ff781329bbbdc0974a098d996e89c9e1f7024262f9e3eec442fbb9ad1ac6/google_auth-2.53.0.tar.gz", hash = "sha256:e7e6aa16f6bee7b2b264830fd04f08087a1d5a836df516251a5d15327b246c9c", size = 335844, upload-time = "2026-05-15T20:53:07.928Z" }
 wheels = [
@@ -1080,11 +1001,11 @@ name = "google-cloud-appengine-logging"
 version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "google-api-core", extra = ["grpc"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "google-auth", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "grpcio", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "proto-plus", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "protobuf", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
+    { name = "grpcio" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7f/b9/fcafc8d2dc68975a65cdff74807547cff9b2a7b00e738d3f5ff0bd112867/google_cloud_appengine_logging-1.10.0.tar.gz", hash = "sha256:b5563e76010a36e6adf1cc489620c29ee4fb3b986b006d237e9a061eb0f0abb7", size = 17744, upload-time = "2026-06-03T14:52:40.298Z" }
 wheels = [
@@ -1096,8 +1017,8 @@ name = "google-cloud-audit-log"
 version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "googleapis-common-protos", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "protobuf", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "googleapis-common-protos" },
+    { name = "protobuf" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/01/46/b971191224557091cc865b47d527e61da180e33b9397904bdefdae1dcacd/google_cloud_audit_log-0.6.0.tar.gz", hash = "sha256:4dd343683c0bb31187ebef3426803f13159e950fbea3fe60a864855cfed959b8", size = 44674, upload-time = "2026-06-03T14:52:48.095Z" }
 wheels = [
@@ -1109,8 +1030,8 @@ name = "google-cloud-core"
 version = "2.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "google-api-core", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "google-auth", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "google-api-core" },
+    { name = "google-auth" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/dd/1eef226e470369b26824a505c34482c0b493bc35fe8e0c6b003b5feca21a/google_cloud_core-2.6.0.tar.gz", hash = "sha256:e76149739f90fac1fc6757c09f47eaccb3145b54adbd7759b0f7c4b235f46c83", size = 36001, upload-time = "2026-05-07T08:04:04.124Z" }
 wheels = [
@@ -1122,16 +1043,16 @@ name = "google-cloud-logging"
 version = "3.16.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "google-api-core", extra = ["grpc"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "google-auth", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "google-cloud-appengine-logging", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "google-cloud-audit-log", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "google-cloud-core", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "grpc-google-iam-v1", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "grpcio", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "opentelemetry-api", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "proto-plus", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "protobuf", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
+    { name = "google-cloud-appengine-logging" },
+    { name = "google-cloud-audit-log" },
+    { name = "google-cloud-core" },
+    { name = "grpc-google-iam-v1" },
+    { name = "grpcio" },
+    { name = "opentelemetry-api" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9b/ba/e749846f13c8d1c6c01eb6317e8b09abc130fe67b5d72081a48d1bf96971/google_cloud_logging-3.16.0.tar.gz", hash = "sha256:08a3076b8f0f724219d6f73b2a242ef69d51e8bce226133aebe41a25f23f5400", size = 293703, upload-time = "2026-06-03T15:28:23.862Z" }
 wheels = [
@@ -1143,11 +1064,11 @@ name = "google-cloud-trace"
 version = "1.19.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "google-api-core", extra = ["grpc"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "google-auth", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "grpcio", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "proto-plus", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "protobuf", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
+    { name = "grpcio" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/89/7b/c2a5848c4722373c92b500b65e6308ad89ca0c7c01054e0d948c58c107f2/google_cloud_trace-1.19.0.tar.gz", hash = "sha256:58293c6efcee6c74bb854ff01b008823bef66845c14f15ffa5209d545098a65d", size = 103875, upload-time = "2026-03-26T22:18:18.123Z" }
 wheels = [
@@ -1159,7 +1080,7 @@ name = "googleapis-common-protos"
 version = "1.75.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "protobuf", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "protobuf" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
 wheels = [
@@ -1168,7 +1089,7 @@ wheels = [
 
 [package.optional-dependencies]
 grpc = [
-    { name = "grpcio", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "grpcio" },
 ]
 
 [[package]]
@@ -1178,17 +1099,11 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6d/6e/802acd792aebb2256fbbee8cacf2727faaeb6f240ac11008f09eae4414bc/greenlet-3.5.1.tar.gz", hash = "sha256:5a56aeb7d5d9cc4b3a735efb5095bd4b4f6f0e4f93e5ca876d0e2315137b7829", size = 197356, upload-time = "2026-05-20T15:05:03.917Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/ff/a4f436709716965eaab9f36ea7b906c8a927fbe32fb1372a2071d964f6b1/greenlet-3.5.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ffea73584b216150eab159b6d12348fb253e68757974de1e2c40d8a318ac89ed", size = 601585, upload-time = "2026-05-20T14:00:06.141Z" },
-    { url = "https://files.pythonhosted.org/packages/65/ad/54bc3fcee3ad368a61b19b67d88117f7a8c29727bf71fffdeda81fbd946e/greenlet-3.5.1-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1072b4f9edcc1e192d9283a66a3e68d6b84c561de33a83d7858beb9ba1effe10", size = 614215, upload-time = "2026-05-20T14:05:42.675Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/6c/de5b1b388cd2d9fbdfeab324863daba37d54e6e233ddbefd70b385a8c591/greenlet-3.5.1-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:89101bfd5011e069be974903cb3a4e4523845e4ece2d62dcd8d358933c0ef249", size = 620094, upload-time = "2026-05-20T14:09:09.18Z" },
     { url = "https://files.pythonhosted.org/packages/40/69/b91cda0647df839483201545913514c2827ebea5e5ccdf931842763bc127/greenlet-3.5.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:add5217d68b31130f0beca584d7fef4878327d2e31642b66618a14eef312b63b", size = 611358, upload-time = "2026-05-20T13:14:26.37Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/43/1204baffab8a6476464795a7ccf394a3248d4f22c9f87173a15b36b6d971/greenlet-3.5.1-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:e6cd99ea59dd5d89f0c956606571d79bfe6f68c9eb7f4a4083a41a7f1587edee", size = 422782, upload-time = "2026-05-20T14:01:39.597Z" },
     { url = "https://files.pythonhosted.org/packages/59/90/3cf77e080350cd02fa307bb2abf05df48f4482c240275bbd2c203ba8bb1c/greenlet-3.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a5ea42a752d47a145eae922b605cd1634665ac3d5ec1e72402d5048e8d60d207", size = 1570475, upload-time = "2026-05-20T14:02:25.29Z" },
     { url = "https://files.pythonhosted.org/packages/65/2c/18cece62045e74598c3c393f70dce4a63f56222015ba29a5d4eeb04f764c/greenlet-3.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c5551170cf4f5ff5623e9af81323751979fee2c731e2287b61f73cd27257b823", size = 1635625, upload-time = "2026-05-20T13:14:34.027Z" },
     { url = "https://files.pythonhosted.org/packages/b1/bf/387f9b6b865fd2ae0d0be09e0004827295a01b71be76ed350dd1e28a91a4/greenlet-3.5.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ffdb3c0bb002c99cd8f298957e046c3dbf6006b5b7cdf11a4e19194624a0a0a", size = 604370, upload-time = "2026-05-20T14:00:07.492Z" },
-    { url = "https://files.pythonhosted.org/packages/32/f5/169ce3d4e4c67291bd18f8cbe0299c9f3e45102c7f1fb3c14780c93e4532/greenlet-3.5.1-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7715a5a2c3378ba602c3a440558261e13a820bb53a82693aacd7b7f6d964e283", size = 616987, upload-time = "2026-05-20T14:05:44.237Z" },
-    { url = "https://files.pythonhosted.org/packages/19/ba/c24110c55dffa55aa6e1d98b45310da33801aeba7686ff0190fe5d46fd32/greenlet-3.5.1-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d40a890035c0058cadbdc4af7569800fd28a0e527a0fdbb7b5f9418f176846ce", size = 622911, upload-time = "2026-05-20T14:09:10.598Z" },
     { url = "https://files.pythonhosted.org/packages/ee/e5/7f2e41d5273be07e77560d61ea4e56485b4d6c316d2a84518c62d1364061/greenlet-3.5.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc71ff466927a201b08305acac451ebe1aedfcea002f62f1f2f2ac2ac1e6a135", size = 613911, upload-time = "2026-05-20T13:14:27.539Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/7b/d20db2e8a5ad6c038702f3179b136f93f0a3d1a21a0c0777f3e470cdf4b2/greenlet-3.5.1-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:67821bb03e4e98664490edb787ff6af501194c29bbee0f5c1dfdcf1dc3d9d436", size = 425228, upload-time = "2026-05-20T14:01:40.837Z" },
     { url = "https://files.pythonhosted.org/packages/c5/a4/fbdc67579b73615a1f91615e814303cc71e06128f7baaba87be79b8fb90c/greenlet-3.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cd443683db272ebaaca03af98c0b063ab30db70ea8a31a1559f35e3f7b744ccd", size = 1570689, upload-time = "2026-05-20T14:02:27.225Z" },
     { url = "https://files.pythonhosted.org/packages/e6/b4/77abbe35078be39718a46cd49caf16bceb35662f97a34101dca28aa98e47/greenlet-3.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:089fff7a6ce8d9316d1f65ebc00273a56be258c1725b32b94de90a3a979557e1", size = 1635602, upload-time = "2026-05-20T13:14:36.344Z" },
 ]
@@ -1198,9 +1113,9 @@ name = "grpc-google-iam-v1"
 version = "0.14.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "googleapis-common-protos", extra = ["grpc"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "grpcio", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "protobuf", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "googleapis-common-protos", extra = ["grpc"] },
+    { name = "grpcio" },
+    { name = "protobuf" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/44/4f/d098419ad0bfc06c9ce440575f05aa22d8973b6c276e86ac7890093d3c37/grpc_google_iam_v1-0.14.4.tar.gz", hash = "sha256:392b3796947ed6334e61171d9ab06bf7eb357f554e5fc7556ad7aab6d0e17038", size = 23706, upload-time = "2026-04-01T01:57:49.813Z" }
 wheels = [
@@ -1212,17 +1127,15 @@ name = "grpcio"
 version = "1.81.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/15/f3/23f47b24f8d8c2028eba501db3acfbb2f592cbb5995eaa6e363a627b74d7/grpcio-1.81.0.tar.gz", hash = "sha256:a5acd7efd3b1fe9b4eb0bcaaa1507eed68a0ad0678b654c3f7b464df9ba9dca5", size = 13032272, upload-time = "2026-06-01T05:56:22.827Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/d5/896a3aaf07068d707d88b282a04914b872db4d32d3c7e6d88e43a3b911fa/grpcio-1.81.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:57b3b0e73a518fa286959b40c3eddd02703504ca186e8b7b2945954519bd8b2c", size = 6053538, upload-time = "2026-06-01T05:54:58.965Z" },
     { url = "https://files.pythonhosted.org/packages/68/6a/7e3eafa4727cd405ff917605ed2949e2af162f233f5cbdd773723a5fea7d/grpcio-1.81.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:8bb1789c94322a13336a2b6c58d9c14d68f8628b6e24205a799c69f5bf8516ce", size = 12053447, upload-time = "2026-06-01T05:55:01.862Z" },
     { url = "https://files.pythonhosted.org/packages/16/79/a4302aa82428de48a922421f522b027a1a727ab4d0926368454aa953d36d/grpcio-1.81.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e4d053900a0d24b75d7521139a3872150301b3d6bde3bed5e12318fb25791e4d", size = 6595872, upload-time = "2026-06-01T05:55:04.946Z" },
     { url = "https://files.pythonhosted.org/packages/e2/98/1f3896a9baae1f2aedf4e99c55291d6fa1f30ad9603d63bc18bda967b53e/grpcio-1.81.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:19f201da7b4e5c0559198abe5a97157e726f3abe6e8f5e832d4a50740f6dcc22", size = 6809676, upload-time = "2026-06-01T05:55:09.513Z" },
     { url = "https://files.pythonhosted.org/packages/34/8b/3441983718095208c5d797fd3239882e97ea89a629f41c8df94b4eef4df9/grpcio-1.81.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:275144b0115353339dbb8a6f28a9cf8997b5bf40e37f8f66ac0b0ea57e95b43f", size = 7412654, upload-time = "2026-06-01T05:55:12.777Z" },
     { url = "https://files.pythonhosted.org/packages/5c/73/3860341e6a1f5347be6ab35c6c0e1e3a8eb59d010388207fd561dcf01a88/grpcio-1.81.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c6ff087cb1f563f47b504b4e29e684129fc5ae4863faf3ebca08a327764ee6cb", size = 7849498, upload-time = "2026-06-01T05:55:18.078Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/29/779ee53c931d0fd55c1d459fde43e485172caa3ac87cbd43d003a13a0185/grpcio-1.81.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:62bbe463c9f0f2ff24e31bd25f8dd8b4bae78900e315915a3195a0ef1471a855", size = 6054973, upload-time = "2026-06-01T05:55:25.043Z" },
     { url = "https://files.pythonhosted.org/packages/9e/b6/7211807926b5a17f8d9a5d47c739a163d6812fefe3e4714e81cf92945ed7/grpcio-1.81.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:43c121e135ae44d1559b430db2b2dfad7421cbbe40e1deba506c7dc62b439719", size = 12048662, upload-time = "2026-06-01T05:55:28.453Z" },
     { url = "https://files.pythonhosted.org/packages/64/89/b1b93ef6b34bd20bbaf707fa99133bc9cc302139d5ec6f77a165c7169796/grpcio-1.81.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f345de40ef2e65f63645d53d251824e6070e07804827c5b00ec2e44555f9f901", size = 6599116, upload-time = "2026-06-01T05:55:31.185Z" },
     { url = "https://files.pythonhosted.org/packages/65/4a/1df2a4cb4a1386e066ab7e4175e34bb884b35ccb60d3621c09c84af6aabb/grpcio-1.81.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a524cd530900bd24511fcb7f2ed144da4ea37711c4b094475d0bceca7a93a170", size = 6811797, upload-time = "2026-06-01T05:55:36.731Z" },
@@ -1235,9 +1148,9 @@ name = "grpcio-status"
 version = "1.81.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "googleapis-common-protos", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "grpcio", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "protobuf", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "protobuf" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/01/b6/cdc177114997d15c887fb09ccfd16705c8ceb8b4ca2487902b54a7bfd1af/grpcio_status-1.81.0.tar.gz", hash = "sha256:b6fe9788cfdd1f0f63c0528a1e0bfdb41e8ff0583e920d2d8e8888598c01bb69", size = 13900, upload-time = "2026-06-01T06:00:32.638Z" }
 wheels = [
@@ -1267,8 +1180,8 @@ name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "h11", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "certifi" },
+    { name = "h11" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
@@ -1280,10 +1193,10 @@ name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "certifi", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "httpcore", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "idna", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
@@ -1313,19 +1226,19 @@ name = "ipykernel"
 version = "7.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "appnope", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
-    { name = "comm", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "debugpy", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "ipython", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "jupyter-client", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "jupyter-core", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "matplotlib-inline", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nest-asyncio2", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "packaging", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "psutil", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pyzmq", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "tornado", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "traitlets", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "appnope", marker = "sys_platform != 'linux'" },
+    { name = "comm" },
+    { name = "debugpy" },
+    { name = "ipython" },
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "matplotlib-inline" },
+    { name = "nest-asyncio2" },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "pyzmq" },
+    { name = "tornado" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3d/c4/e4a38f579de4225a561305666f7541cdabb30075def2aa1ac17bd73c1fb5/ipykernel-7.3.0.tar.gz", hash = "sha256:9acaaaf97d16355166e4085afe9d225bfbdf2b7ef520f9df3be8f2b248275e09", size = 184899, upload-time = "2026-06-10T08:41:25.481Z" }
 wheels = [
@@ -1337,15 +1250,15 @@ name = "ipython"
 version = "9.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "decorator", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "ipython-pygments-lexers", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "jedi", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "matplotlib-inline", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pexpect", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "prompt-toolkit", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pygments", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "stack-data", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "traitlets", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/73/7114f80a8f9cabdb13c27732dce24af945b2923dcab80723602f7c8bc2d8/ipython-9.12.0.tar.gz", hash = "sha256:01daa83f504b693ba523b5a407246cabde4eb4513285a3c6acaff11a66735ee4", size = 4428879, upload-time = "2026-03-27T09:42:45.312Z" }
 wheels = [
@@ -1357,7 +1270,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -1369,11 +1282,11 @@ name = "ipywidgets"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "comm", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "ipython", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "jupyterlab-widgets", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "traitlets", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "widgetsnbextension", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "comm" },
+    { name = "ipython" },
+    { name = "jupyterlab-widgets" },
+    { name = "traitlets" },
+    { name = "widgetsnbextension" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4c/ae/c5ce1edc1afe042eadb445e95b0671b03cee61895264357956e61c0d2ac0/ipywidgets-8.1.8.tar.gz", hash = "sha256:61f969306b95f85fba6b6986b7fe45d73124d1d9e3023a8068710d47a22ea668", size = 116739, upload-time = "2025-11-01T21:18:12.393Z" }
 wheels = [
@@ -1385,7 +1298,7 @@ name = "isoduration"
 version = "20.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "arrow", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "arrow" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7c/1a/3c8edc664e06e6bd06cce40c6b22da5f1429aa4224d0c590f3be21c91ead/isoduration-20.11.0.tar.gz", hash = "sha256:ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9", size = 11649, upload-time = "2020-11-01T11:00:00.312Z" }
 wheels = [
@@ -1397,7 +1310,7 @@ name = "jedi"
 version = "0.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "parso", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "parso" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/46/b7/a3635f6a2d7cf5b5dd98064fc1d5fbbafcb25477bcea204a3a92145d158b/jedi-0.20.0.tar.gz", hash = "sha256:c3f4ccbd276696f4b19c54618d4fb18f9fc24b0aef02acf704b23f487daa1011", size = 3119416, upload-time = "2026-05-01T23:38:47.814Z" }
 wheels = [
@@ -1409,7 +1322,7 @@ name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markupsafe", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "markupsafe" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
@@ -1439,10 +1352,10 @@ name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "jsonschema-specifications", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "referencing", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "rpds-py", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
 wheels = [
@@ -1451,15 +1364,15 @@ wheels = [
 
 [package.optional-dependencies]
 format-nongpl = [
-    { name = "fqdn", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "idna", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "isoduration", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "jsonpointer", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "rfc3339-validator", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "rfc3986-validator", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "rfc3987-syntax", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "uri-template", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "webcolors", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "fqdn" },
+    { name = "idna" },
+    { name = "isoduration" },
+    { name = "jsonpointer" },
+    { name = "rfc3339-validator" },
+    { name = "rfc3986-validator" },
+    { name = "rfc3987-syntax" },
+    { name = "uri-template" },
+    { name = "webcolors" },
 ]
 
 [[package]]
@@ -1467,7 +1380,7 @@ name = "jsonschema-specifications"
 version = "2025.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "referencing", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "referencing" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
@@ -1479,12 +1392,12 @@ name = "jupyter"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ipykernel", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "ipywidgets", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "jupyter-console", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "jupyterlab", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nbconvert", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "notebook", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "ipykernel" },
+    { name = "ipywidgets" },
+    { name = "jupyter-console" },
+    { name = "jupyterlab" },
+    { name = "nbconvert" },
+    { name = "notebook" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/f3/af28ea964ab8bc1e472dba2e82627d36d470c51f5cd38c37502eeffaa25e/jupyter-1.1.1.tar.gz", hash = "sha256:d55467bceabdea49d7e3624af7e33d59c37fff53ed3a350e1ac957bed731de7a", size = 5714959, upload-time = "2024-08-30T07:15:48.299Z" }
 wheels = [
@@ -1496,12 +1409,12 @@ name = "jupyter-client"
 version = "8.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jupyter-core", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "python-dateutil", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pyzmq", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "tornado", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "traitlets", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "jupyter-core" },
+    { name = "python-dateutil" },
+    { name = "pyzmq" },
+    { name = "tornado" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7d/dc/5512503b088997c2250b8bf18258fba9d9ce5ead641183700960d3c9d342/jupyter_client-8.9.1.tar.gz", hash = "sha256:a58f730dd9e728ba16ba1d62ebccf7ffe1ebbdbce4e95cfae941b7321ae1f4fa", size = 359256, upload-time = "2026-06-09T13:15:01.033Z" }
 wheels = [
@@ -1513,14 +1426,14 @@ name = "jupyter-console"
 version = "6.6.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ipykernel", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "ipython", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "jupyter-client", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "jupyter-core", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "prompt-toolkit", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pygments", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pyzmq", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "traitlets", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "ipykernel" },
+    { name = "ipython" },
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "pyzmq" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bd/2d/e2fd31e2fc41c14e2bcb6c976ab732597e907523f6b2420305f9fc7fdbdb/jupyter_console-6.6.3.tar.gz", hash = "sha256:566a4bf31c87adbfadf22cdf846e3069b59a71ed5da71d6ba4d8aaad14a53539", size = 34363, upload-time = "2023-03-06T14:13:31.02Z" }
 wheels = [
@@ -1532,8 +1445,8 @@ name = "jupyter-core"
 version = "5.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "platformdirs", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "traitlets", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "platformdirs" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/49/9d1284d0dc65e2c757b74c6687b6d319b02f822ad039e5c512df9194d9dd/jupyter_core-5.9.1.tar.gz", hash = "sha256:4d09aaff303b9566c3ce657f580bd089ff5c91f5f89cf7d8846c3cdf465b5508", size = 89814, upload-time = "2025-10-16T19:19:18.444Z" }
 wheels = [
@@ -1545,14 +1458,14 @@ name = "jupyter-events"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jsonschema", extra = ["format-nongpl"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "packaging", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "python-json-logger", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pyyaml", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "referencing", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "rfc3339-validator", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "rfc3986-validator", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "traitlets", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "jsonschema", extra = ["format-nongpl"] },
+    { name = "packaging" },
+    { name = "python-json-logger" },
+    { name = "pyyaml" },
+    { name = "referencing" },
+    { name = "rfc3339-validator" },
+    { name = "rfc3986-validator" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/18/f8/475c4241b2b75af0deaae453ed003c6c851766dbc44d332d8baf245dc931/jupyter_events-0.12.1.tar.gz", hash = "sha256:faff25f77218335752f35f23c5fe6e4a392a7bd99a5939ccb9b8fbf594636cf3", size = 62854, upload-time = "2026-04-20T23:17:50.66Z" }
 wheels = [
@@ -1564,7 +1477,7 @@ name = "jupyter-lsp"
 version = "2.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jupyter-server", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "jupyter-server" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/36/ff/1e4a61f5170a9a1d978f3ac3872449de6c01fc71eaf89657824c878b1549/jupyter_lsp-2.3.1.tar.gz", hash = "sha256:fdf8a4aa7d85813976d6e29e95e6a2c8f752701f926f2715305249a3829805a6", size = 55677, upload-time = "2026-04-02T08:10:06.749Z" }
 wheels = [
@@ -1576,23 +1489,23 @@ name = "jupyter-server"
 version = "2.19.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "argon2-cffi", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "jinja2", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "jupyter-client", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "jupyter-core", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "jupyter-events", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "jupyter-server-terminals", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nbconvert", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nbformat", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "packaging", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "prometheus-client", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pyzmq", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "send2trash", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "terminado", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "tornado", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "traitlets", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "websocket-client", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "anyio" },
+    { name = "argon2-cffi" },
+    { name = "jinja2" },
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "jupyter-events" },
+    { name = "jupyter-server-terminals" },
+    { name = "nbconvert" },
+    { name = "nbformat" },
+    { name = "packaging" },
+    { name = "prometheus-client" },
+    { name = "pyzmq" },
+    { name = "send2trash" },
+    { name = "terminado" },
+    { name = "tornado" },
+    { name = "traitlets" },
+    { name = "websocket-client" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/a0/eb3c511f54df7b54ca5fc7bff3f4d2277d69052d6a7f521643dfed5279d6/jupyter_server-2.19.0.tar.gz", hash = "sha256:1731236bc32b680223e1ceb9d68209a845203475012ef68773a81434b46a31a7", size = 754561, upload-time = "2026-05-29T11:21:26.057Z" }
 wheels = [
@@ -1604,7 +1517,7 @@ name = "jupyter-server-terminals"
 version = "0.5.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "terminado", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "terminado" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f4/a7/bcd0a9b0cbba88986fe944aaaf91bfda603e5a50bda8ed15123f381a3b2f/jupyter_server_terminals-0.5.4.tar.gz", hash = "sha256:bbda128ed41d0be9020349f9f1f2a4ab9952a73ed5f5ac9f1419794761fb87f5", size = 31770, upload-time = "2026-01-14T16:53:20.213Z" }
 wheels = [
@@ -1616,19 +1529,19 @@ name = "jupyterlab"
 version = "4.5.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "async-lru", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "httpx", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "ipykernel", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "jinja2", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "jupyter-core", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "jupyter-lsp", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "jupyter-server", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "jupyterlab-server", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "notebook-shim", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "packaging", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "setuptools", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "tornado", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "traitlets", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "async-lru" },
+    { name = "httpx" },
+    { name = "ipykernel" },
+    { name = "jinja2" },
+    { name = "jupyter-core" },
+    { name = "jupyter-lsp" },
+    { name = "jupyter-server" },
+    { name = "jupyterlab-server" },
+    { name = "notebook-shim" },
+    { name = "packaging" },
+    { name = "setuptools" },
+    { name = "tornado" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/74/089613e6099e851a6130816f2df592c839d8565f8746a701edada05a33e4/jupyterlab-4.5.8.tar.gz", hash = "sha256:af54d7242cc689a1e6c3ad213cc9b6d9781787d9ec67c52ec9a8f4707088cadd", size = 23994076, upload-time = "2026-06-04T12:32:12.906Z" }
 wheels = [
@@ -1649,13 +1562,13 @@ name = "jupyterlab-server"
 version = "2.28.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "babel", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "jinja2", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "json5", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "jsonschema", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "jupyter-server", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "packaging", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "requests", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "babel" },
+    { name = "jinja2" },
+    { name = "json5" },
+    { name = "jsonschema" },
+    { name = "jupyter-server" },
+    { name = "packaging" },
+    { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d6/2c/90153f189e421e93c4bb4f9e3f59802a1f01abd2ac5cf40b152d7f735232/jupyterlab_server-2.28.0.tar.gz", hash = "sha256:35baa81898b15f93573e2deca50d11ac0ae407ebb688299d3a5213265033712c", size = 76996, upload-time = "2025-10-22T13:59:18.37Z" }
 wheels = [
@@ -1689,16 +1602,12 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/24/8493538fa4f62f982686398a5b8f68008138a75086abdea19ade64bf4255/librt-0.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40071fc5fe0ce8daa6de616702314a01e1250711682b0523d6ab8d4525910cb3", size = 143614, upload-time = "2026-05-10T18:15:54.657Z" },
     { url = "https://files.pythonhosted.org/packages/ff/1e/f8bad050810d9171f34a1648ed910e56814c2ba61639f2bd53c6377ae24b/librt-0.11.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:137e79445c896a0ea7b265f52d23954e05b64222ee1af69e2cb34219067cbb67", size = 485538, upload-time = "2026-05-10T18:15:56.117Z" },
     { url = "https://files.pythonhosted.org/packages/b0/da/5d1876984b3746c85dbd219dbfcb73c85f54ee263fd32e5b2a632ec14571/librt-0.11.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d5b0eea49f5562861ee8d757a32ef7d559c1d35be2aaaa1ec28941d74c9ffc8a", size = 513082, upload-time = "2026-05-10T18:15:58.805Z" },
-    { url = "https://files.pythonhosted.org/packages/19/6e/55bdf5d5ca00c3e18430690bf2c953d8d3ffd3c337418173d33dec985dc9/librt-0.11.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0d1029d7e1ae1a7e647ed6fb5df8c4ce2dffefb7a9f5fd1376a4554d96dac09f", size = 508105, upload-time = "2026-05-10T18:16:00.2Z" },
     { url = "https://files.pythonhosted.org/packages/07/10/f1f23a7c595ee90ece4d35c851e5d104b1311a887ed1b4ac4c35bbd13da8/librt-0.11.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bc3ce6b33c5828d9e80592011a5c584cb2ce86edbc4088405f70da47dc1d1b3b", size = 522268, upload-time = "2026-05-10T18:16:01.708Z" },
-    { url = "https://files.pythonhosted.org/packages/50/db/b4a47c6f91db4ff76348a0b3dd0cc65e090a078b765a810a62ff9434c3d3/librt-0.11.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:9bc0ca6ad9381cbe8e4aa6e5726e4c80c78115a6e9723c599ed1d73e092bc49d", size = 516294, upload-time = "2026-05-10T18:16:05.173Z" },
     { url = "https://files.pythonhosted.org/packages/9e/58/9384b2f4eb1ed1d273d40948a7c5c4b2360213b402ef3be4641c06299f9c/librt-0.11.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:070aa8c26c0a74774317a72df8851facc7f0f012a5b406557ac56992d92e1ec8", size = 553608, upload-time = "2026-05-10T18:16:06.839Z" },
     { url = "https://files.pythonhosted.org/packages/61/fd/caa1d60b12f7dd79ccea23054e06eeaebe266a5f52c40a6b651069200ce5/librt-0.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fa475675db22290c3158e1d42326d0f5a65f04f44a0e68c3630a25b53560fb9c", size = 143565, upload-time = "2026-05-10T18:16:13.334Z" },
     { url = "https://files.pythonhosted.org/packages/b8/a9/dc744f5c2b4978d48db970be29f22716d3413d28b14ad99740817315cf2c/librt-0.11.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:621db29691044bdeda22e789e482e1b0f3a985d90e3426c9c6d17606416205ea", size = 485395, upload-time = "2026-05-10T18:16:14.729Z" },
     { url = "https://files.pythonhosted.org/packages/a6/6d/d8ee9c114bebf2c50e29ec2aa940826fccb62a645c3e4c18760987d0e16d/librt-0.11.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c39513d8b7477a2e1ed8c43fc21c524e8d5a0f8d4e8b7b074dbdbe7820a08e2", size = 513010, upload-time = "2026-05-10T18:16:17.647Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/43/0b5708af2bd30a46400e72ba6bdaa8f066f15fb9a688527e34220e8d6c06/librt-0.11.0-cp313-cp313-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7aef3cf1d5af86e770ab04bfd993dfc4ae8b8c17f66fb77dd4a7d50de7bbb1a3", size = 508433, upload-time = "2026-05-10T18:16:19.309Z" },
     { url = "https://files.pythonhosted.org/packages/4a/50/356187247d09013490481033183b3532b58acf8028bcb34b2b56a375c9b2/librt-0.11.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:557183ddc36babe46b27dd60facbd5adb4492181a5be887587d57cda6e092f21", size = 522595, upload-time = "2026-05-10T18:16:20.642Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/b5/a81322dbeedeeaf9c1ee6f001734d28a09d8383ac9e6779bc24bbd0743c6/librt-0.11.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:4ce1f21fbe589bc1afd7872dece84fb0e1144f794a288e58a10d2c54a55c43be", size = 516847, upload-time = "2026-05-10T18:16:23.627Z" },
     { url = "https://files.pythonhosted.org/packages/ae/66/6e6323787d592b55204a42595ff1102da5115601b53a7e9ddebc889a6da5/librt-0.11.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b09f7044ea2b64c9da42fd3d335666518cfd1c6e8a182c95da73d0214b41e", size = 553920, upload-time = "2026-05-10T18:16:25.025Z" },
 ]
 
@@ -1707,7 +1616,7 @@ name = "markdown-it-py"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mdurl", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "mdurl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
 wheels = [
@@ -1723,23 +1632,17 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
     { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
     { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
     { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
-    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
     { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
     { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
     { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
     { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
     { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
     { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
     { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
     { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
     { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
     { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
     { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
 ]
 
@@ -1748,7 +1651,7 @@ name = "matplotlib-inline"
 version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "traitlets", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bd/c0/9f7c9a46090390368a4d7bcb76bb87a4a36c421e4c0792cdb53486ffac7a/matplotlib_inline-0.2.2.tar.gz", hash = "sha256:72f3fe8fce36b70d4a5b612f899090cd0401deddc4ea90e1572b9f4bfb058c79", size = 8150, upload-time = "2026-05-08T17:33:33.49Z" }
 wheels = [
@@ -1791,38 +1694,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/9c/f20e0e2cf80e4b2e4b1c365bf5fe104ee633c751a724246262db8f1a0b13/multidict-6.7.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a90f75c956e32891a4eda3639ce6dd86e87105271f43d43442a3aedf3cddf172", size = 76893, upload-time = "2026-01-26T02:43:52.754Z" },
     { url = "https://files.pythonhosted.org/packages/a9/65/1caac9d4cd32e8433908683446eebc953e82d22b03d10d41a5f0fefe991b/multidict-6.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b0fa96985700739c4c7853a43c0b3e169360d6855780021bfc6d0f1ce7c123e7", size = 43872, upload-time = "2026-01-26T02:43:55.041Z" },
     { url = "https://files.pythonhosted.org/packages/fd/80/c959c5933adedb9ac15152e4067c702a808ea183a8b64cf8f31af8ad3155/multidict-6.7.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eb0ce7b2a32d09892b3dd6cc44877a0d02a33241fafca5f25c8b6b62374f8b75", size = 258883, upload-time = "2026-01-26T02:43:57.499Z" },
-    { url = "https://files.pythonhosted.org/packages/86/85/7ed40adafea3d4f1c8b916e3b5cc3a8e07dfcdcb9cd72800f4ed3ca1b387/multidict-6.7.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c3a32d23520ee37bf327d1e1a656fec76a2edd5c038bf43eddfa0572ec49c60b", size = 242413, upload-time = "2026-01-26T02:43:58.755Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/57/b8565ff533e48595503c785f8361ff9a4fde4d67de25c207cd0ba3befd03/multidict-6.7.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9c90fed18bffc0189ba814749fdcc102b536e83a9f738a9003e569acd540a733", size = 268404, upload-time = "2026-01-26T02:44:00.216Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/50/9810c5c29350f7258180dfdcb2e52783a0632862eb334c4896ac717cebcb/multidict-6.7.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:da62917e6076f512daccfbbde27f46fed1c98fee202f0559adec8ee0de67f71a", size = 269456, upload-time = "2026-01-26T02:44:02.202Z" },
     { url = "https://files.pythonhosted.org/packages/f3/8d/5e5be3ced1d12966fefb5c4ea3b2a5b480afcea36406559442c6e31d4a48/multidict-6.7.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bfde23ef6ed9db7eaee6c37dcec08524cb43903c60b285b172b6c094711b3961", size = 256322, upload-time = "2026-01-26T02:44:03.56Z" },
     { url = "https://files.pythonhosted.org/packages/31/6e/d8a26d81ac166a5592782d208dd90dfdc0a7a218adaa52b45a672b46c122/multidict-6.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3758692429e4e32f1ba0df23219cd0b4fc0a52f476726fff9337d1a57676a582", size = 253955, upload-time = "2026-01-26T02:44:04.845Z" },
-    { url = "https://files.pythonhosted.org/packages/59/4c/7c672c8aad41534ba619bcd4ade7a0dc87ed6b8b5c06149b85d3dd03f0cd/multidict-6.7.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:398c1478926eca669f2fd6a5856b6de9c0acf23a2cb59a14c0ba5844fa38077e", size = 251254, upload-time = "2026-01-26T02:44:06.133Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/ba/f5449385510825b73d01c2d4087bf6d2fccc20a2d42ac34df93191d3dd03/multidict-6.7.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:a088b62bd733e2ad12c50dad01b7d0166c30287c166e137433d3b410add807a6", size = 263588, upload-time = "2026-01-26T02:44:09.382Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/11/afc7c677f68f75c84a69fe37184f0f82fce13ce4b92f49f3db280b7e92b3/multidict-6.7.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:3d51ff4785d58d3f6c91bdbffcb5e1f7ddfda557727043aa20d20ec4f65e324a", size = 259642, upload-time = "2026-01-26T02:44:10.73Z" },
     { url = "https://files.pythonhosted.org/packages/2b/17/ebb9644da78c4ab36403739e0e6e0e30ebb135b9caf3440825001a0bddcb/multidict-6.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc5907494fccf3e7d3f94f95c91d6336b092b5fc83811720fae5e2765890dfba", size = 251377, upload-time = "2026-01-26T02:44:12.042Z" },
     { url = "https://files.pythonhosted.org/packages/f2/22/929c141d6c0dba87d3e1d38fbdf1ba8baba86b7776469f2bc2d3227a1e67/multidict-6.7.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2b41f5fed0ed563624f1c17630cb9941cf2309d4df00e494b551b5f3e3d67a23", size = 76174, upload-time = "2026-01-26T02:44:18.509Z" },
     { url = "https://files.pythonhosted.org/packages/79/76/55cd7186f498ed080a18440c9013011eb548f77ae1b297206d030eb1180a/multidict-6.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:935434b9853c7c112eee7ac891bc4cb86455aa631269ae35442cb316790c1445", size = 43524, upload-time = "2026-01-26T02:44:21.571Z" },
     { url = "https://files.pythonhosted.org/packages/f6/32/befed7f74c458b4a525e60519fe8d87eef72bb1e99924fa2b0f9d97a221e/multidict-6.7.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e82d14e3c948952a1a85503817e038cba5905a3352de76b9a465075d072fba23", size = 256952, upload-time = "2026-01-26T02:44:24.306Z" },
-    { url = "https://files.pythonhosted.org/packages/03/d6/c878a44ba877f366630c860fdf74bfb203c33778f12b6ac274936853c451/multidict-6.7.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4cfb48c6ea66c83bcaaf7e4dfa7ec1b6bbcf751b7db85a328902796dfde4c060", size = 240317, upload-time = "2026-01-26T02:44:25.772Z" },
-    { url = "https://files.pythonhosted.org/packages/68/49/57421b4d7ad2e9e60e25922b08ceb37e077b90444bde6ead629095327a6f/multidict-6.7.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1d540e51b7e8e170174555edecddbd5538105443754539193e3e1061864d444d", size = 267132, upload-time = "2026-01-26T02:44:27.648Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/fe/ec0edd52ddbcea2a2e89e174f0206444a61440b40f39704e64dc807a70bd/multidict-6.7.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:273d23f4b40f3dce4d6c8a821c741a86dec62cded82e1175ba3d99be128147ed", size = 268140, upload-time = "2026-01-26T02:44:29.588Z" },
     { url = "https://files.pythonhosted.org/packages/b0/73/6e1b01cbeb458807aa0831742232dbdd1fa92bfa33f52a3f176b4ff3dc11/multidict-6.7.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d624335fd4fa1c08a53f8b4be7676ebde19cd092b3895c421045ca87895b429", size = 254277, upload-time = "2026-01-26T02:44:30.902Z" },
     { url = "https://files.pythonhosted.org/packages/6a/b2/5fb8c124d7561a4974c342bc8c778b471ebbeb3cc17df696f034a7e9afe7/multidict-6.7.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:12fad252f8b267cc75b66e8fc51b3079604e8d43a75428ffe193cd9e2195dfd6", size = 252291, upload-time = "2026-01-26T02:44:32.31Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/96/51d4e4e06bcce92577fcd488e22600bd38e4fd59c20cb49434d054903bd2/multidict-6.7.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:03ede2a6ffbe8ef936b92cb4529f27f42be7f56afcdab5ab739cd5f27fb1cbf9", size = 250156, upload-time = "2026-01-26T02:44:33.734Z" },
-    { url = "https://files.pythonhosted.org/packages/44/a3/ec5b5bd98f306bc2aa297b8c6f11a46714a56b1e6ef5ebda50a4f5d7c5fb/multidict-6.7.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5c4b9bfc148f5a91be9244d6264c53035c8a0dcd2f51f1c3c6e30e30ebaa1c84", size = 262221, upload-time = "2026-01-26T02:44:36.604Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/f7/e8c0d0da0cd1e28d10e624604e1a36bcc3353aaebdfdc3a43c72bc683a12/multidict-6.7.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:401c5a650f3add2472d1d288c26deebc540f99e2fb83e9525007a74cd2116f1d", size = 258664, upload-time = "2026-01-26T02:44:38.008Z" },
     { url = "https://files.pythonhosted.org/packages/52/da/151a44e8016dd33feed44f730bd856a66257c1ee7aed4f44b649fb7edeb3/multidict-6.7.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:97891f3b1b3ffbded884e2916cacf3c6fc87b66bb0dde46f7357404750559f33", size = 249490, upload-time = "2026-01-26T02:44:39.386Z" },
     { url = "https://files.pythonhosted.org/packages/6d/b3/e6b21c6c4f314bb956016b0b3ef2162590a529b84cb831c257519e7fde44/multidict-6.7.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c76c4bec1538375dad9d452d246ca5368ad6e1c9039dadcf007ae59c70619ea1", size = 83175, upload-time = "2026-01-26T02:44:44.894Z" },
     { url = "https://files.pythonhosted.org/packages/c4/57/a0ed92b23f3a042c36bc4227b72b97eca803f5f1801c1ab77c8a212d455e/multidict-6.7.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e954b24433c768ce78ab7929e84ccf3422e46deb45a4dc9f93438f8217fa2d34", size = 46930, upload-time = "2026-01-26T02:44:47.278Z" },
     { url = "https://files.pythonhosted.org/packages/58/18/64f5a795e7677670e872673aca234162514696274597b3708b2c0d276cce/multidict-6.7.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:253282d70d67885a15c8a7716f3a73edf2d635793ceda8173b9ecc21f2fb8292", size = 250031, upload-time = "2026-01-26T02:44:50.544Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/ed/e192291dbbe51a8290c5686f482084d31bcd9d09af24f63358c3d42fd284/multidict-6.7.1-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:0b4c48648d7649c9335cf1927a8b87fa692de3dcb15faa676c6a6f1f1aabda43", size = 228596, upload-time = "2026-01-26T02:44:51.951Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/7e/3562a15a60cf747397e7f2180b0a11dc0c38d9175a650e75fa1b4d325e15/multidict-6.7.1-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:98bc624954ec4d2c7cb074b8eefc2b5d0ce7d482e410df446414355d158fe4ca", size = 257492, upload-time = "2026-01-26T02:44:53.902Z" },
-    { url = "https://files.pythonhosted.org/packages/24/02/7d0f9eae92b5249bb50ac1595b295f10e263dd0078ebb55115c31e0eaccd/multidict-6.7.1-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1b99af4d9eec0b49927b4402bcbb58dea89d3e0db8806a4086117019939ad3dd", size = 255899, upload-time = "2026-01-26T02:44:55.316Z" },
     { url = "https://files.pythonhosted.org/packages/00/e3/9b60ed9e23e64c73a5cde95269ef1330678e9c6e34dd4eb6b431b85b5a10/multidict-6.7.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6aac4f16b472d5b7dc6f66a0d49dd57b0e0902090be16594dc9ebfd3d17c47e7", size = 247970, upload-time = "2026-01-26T02:44:56.783Z" },
     { url = "https://files.pythonhosted.org/packages/3e/06/538e58a63ed5cfb0bd4517e346b91da32fde409d839720f664e9a4ae4f9d/multidict-6.7.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:21f830fe223215dffd51f538e78c172ed7c7f60c9b96a2bf05c4848ad49921c3", size = 245060, upload-time = "2026-01-26T02:44:58.195Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/2f/d743a3045a97c895d401e9bd29aaa09b94f5cbdf1bd561609e5a6c431c70/multidict-6.7.1-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:f5dd81c45b05518b9aa4da4aa74e1c93d715efa234fd3e8a179df611cc85e5f4", size = 235888, upload-time = "2026-01-26T02:44:59.57Z" },
-    { url = "https://files.pythonhosted.org/packages/20/1f/9d2327086bd15da2725ef6aae624208e2ef828ed99892b17f60c344e57ed/multidict-6.7.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:c9035dde0f916702850ef66460bc4239d89d08df4d02023a5926e7446724212c", size = 252341, upload-time = "2026-01-26T02:45:02.484Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/2c/2a1aa0280cf579d0f6eed8ee5211c4f1730bd7e06c636ba2ee6aafda302e/multidict-6.7.1-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:af959b9beeb66c822380f222f0e0a1889331597e81f1ded7f374f3ecb0fd6c52", size = 246391, upload-time = "2026-01-26T02:45:03.862Z" },
     { url = "https://files.pythonhosted.org/packages/e5/03/7ca022ffc36c5a3f6e03b179a5ceb829be9da5783e6fe395f347c0794680/multidict-6.7.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:41f2952231456154ee479651491e94118229844dd7226541788be783be2b5108", size = 243422, upload-time = "2026-01-26T02:45:05.296Z" },
     { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
 ]
@@ -1832,10 +1717,10 @@ name = "mypy"
 version = "1.20.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "librt", marker = "(platform_machine == 'arm64' and platform_python_implementation != 'PyPy' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux')" },
-    { name = "mypy-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pathspec", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/af/e3d4b3e9ec91a0ff9aabfdb38692952acf49bbb899c2e4c29acb3a6da3ae/mypy-1.20.2.tar.gz", hash = "sha256:e8222c26daaafd9e8626dec58ae36029f82585890589576f769a650dd20fd665", size = 3817349, upload-time = "2026-04-21T17:12:28.473Z" }
 wheels = [
@@ -1864,10 +1749,10 @@ name = "nbclient"
 version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jupyter-client", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "jupyter-core", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nbformat", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "traitlets", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "nbformat" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/28/a5/b3bae4b590c0cbcada2c63a34f7580024e834a8ba213e949a2f906705787/nbclient-0.11.0.tar.gz", hash = "sha256:04a134a5b087f2c5887f228aca155db50169b8cd9334dee6942c8e927e56081a", size = 62535, upload-time = "2026-06-05T07:52:41.746Z" }
 wheels = [
@@ -1879,20 +1764,20 @@ name = "nbconvert"
 version = "7.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "beautifulsoup4", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "bleach", extra = ["css"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "defusedxml", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "jinja2", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "jupyter-core", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "jupyterlab-pygments", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "markupsafe", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "mistune", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nbclient", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nbformat", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "packaging", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pandocfilters", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pygments", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "traitlets", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "beautifulsoup4" },
+    { name = "bleach", extra = ["css"] },
+    { name = "defusedxml" },
+    { name = "jinja2" },
+    { name = "jupyter-core" },
+    { name = "jupyterlab-pygments" },
+    { name = "markupsafe" },
+    { name = "mistune" },
+    { name = "nbclient" },
+    { name = "nbformat" },
+    { name = "packaging" },
+    { name = "pandocfilters" },
+    { name = "pygments" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/01/b1/708e53fe2e429c103c6e6e159106bcf0357ac41aa4c28772bd8402339051/nbconvert-7.17.1.tar.gz", hash = "sha256:34d0d0a7e73ce3cbab6c5aae8f4f468797280b01fd8bd2ca746da8569eddd7d2", size = 865311, upload-time = "2026-04-08T00:44:14.914Z" }
 wheels = [
@@ -1904,10 +1789,10 @@ name = "nbformat"
 version = "5.10.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "fastjsonschema", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "jsonschema", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "jupyter-core", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "traitlets", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "fastjsonschema" },
+    { name = "jsonschema" },
+    { name = "jupyter-core" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6d/fd/91545e604bc3dad7dca9ed03284086039b294c6b3d75c0d2fa45f9e9caf3/nbformat-5.10.4.tar.gz", hash = "sha256:322168b14f937a5d11362988ecac2a4952d3d8e3a2cbeb2319584631226d5b3a", size = 142749, upload-time = "2024-04-04T11:20:37.371Z" }
 wheels = [
@@ -1946,11 +1831,11 @@ name = "notebook"
 version = "7.5.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jupyter-server", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "jupyterlab", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "jupyterlab-server", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "notebook-shim", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "tornado", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "jupyter-server" },
+    { name = "jupyterlab" },
+    { name = "jupyterlab-server" },
+    { name = "notebook-shim" },
+    { name = "tornado" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3e/c4/f71f8716f2903e9e817a47f534b9fd84831e155e2acb32c26691c8e06243/notebook-7.5.7.tar.gz", hash = "sha256:d6d59288a25303b25e1dcb71e9b017ec3a785f7d92f38b9bc288ca1970d5b0a8", size = 14171612, upload-time = "2026-06-04T18:33:45.224Z" }
 wheels = [
@@ -1962,7 +1847,7 @@ name = "notebook-shim"
 version = "0.2.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jupyter-server", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "jupyter-server" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/54/d2/92fa3243712b9a3e8bafaf60aac366da1cada3639ca767ff4b5b3654ec28/notebook_shim-0.2.4.tar.gz", hash = "sha256:b4b2cfa1b65d98307ca24361f5b30fe785b53c3fd07b7a47e89acb5e6ac638cb", size = 13167, upload-time = "2024-02-14T23:35:18.353Z" }
 wheels = [
@@ -1974,7 +1859,7 @@ name = "opentelemetry-api"
 version = "1.42.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b4/1c/125e1c936c0873796771b7f04f6c93b9f1bf5d424cea90fda94a99f61da8/opentelemetry_api-1.42.1.tar.gz", hash = "sha256:56c63bea9f77b62856be8c47600474acad853b2924b99b1687c4cb6297166716", size = 72296, upload-time = "2026-05-21T16:32:49.335Z" }
 wheels = [
@@ -1986,10 +1871,10 @@ name = "opentelemetry-exporter-gcp-trace"
 version = "1.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "google-cloud-trace", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "opentelemetry-api", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "opentelemetry-resourcedetector-gcp", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "opentelemetry-sdk", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "google-cloud-trace" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-resourcedetector-gcp" },
+    { name = "opentelemetry-sdk" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bf/55/32922e72d88421505383dfdba9c1ee6ad67253f94f2358f6e9dbc4ac3749/opentelemetry_exporter_gcp_trace-1.12.0.tar.gz", hash = "sha256:18c6e56fe123eed020d5005fdd819b196d64f651545bce1ca7e2e2cbaf9d343b", size = 18779, upload-time = "2026-04-28T20:59:41.974Z" }
 wheels = [
@@ -2001,10 +1886,10 @@ name = "opentelemetry-resourcedetector-gcp"
 version = "1.12.0a0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-api", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "opentelemetry-sdk", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "requests", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/21/ae/b62c5e986c9c7f908a15682ea173bcfcdc00403c0c85243ccbd30eca7fc2/opentelemetry_resourcedetector_gcp-1.12.0a0.tar.gz", hash = "sha256:d5e3f78283a272eb92547e00bbeff45b7332a34ae791a70ab4eba81af9bc3baf", size = 18797, upload-time = "2026-04-28T20:59:43.195Z" }
 wheels = [
@@ -2016,9 +1901,9 @@ name = "opentelemetry-sdk"
 version = "1.42.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-api", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "opentelemetry-semantic-conventions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/f7/b390bd9bfd703bf98a68fea1f27786c6872331fd617164a54b8a59bdc008/opentelemetry_sdk-1.42.1.tar.gz", hash = "sha256:8c834e8f8c9ba4171d4ec843d0cb8a67e4c7394d3f9e9297e582cbd9456ddbf7", size = 239262, upload-time = "2026-05-21T16:33:04.641Z" }
 wheels = [
@@ -2030,8 +1915,8 @@ name = "opentelemetry-semantic-conventions"
 version = "0.63b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-api", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/93/99/4d7dd6df64795951413ce6e815f8cf1eb191daf7196ae86574589643d5f3/opentelemetry_semantic_conventions-0.63b1.tar.gz", hash = "sha256:3daf963611334b365e98a57438183eb012d3bfb40b2d931a9af613476b8701a9", size = 148340, upload-time = "2026-05-21T16:33:05.455Z" }
 wheels = [
@@ -2061,7 +1946,7 @@ name = "parsimonious"
 version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "regex", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "regex" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7b/91/abdc50c4ef06fdf8d047f60ee777ca9b2a7885e1a9cea81343fbecda52d7/parsimonious-0.10.0.tar.gz", hash = "sha256:8281600da180ec8ae35427a4ab4f7b82bfec1e3d1e52f80cb60ea82b9512501c", size = 52172, upload-time = "2022-09-03T17:01:17.004Z" }
 wheels = [
@@ -2091,7 +1976,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -2130,7 +2015,7 @@ name = "prompt-toolkit"
 version = "3.0.52"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "wcwidth", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "wcwidth" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
 wheels = [
@@ -2146,41 +2031,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/cb/e27bc2b2737a0bb49962b275efa051e8f1c35a936df7d5139b6b658b7dc9/propcache-0.5.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:806719138ecd720339a12410fb9614ac9b2b2d3a5fdf8235d56981c36f4039ba", size = 95887, upload-time = "2026-05-08T21:00:11.277Z" },
     { url = "https://files.pythonhosted.org/packages/2c/7d/49777a3e20b55863d4794384a38acd460c04157b0a00f8602b0d508b8431/propcache-0.5.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e5cbfac9f61484f7e9f3597775500cd3ebe8274e9b050c38f9525c77c97520bf", size = 55190, upload-time = "2026-05-08T21:00:13.935Z" },
     { url = "https://files.pythonhosted.org/packages/44/c7/085d0cd63062e84044e3f05797749c3f8e3938ff3aeb0eb2f69d43fafc91/propcache-0.5.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5dbc581d2814337da56222fab8dc5f161cd798a434e49bac27930aaef798e144", size = 59995, upload-time = "2026-05-08T21:00:15.526Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/42/32cf8e3009e92b2645cf1e944f701e8ea4e924dffde1ee26db860bcbf7e4/propcache-0.5.2-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:857187f381f88c8e2fa2fe56ab94879d011b883d5a2ee5a1b60a8cd2a06846d9", size = 63422, upload-time = "2026-05-08T21:00:16.824Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/1b/f112433f99fc979431b87a39ef169e3f8df070d99a72792c56d6937ac48b/propcache-0.5.2-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:178b4a2cdaac1818e2bf1c5a99b94383fa73ea5382e032a48dec07dc5668dc42", size = 64342, upload-time = "2026-05-08T21:00:18.362Z" },
     { url = "https://files.pythonhosted.org/packages/14/15/5574111ae50dd6e879456888c0eadd4c5a869959775854e18e18a6b345f3/propcache-0.5.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f328175a2cde1f0ff2c4ed8ce968b9dcfb55f3a7153f39e2957ed994da13476", size = 61639, upload-time = "2026-05-08T21:00:19.692Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/da/4d775080b1490c0ae604acda868bd71aabe3a89ed16f2aa4339eb8a283e7/propcache-0.5.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5671d09a36b06d0fd4a3da0fccbcae360e9b1570924171a15e9e0997f0249fba", size = 61588, upload-time = "2026-05-08T21:00:21.155Z" },
     { url = "https://files.pythonhosted.org/packages/04/ac/f076982cbe2195ee9cf32de5a1e46951d9fb399fc207f390562dd0fd8fb2/propcache-0.5.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:80168e2ebe4d3ec6599d10ad8f520304ae1cad9b6c5a95372aef1b66b7bfb53a", size = 60029, upload-time = "2026-05-08T21:00:22.713Z" },
-    { url = "https://files.pythonhosted.org/packages/70/60/189be62e0dd898dce3b331e1b8c7a543cd3a405ac0c81fe8ee8a9d5d77e1/propcache-0.5.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:45f11346f884bc47444f6e6647131055844134c3175b629f84952e2b5cd62b64", size = 56774, upload-time = "2026-05-08T21:00:24.001Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/9e/93377b9c7939c1ffae98f878dee955efadfd638078bc86dbc21f9d52f651/propcache-0.5.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:8e778ebd44ef4f66ed60a0416b06b489687db264a9c0b3620362f26489492913", size = 63532, upload-time = "2026-05-08T21:00:25.545Z" },
-    { url = "https://files.pythonhosted.org/packages/14/f9/590ef6cfb9b8028d516d287812ece32bb0bc5f11fbb9c8bf6b2e6313fec8/propcache-0.5.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:c0cb9ed24c8964e172768d455a38254c2dd8a552905729ce006cad3d3dda59b1", size = 61592, upload-time = "2026-05-08T21:00:27.186Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/5e/70958b3034c297a630bba2f17ca7abc2d5f39a803ad7e370ab79d1ecd022/propcache-0.5.2-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:1d1ad32d9d4355e2be65574fd0bfd3677e7066b009cd5b9b2dee8aa6a6393b33", size = 64788, upload-time = "2026-05-08T21:00:28.8Z" },
     { url = "https://files.pythonhosted.org/packages/12/fd/77fe5936d8c3086ca9048f7f415f122ed82e53884a9ec193646b42deef06/propcache-0.5.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c80f4ba3e8f00189165999a742ee526ebeccedf6c3f7beb0c7df821e9772435a", size = 62514, upload-time = "2026-05-08T21:00:30.098Z" },
     { url = "https://files.pythonhosted.org/packages/c5/09/f049e45385503fe67db75a6b6186a7b9f0c3930366dc960522c312a825b1/propcache-0.5.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:099aaf4b4d1a02265b92a977edf00b5c4f63b3b17ac6de39b0d637c9cac0188a", size = 94457, upload-time = "2026-05-08T21:00:36.355Z" },
     { url = "https://files.pythonhosted.org/packages/a9/12/a6ba6482bb5ea3260c000c9b20881c95fa11c6b30173715668259f844ed7/propcache-0.5.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fc299c129490f55f254cd90be0deca4764e36e9a7c08b4aa588479a3bbed3098", size = 54545, upload-time = "2026-05-08T21:00:39.319Z" },
     { url = "https://files.pythonhosted.org/packages/a9/19/7fa086f5764c59ec8a8e157cd93aa8497acc00aba9dcdec56bfffb32602d/propcache-0.5.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a6ae2198be502c10f09b2516e7b5d019816924bc3183a43ce792a7bd6625e6f4", size = 59886, upload-time = "2026-05-08T21:00:40.621Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/e4/5d7663dc8235956c8f5281698a3af1d351d8820341ddd890f59d9a9127f2/propcache-0.5.2-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6041d31504dc1779d700e1edcfb08eea334b357620b06681a4eabb57a74e574e", size = 63261, upload-time = "2026-05-08T21:00:41.775Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/4a/15a03adee24d6350da4292caeac44c34c033d2afe5e87eb370f38854560f/propcache-0.5.2-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f7eabc04151c78a9f4d5bbb5f1faf571e4defeb4b585e0fe95b60ff2dbe4d3d7", size = 64184, upload-time = "2026-05-08T21:00:43.018Z" },
     { url = "https://files.pythonhosted.org/packages/8b/c6/979176efdaa3d239e36d503d5af63a0a773b36662ed8f52e5b6a6d9fd40e/propcache-0.5.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4db0ba63d693afd40d249bd93f842b5f144f8fcbb83de05660373bcf30517b1d", size = 61534, upload-time = "2026-05-08T21:00:44.507Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/22/63e8cd1bae4c2d2be6493b6b7d10566ddafad88137cfbc99964a1119853c/propcache-0.5.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1dbcf7675229b35d31abb6547d8ebc8c27a830ac3f9a794edff6254873ec7c0a", size = 61500, upload-time = "2026-05-08T21:00:45.796Z" },
     { url = "https://files.pythonhosted.org/packages/60/5a/28e5d9acbac1cc9ccb67045e8c1b943aa8d79fdf39c93bd73cacd68008ea/propcache-0.5.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d310c013aad2c72f1c3f2f8dd3279d460a858c551f97aeb8c63e4693cca7b4d2", size = 59994, upload-time = "2026-05-08T21:00:47.093Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/40/db650677f554a95b9c01a7c9d93d629e93a15562f5deb4573c9ee136fed2/propcache-0.5.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:06187263ddad280d05b4d8a8b3bb7d164cbebd469236544a42e6d9b28ac6a4fa", size = 56884, upload-time = "2026-05-08T21:00:48.376Z" },
-    { url = "https://files.pythonhosted.org/packages/80/45/70b39b89516ff8b96bf732fa6fded8cef20f293cb1508690101c3c07ec51/propcache-0.5.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3115559b8effafd63b142ea5ed53d63a16ea6469cbc63dce4ee194b42db5d853", size = 63464, upload-time = "2026-05-08T21:00:49.954Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/e2/fa59d3a89eac5534293124af4f1d0d0ada091ce4a0ab4610ce03fd2bdd8d/propcache-0.5.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c60462af8e6dc30c35407c7237ea908d777b22862bbee27bc4699c0d8bcdc45a", size = 61588, upload-time = "2026-05-08T21:00:51.281Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/97/efb547a55c4bc7381cfb202d6a2239ac621045277bc1ea5dfd3a7f0516c0/propcache-0.5.2-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:40314bca9ac559716fe374094fc81c11dcc34b64fd6c585360f5775690505704", size = 64667, upload-time = "2026-05-08T21:00:52.602Z" },
     { url = "https://files.pythonhosted.org/packages/92/56/f5c7d9b4b7595d5127da38974d791b2153f3d1eae6c674af3583ace92ad3/propcache-0.5.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cfa21e036ce1e1db2be04ba3b85d2df1bb1702fa01932d984c5464c665228ff4", size = 62463, upload-time = "2026-05-08T21:00:54.303Z" },
     { url = "https://files.pythonhosted.org/packages/1b/82/c1d268bbbf2ef981c5bf0fbbe746db617c66e3bcefe431a1aa8943fbe23a/propcache-0.5.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:a592f5f3da71c8691c788c13cb6734b6d17663d2e1cb8caddf0673d01ef8847d", size = 98872, upload-time = "2026-05-08T21:00:59.889Z" },
     { url = "https://files.pythonhosted.org/packages/67/f0/9b90ca2a210b3d09bcfcd96ecd0f55545c091535abce2a45de2775cfd357/propcache-0.5.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:10734b5484ea113152ee25a91dccedf81631791805d2c9ccb054958e51842c94", size = 56696, upload-time = "2026-05-08T21:01:02.941Z" },
     { url = "https://files.pythonhosted.org/packages/9d/0e/6e9d4ba07c8e56e21ddec1e75f12148142b21ca83a51871babce095334f4/propcache-0.5.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cafca7e56c12bb02ae16d283742bef25a61122e9dab2b5b3f2ccbe589ce32164", size = 62378, upload-time = "2026-05-08T21:01:04.475Z" },
-    { url = "https://files.pythonhosted.org/packages/65/19/c10badaa463dde8a27ce884f8ee2ec37e6035b7c9f5ff0c8f74f06f08dac/propcache-0.5.2-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f064f8d2b59177878b7615df1735cd8fe3462ed6be8c7b217d17a276489c2b7f", size = 65283, upload-time = "2026-05-08T21:01:05.959Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/b6/93bea99ca80e19cef6512a8580e5b7857bbe09422d9daa7fd4ef5723306c/propcache-0.5.2-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f78abfa8dfc32376fd1aacf597b2f2fbbe0ea751419aee718af5d4f82537ef8c", size = 66616, upload-time = "2026-05-08T21:01:07.228Z" },
     { url = "https://files.pythonhosted.org/packages/83/e4/5c7462e50625f051f37fb38b8224f7639f667184bbd34424ec83819bb1b7/propcache-0.5.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f7467da8a9822bf1a55336f877340c5bcbd3c482afc43a99771169f74a26dedc", size = 63773, upload-time = "2026-05-08T21:01:08.514Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/b6/99238894047b13c823be25027e736626cd414a52a5e30d2c3347c2733529/propcache-0.5.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a6ddc6ac9e25de626c1f129c1b467d7ecd33ce2237d3fd0c4e429feef0a7ee1f", size = 63664, upload-time = "2026-05-08T21:01:09.874Z" },
     { url = "https://files.pythonhosted.org/packages/85/1e/a3a1a63116a2b8edb415a8bb9a6f0c34bd03830b1e18e8ce2904e1dc1cf4/propcache-0.5.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:2f22cbbac9e26a8e864c0985ff1268d5d939d53d9d9411a9824279097e03a2cb", size = 62643, upload-time = "2026-05-08T21:01:11.132Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/03/893cf147de2fc6543c5eaa07ad833170e7e2a2385725bbebe8c0503723bb/propcache-0.5.2-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:fc76378c62a0f04d0cd82fbb1a2cd2d7e28fcb40d5873f28a6c44e388aaa2751", size = 59595, upload-time = "2026-05-08T21:01:12.387Z" },
-    { url = "https://files.pythonhosted.org/packages/86/3b/04c1a2e12c57766568ba75ba72b3bf2042818d4c1425fab6fc07155c7cff/propcache-0.5.2-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:acd2c8edba48e31e58a363b8cf4e5c7db3b04b3f9e371f601df30d9b0d244836", size = 65711, upload-time = "2026-05-08T21:01:13.676Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/34/80f8d0099f8d6bacc4de1624c85672681c8cd1149ca2da0e38fd120b817f/propcache-0.5.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:452b5065457eb9991ec5eb38ff41d6cd4c991c9ac7c531c4d5849ae473a9a13f", size = 64247, upload-time = "2026-05-08T21:01:14.936Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/1a/8b08f3a5f1037e9e370c55883ceeeee0f6dd0416fb2d2d67b8bfc91f2a79/propcache-0.5.2-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:3430bb2bfe1331885c427745a751e774ee679fd4344f80b97bf879815fe8fa55", size = 67102, upload-time = "2026-05-08T21:01:16.281Z" },
     { url = "https://files.pythonhosted.org/packages/34/68/8bdb7bb7756d76e005490649d10e4a8369e610c74d619f71e1aedf889e9c/propcache-0.5.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:cef6cea3922890dd6c9654971001fa797b526c16ab5e1e46c05fd6f877be7568", size = 64964, upload-time = "2026-05-08T21:01:17.57Z" },
     { url = "https://files.pythonhosted.org/packages/3a/ed/1cdcab6ba3d6ab7feca11fc14f0eeea80755bb53ef4e892079f31b10a25f/propcache-0.5.2-py3-none-any.whl", hash = "sha256:be1ddfcbb376e3de5d2e2db1d58d6d67463e6b4f9f040c000de8e300295465fe", size = 14036, upload-time = "2026-05-08T21:02:10.673Z" },
 ]
@@ -2190,7 +2054,7 @@ name = "proto-plus"
 version = "1.28.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "protobuf", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "protobuf" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c9/56/e647b0c675392d2da368da7b6f158f7368b18542fd6f7d7400a2f39de000/proto_plus-1.28.0.tar.gz", hash = "sha256:38e5696342835b08fc116f30a25665b29531cda9d5d5643e9b81fc312385abd9", size = 57221, upload-time = "2026-05-07T08:04:50.811Z" }
 wheels = [
@@ -2205,7 +2069,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/60/fd/5b1491d9e4b586d62
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/ee/93d06e358a4aa32280b00e722d3ea0a1f25fc3cc5778d80581c9cca2c10e/protobuf-7.35.0-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:66be6c513931c794fa92c080ffee41671390da3d79da219cf9c0c0907f035dda", size = 433225, upload-time = "2026-05-19T23:02:19.884Z" },
     { url = "https://files.pythonhosted.org/packages/8b/39/1c76c2da93f3c507e958e0aecee2391cc44d4625de6c728bbc555195b5a8/protobuf-7.35.0-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:fcbe42a4ac09d3ec9c987ddfcd956afd0b15f1ff613bd8371bde9405ffd5c8e5", size = 328847, upload-time = "2026-05-19T23:02:22.3Z" },
-    { url = "https://files.pythonhosted.org/packages/91/1a/39f7ce90a238c1a987a4d81ec26379e02ca0aff367de68e4a1fa474215b9/protobuf-7.35.0-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:4cbf5cc286130e06a6c9bbefac442431173906dfcc979712183d4adcc01b37ee", size = 344030, upload-time = "2026-05-19T23:02:23.591Z" },
     { url = "https://files.pythonhosted.org/packages/70/5b/6baf9008817964454055ff3fe65f1de0b5f1e26c80c82f7fb108b7cd4ea3/protobuf-7.35.0-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:6c0f98f10c8a05ea30f8993dfef2de093d27b490fdae78bb60c8343795d55011", size = 327130, upload-time = "2026-05-19T23:02:24.637Z" },
     { url = "https://files.pythonhosted.org/packages/b8/ef/50433d346c56657a70d27f156c7b349ac59a068b01de4eb796e747eecc43/protobuf-7.35.0-py3-none-any.whl", hash = "sha256:c13f325cf242bad135c350629eeb5d54b24228eb472fb3e2e9ebbd4c5dc20ca0", size = 171659, upload-time = "2026-05-19T23:02:27.842Z" },
 ]
@@ -2227,22 +2090,14 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2a/60/a3624f79acea344c16fbef3a94d28b89a8042ddfb8f3e4ca83f538671409/psycopg2_binary-2.9.12.tar.gz", hash = "sha256:5ac9444edc768c02a6b6a591f070b8aae28ff3a99be57560ac996001580f294c", size = 379686, upload-time = "2026-04-21T09:40:34.304Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/01/3dd14e46ba48c1e1a6ec58ee599fa1b5efa00c246d5046cd903d0eeb1af1/psycopg2_binary-2.9.12-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d3227a3bc228c10d21011a99245edca923e4e8bf461857e869a507d9a41fe9f6", size = 3822936, upload-time = "2026-04-20T23:34:32.77Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/f7/0640e4901119d8a9f7a1784b927f494e2198e213ceb593753d1f2c8b1b30/psycopg2_binary-2.9.12-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:995ce929eede89db6254b50827e2b7fd61e50d11f0b116b29fffe4a2e53c4580", size = 4578676, upload-time = "2026-04-20T23:34:35.18Z" },
     { url = "https://files.pythonhosted.org/packages/b0/55/44df3965b5f297c50cc0b1b594a31c67d6127a9d133045b8a66611b14dfb/psycopg2_binary-2.9.12-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9fe06d93e72f1c048e731a2e3e7854a5bfaa58fc736068df90b352cefe66f03f", size = 4274917, upload-time = "2026-04-20T23:34:37.982Z" },
     { url = "https://files.pythonhosted.org/packages/b0/4b/74535248b1eac0c9336862e8617c765ac94dac76f9e25d7c4a79588c8907/psycopg2_binary-2.9.12-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40e7b28b63aaf737cb3a1edc3a9bbc9a9f4ad3dcb7152e8c1130e4050eddcb7d", size = 5894843, upload-time = "2026-04-20T23:34:40.856Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/ba/f1bf8d2ae71868ad800b661099086ee52bc0f8d9f05be1acd8ebb06757cc/psycopg2_binary-2.9.12-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:89d19a9f7899e8eb0656a2b3a08e0da04c720a06db6e0033eab5928aabe60fa9", size = 4110556, upload-time = "2026-04-20T23:34:44.016Z" },
     { url = "https://files.pythonhosted.org/packages/45/46/c15706c338403b7c420bcc0c2905aad116cc064545686d8bf85f1999ea00/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:612b965daee295ae2da8f8218ce1d274645dc76ef3f1abf6a0a94fd57eff876d", size = 3655714, upload-time = "2026-04-20T23:34:46.233Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/7c/a2d5dc09b64a4564db242a0fe418fde7d33f6f8259dd2c5b9d7def00fb5a/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:b9a339b79d37c1b45f3235265f07cdeb0cb5ad7acd2ac7720a5920989c17c24e", size = 3301154, upload-time = "2026-04-20T23:34:49.528Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/e8/cc8c9a4ce71461f9ec548d38cadc41dc184b34c73e6455450775a9334ccd/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:3471336e1acfd9c7fe507b8bad5af9317b6a89294f9eb37bd9a030bb7bebcdc6", size = 3048882, upload-time = "2026-04-20T23:34:51.86Z" },
     { url = "https://files.pythonhosted.org/packages/19/6a/31e2296bc0787c5ab75d3d118e40b239db8151b5192b90b77c72bc9256e9/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7af18183109e23502c8b2ae7f6926c0882766f35b5175a4cd737ad825e4d7a1b", size = 3351298, upload-time = "2026-04-20T23:34:54.124Z" },
     { url = "https://files.pythonhosted.org/packages/5e/af/48f76af9d50d61cf390f8cd657b503168b089e2e9298e48465d029fcc713/psycopg2_binary-2.9.12-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4413d0caef93c5cf50b96863df4c2efe8c269bf2267df353225595e7e15e8df7", size = 3822990, upload-time = "2026-04-20T23:35:00.821Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/df/aba0f99397cd811d32e06fc0cc781f1f3ce98bc0e729cb423925085d781a/psycopg2_binary-2.9.12-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:4dfcf8e45ebb0c663be34a3442f65e17311f3367089cd4e5e3a3e8e62c978777", size = 4578696, upload-time = "2026-04-20T23:35:03.409Z" },
     { url = "https://files.pythonhosted.org/packages/95/9c/eaa74021ac4e4d5c2f83d82fc6615a63f4fe6c94dc4e94c3990427053f67/psycopg2_binary-2.9.12-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c41321a14dd74aceb6a9a643b9253a334521babfa763fa873e33d89cfa122fb5", size = 4274982, upload-time = "2026-04-20T23:35:05.583Z" },
     { url = "https://files.pythonhosted.org/packages/35/ed/c25deff98bd26187ba48b3b250a3ffc3037c46c5b89362534a15d200e0db/psycopg2_binary-2.9.12-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:83946ba43979ebfdc99a3cd0ee775c89f221df026984ba19d46133d8d75d3cd9", size = 5894867, upload-time = "2026-04-20T23:35:07.902Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/81/8d0e21ca77373c6c9589e5c4528f6e8f0c08c62cafc76fb0bddb7a2cee22/psycopg2_binary-2.9.12-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:411e85815652d13560fbe731878daa5d92378c4995a22302071890ec3397d019", size = 4110578, upload-time = "2026-04-20T23:35:10.149Z" },
     { url = "https://files.pythonhosted.org/packages/00/fc/f481e2435bd8f742d0123309174aae4165160ad3ef17c1b99c3622c241d2/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1c8ad4c08e00f7679559eaed7aff1edfffc60c086b976f93972f686384a95e2c", size = 3655816, upload-time = "2026-04-20T23:35:12.56Z" },
-    { url = "https://files.pythonhosted.org/packages/53/79/b9f46466bdbe9f239c96cde8be33c1aace4842f06013b47b730dc9759187/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:00814e40fa23c2b37ef0a1e3c749d89982c73a9cb5046137f0752a22d432e82f", size = 3301307, upload-time = "2026-04-20T23:35:15.029Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/19/7dc003b32fe35024df89b658104f7c8538a8b2dcbde7a4e746ce929742e7/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:98062447aebc20ed20add1f547a364fd0ef8933640d5372ff1873f8deb9b61be", size = 3048968, upload-time = "2026-04-20T23:35:16.757Z" },
     { url = "https://files.pythonhosted.org/packages/91/58/2dbd7db5c604d45f4950d988506aae672a14126ec22998ced5021cbb76bb/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:66a7685d7e548f10fb4ce32fb01a7b7f4aa702134de92a292c7bd9e0d3dbd290", size = 3351369, upload-time = "2026-04-20T23:35:18.933Z" },
 ]
 
@@ -2278,7 +2133,7 @@ name = "pyasn1-modules"
 version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyasn1", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pyasn1" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
 wheels = [
@@ -2317,10 +2172,10 @@ name = "pydantic"
 version = "2.13.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "annotated-types", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pydantic-core", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typing-inspection", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
 wheels = [
@@ -2332,29 +2187,19 @@ name = "pydantic-core"
 version = "2.46.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
     { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
-    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
     { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
-    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
     { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
     { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
     { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
     { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
-    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
     { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
     { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
-    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
     { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
     { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
     { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
@@ -2366,9 +2211,9 @@ name = "pydantic-settings"
 version = "2.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "python-dotenv", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typing-inspection", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
 wheels = [
@@ -2389,10 +2234,10 @@ name = "pytest"
 version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "iniconfig", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "packaging", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pluggy", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pygments", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
 wheels = [
@@ -2404,7 +2249,7 @@ name = "pytest-asyncio"
 version = "0.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pytest", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pytest" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8e/c4/453c52c659521066969523e87d85d54139bbd17b78f09532fb8eb8cdb58e/pytest_asyncio-0.26.0.tar.gz", hash = "sha256:c4df2a697648241ff39e7f0e4a73050b03f123f760673956cf0d72a4990e312f", size = 54156, upload-time = "2025-03-25T06:22:28.883Z" }
 wheels = [
@@ -2416,7 +2261,7 @@ name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "six", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "six" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
@@ -2467,13 +2312,11 @@ sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd77
 wheels = [
     { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
     { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
-    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
     { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
     { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
     { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
     { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
     { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
-    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
     { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
     { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
     { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
@@ -2484,7 +2327,7 @@ name = "pyzmq"
 version = "27.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "(implementation_name == 'pypy' and platform_machine == 'arm64' and sys_platform == 'darwin') or (implementation_name == 'pypy' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'pypy' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "cffi", marker = "implementation_name == 'pypy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/0b/3c9baedbdf613ecaa7aa07027780b8867f57b6293b6ee50de316c9f3222b/pyzmq-27.1.0.tar.gz", hash = "sha256:ac0765e3d44455adb6ddbf4417dcce460fc40a05978c08efdf2948072f6db540", size = 281750, upload-time = "2025-09-08T23:10:18.157Z" }
 wheels = [
@@ -2493,7 +2336,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/9b/c108cdb55560eaf253f0cbdb61b29971e9fb34d9c3499b0e96e4e60ed8a5/pyzmq-27.1.0-cp312-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43ad9a73e3da1fab5b0e7e13402f0b2fb934ae1c876c51d0afff0e7c052eca31", size = 840995, upload-time = "2025-09-08T23:08:08.396Z" },
     { url = "https://files.pythonhosted.org/packages/c2/bb/b79798ca177b9eb0825b4c9998c6af8cd2a7f15a6a1a4272c1d1a21d382f/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0de3028d69d4cdc475bfe47a6128eb38d8bc0e8f4d69646adfbcd840facbac28", size = 1642070, upload-time = "2025-09-08T23:08:09.989Z" },
     { url = "https://files.pythonhosted.org/packages/46/bd/2d45ad24f5f5ae7e8d01525eb76786fa7557136555cac7d929880519e33a/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f30f395a9e6fbca195400ce833c731e7b64c3919aa481af4d88c3759e0cb7496", size = 1878550, upload-time = "2025-09-08T23:08:13.513Z" },
-    { url = "https://files.pythonhosted.org/packages/60/cb/84a13459c51da6cec1b7b1dc1a47e6db6da50b77ad7fd9c145842750a011/pyzmq-27.1.0-cp313-cp313-android_24_arm64_v8a.whl", hash = "sha256:93ad4b0855a664229559e45c8d23797ceac03183c7b6f5b4428152a6b06684a5", size = 1122436, upload-time = "2025-09-08T23:08:20.801Z" },
     { url = "https://files.pythonhosted.org/packages/a5/ad/15906493fd40c316377fd8a8f6b1f93104f97a752667763c9b9c1b71d42d/pyzmq-27.1.0-cp313-cp313t-macosx_10_15_universal2.whl", hash = "sha256:e343d067f7b151cfe4eb3bb796a7752c9d369eed007b91231e817071d2c2fec7", size = 1341197, upload-time = "2025-09-08T23:08:24.286Z" },
     { url = "https://files.pythonhosted.org/packages/69/2d/d83dd6d7ca929a2fc67d2c3005415cdf322af7751d773524809f9e585129/pyzmq-27.1.0-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d54530c8c8b5b8ddb3318f481297441af102517602b569146185fa10b63f4fa9", size = 660469, upload-time = "2025-09-08T23:08:27.623Z" },
     { url = "https://files.pythonhosted.org/packages/3e/cd/9822a7af117f4bc0f1952dbe9ef8358eb50a24928efd5edf54210b850259/pyzmq-27.1.0-cp313-cp313t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f3afa12c392f0a44a2414056d730eebc33ec0926aae92b5ad5cf26ebb6cc128", size = 847961, upload-time = "2025-09-08T23:08:29.672Z" },
@@ -2506,9 +2348,9 @@ name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "rpds-py", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typing-extensions", marker = "(python_full_version < '3.13' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
@@ -2524,38 +2366,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/50/9b/6550044bc44e17c84d312c031c2ec42fbdb6a4ec4e29093be3a172d08772/regex-2026.5.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:57eeeb05db7979413dec5438f2db21d7ecbba787cde7a711df1a6f6df672aa06", size = 490451, upload-time = "2026-05-09T23:12:34.72Z" },
     { url = "https://files.pythonhosted.org/packages/54/4b/ee27938d1b2c443e89a9a10e00d2d19aa5ee300cd3d61140644e93bb083e/regex-2026.5.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f7a7c26137296beba7784de6eba69c6a93a63ccebc385e4962fe67e267a91225", size = 289599, upload-time = "2026-05-09T23:12:38.089Z" },
     { url = "https://files.pythonhosted.org/packages/d8/dd/ba103dc19614e25f3880800ca67ce093d6e21b325d72b8383c7bf906e9fa/regex-2026.5.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6441cc660d76107934a09c22167200839a0e89604a6297f78a974e66e931d2c0", size = 796732, upload-time = "2026-05-09T23:12:40.062Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/e7/f035b4fd858b050b0080bf302968dc0f59ba34e391872d54936758e6844e/regex-2026.5.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:91328f1c23d47595ca3ef0a7557fa129c5a23404b775c770697d2f35b33e0107", size = 865440, upload-time = "2026-05-09T23:12:42.059Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/51/8cd301ecc899aea28124357f729f4272f44de7806fc7ca02490bfbe253e8/regex-2026.5.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:93a7860539414dddaefba2b40f8771765ae17949d4c7182b876ce429e11a8309", size = 912329, upload-time = "2026-05-09T23:12:44.373Z" },
     { url = "https://files.pythonhosted.org/packages/cc/1e/3fbe2fa1e8cebd62f3bb7d3321cff1640aca2e240b51d9bd624aad949260/regex-2026.5.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dd2810d22146b6d838acc5ec15602cb6b47920aa4e33015df3868eedfd20bab8", size = 801239, upload-time = "2026-05-09T23:12:46.268Z" },
-    { url = "https://files.pythonhosted.org/packages/17/2f/6f6008682bf2cf98040a0d3153a8e557b6ab728d7713d045cee4ce544ab8/regex-2026.5.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:daff2bdbaf1d23e52fdff7c0b7bc2048b68f978df6a4d107ac981f94caef2e66", size = 777054, upload-time = "2026-05-09T23:12:48.051Z" },
     { url = "https://files.pythonhosted.org/packages/19/2b/eee0d20a6842ba04df4b8847a920b57ef56853f14ef85405473e586b605a/regex-2026.5.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4eeb011098fcb77af513dcef521a3dbecbf8849b1e38940759d293b7a93f5026", size = 785098, upload-time = "2026-05-09T23:12:49.851Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/98/6fc1e6410feefb92159edaed5041992bfe390e8d26c721865434acbca558/regex-2026.5.9-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:ea9c8ecfa1b73c73b626534d6626e5340d429630943672b8480724f44e84b962", size = 860095, upload-time = "2026-05-09T23:12:51.666Z" },
-    { url = "https://files.pythonhosted.org/packages/18/a3/bd855e0f2cb1a978ecf6fa6bb69632dd9c3f6ea3b81cde62fde14c9daec7/regex-2026.5.9-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:cd2846168eb9ee3c513902bc8225409cb1caab31d04728b145171fa1625d9621", size = 765762, upload-time = "2026-05-09T23:12:53.413Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/66/0ae8c092e60b14c79d24f8e0b7f0aea5bfbffdcab00b5483d13404d3c3a5/regex-2026.5.9-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:39617fb0cde9c0e6306dc70e3bfc096f3da793219879f7ae7aa341a69fbdcf6d", size = 852100, upload-time = "2026-05-09T23:12:55.256Z" },
     { url = "https://files.pythonhosted.org/packages/21/de/8dfde60fc1b21c946a893ba273403b72617edb261370cb1087099a83f088/regex-2026.5.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fd03c4f0e33280d15cae17159b899245d6b7c53d21def19b263b39655061f5ce", size = 789479, upload-time = "2026-05-09T23:12:57.573Z" },
     { url = "https://files.pythonhosted.org/packages/aa/da/797e91ecec6f84135da778ddce78c20e0af5d2a15c26f87a81bc3eadb6db/regex-2026.5.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d626b84406444b165fc0ba981604edea39f0588ff1f92baa23fe50799ea9afdb", size = 490303, upload-time = "2026-05-09T23:13:04.382Z" },
     { url = "https://files.pythonhosted.org/packages/2d/e7/d0eaf5713828417b9e5648cf81fa9bacd4961f6ab98c380c2034f8716e35/regex-2026.5.9-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a8820737949116ffff55fe18f9fc644530063ba6ebfcb8314239416e78f1347c", size = 289468, upload-time = "2026-05-09T23:13:08.214Z" },
     { url = "https://files.pythonhosted.org/packages/d3/9b/b3fdd62b003baa1a9b593cd8c8699c9651c2e80cc21a5c715707983c42d7/regex-2026.5.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0fbdbac82cb3e4450d0ccde7d7a35607f4cb2dd9fba4b8b69bfaf8c9fa6aed", size = 796749, upload-time = "2026-05-09T23:13:10.573Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/30/66ab84588765f5b4b271a9ca09ef7ce2b87caa95176ec3d2ad65d7bc4902/regex-2026.5.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:57e8915c7986aa33d25e4d3629cef711cd2863f2961b10409f0c04cb8b7d9020", size = 865445, upload-time = "2026-05-09T23:13:12.523Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/89/f05169e8588aac365f35ffc7f3bc3184f095ef4cfded7cfaa3c7fd5dbd89/regex-2026.5.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:508f56a89ba9cb26e4168cbc37dbd60a28d82430a9e18ad1d25fe0883c314ca2", size = 912322, upload-time = "2026-05-09T23:13:14.281Z" },
     { url = "https://files.pythonhosted.org/packages/30/e1/c93444052cf41581f3c884ab3fb5823daf0992f11cd4388d4275ca610558/regex-2026.5.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6d189041f15691cfa2b6c4290448ec221244d225b3f5fe9e7771b34ffcdf6e2", size = 801269, upload-time = "2026-05-09T23:13:16.569Z" },
-    { url = "https://files.pythonhosted.org/packages/50/fe/0cf96b882f540e62e8b9956599798203d599c44cf4c77917ca27400ff69b/regex-2026.5.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e82db382b44d0111b22601c509c89f64434816c9e0eef9d1989cda8cc6ff1c04", size = 777085, upload-time = "2026-05-09T23:13:18.675Z" },
     { url = "https://files.pythonhosted.org/packages/23/5c/d78d4924e7fc875557b9e9b768423925fdfaac5549d06da7810019a9bd26/regex-2026.5.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2acfb48634f64996b57f90f39afa692ff362162722581921fe92239a59960f3c", size = 785153, upload-time = "2026-05-09T23:13:20.525Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/e0/5214774090e7b4524dcea3e3c4aa74141d43043f8beb49c1599db1c8b53a/regex-2026.5.9-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d29eebfc9525db68cad3c97eedd7f754fa265aa5cd0cf4f863b2421e1b48fc9f", size = 860164, upload-time = "2026-05-09T23:13:22.263Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/e1/4a57a83350319b1271f0d7a249b8672513ed928b237a741631270de6caea/regex-2026.5.9-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:debb893095e944091c16e641a6e33c1b0f4cb61ab945ec5afbf53ce7068834d8", size = 765731, upload-time = "2026-05-09T23:13:24.277Z" },
-    { url = "https://files.pythonhosted.org/packages/12/f4/499e74a20c156fc75836ee04a72a38d1a063978f600937f9760467beb1b0/regex-2026.5.9-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:d659eee77986549c9ea45b861c7567e44d6287c3dc9a4565478853f7b9fe2ff6", size = 852062, upload-time = "2026-05-09T23:13:26.125Z" },
     { url = "https://files.pythonhosted.org/packages/5b/92/7eebc0d0a01e78629695f342ba17e0deaff8fb45e79cc0d7b98287da6e3e/regex-2026.5.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2efa205e6d98b24d1f3ab395c11aa15cdf10935bca283d0285e0499c284fba21", size = 789577, upload-time = "2026-05-09T23:13:27.814Z" },
     { url = "https://files.pythonhosted.org/packages/e8/e9/d21346f7b60ed58789371358ed66b09d00f832e1bd7c06e55d9da5679882/regex-2026.5.9-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:01f28d868834624c934b8d2e0aa1c8341337e37831f4a012f18a5afcba4cbaf3", size = 494172, upload-time = "2026-05-09T23:13:35.935Z" },
     { url = "https://files.pythonhosted.org/packages/f2/7d/9fbf919768368d3f8a4f6c692cf2aa61e482b2b81ec6a298ace4cbf02480/regex-2026.5.9-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b96350aa424e79d4fd6b567b344dcbe2b2d6bfc48dfe7717587e1fa6d43da6ff", size = 292314, upload-time = "2026-05-09T23:13:40.353Z" },
     { url = "https://files.pythonhosted.org/packages/e2/6c/e41bfeecb589716843e7c4df09ba46ff2a42961457afece19059d85caeef/regex-2026.5.9-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f3af7a4903c5c04a11a196a5aa75cdd7dd3f8508132f9fb3259d9f5908e3b88", size = 811681, upload-time = "2026-05-09T23:13:42.543Z" },
-    { url = "https://files.pythonhosted.org/packages/87/83/a5c1c525fba0aa656e88ad0face0b1829788ef4c2fb6b26df58aa1151b84/regex-2026.5.9-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7e87577720152d2caae19fe2baaf1f8d5ca12091e9e229f03915c37d1e4b9178", size = 871135, upload-time = "2026-05-09T23:13:44.326Z" },
-    { url = "https://files.pythonhosted.org/packages/18/d4/80882e799e440dd878b0979cbebf8fa4d54624a332c83037c7a701649e3f/regex-2026.5.9-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c8b9b9d294cfea3cd19c718ade7cc93492b2c4991abd9a68d0b3477ae6d8e100", size = 917265, upload-time = "2026-05-09T23:13:47.295Z" },
     { url = "https://files.pythonhosted.org/packages/ae/ff/8db60211e2286e396aad7dc7725356c502bff0901ea05bd6cdc2e1a042b9/regex-2026.5.9-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:728d8bfd28a8845c8b6bc5dc7ce010453d206396786c0765c2740cb65f37791e", size = 816311, upload-time = "2026-05-09T23:13:49.885Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/47/742ef579c61730f8d268e5cf1f9ce0e37e2ea041ad0f5644724f2378e463/regex-2026.5.9-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7e30b874d341fac767d7df5a0870540541c2c054b80cfaac116e8d367a8a7ff2", size = 785498, upload-time = "2026-05-09T23:13:52.25Z" },
     { url = "https://files.pythonhosted.org/packages/7f/ab/cb0999802dcb0fb95b1ab005e8d4163d8afdd67efc2cb6b6630ac13f8cb1/regex-2026.5.9-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fd190e88a895a8901325fad284a3f74ea52b1da8525b76cc811fa9b1edf0ce2b", size = 801348, upload-time = "2026-05-09T23:13:54.127Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/62/8ca59a24c55bc34d166eefaf3717bd77772f329fdbf984d86581e0a3571c/regex-2026.5.9-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:8e76e8161ad00694cfce6767d5dea860c6391ac5b83e5c3a39661e696f11fc7e", size = 866493, upload-time = "2026-05-09T23:13:56.067Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/3d/30f2ae62cef3278bb5bb821f467277a55fb73f01032cf85997e15e8289a8/regex-2026.5.9-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ddda5340e6c01a293027dd46232fa79eaff1b48058ce7a98f572b6445b088041", size = 772811, upload-time = "2026-05-09T23:13:57.867Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/ae/7d2089bcd78ad0c0161bc684339df50032acb438a7bd3305e7ddb1193cec/regex-2026.5.9-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:205109e96b3cf5adf8f4cd62bedde9487feb282b9497a3535451e5a24cd706a0", size = 856584, upload-time = "2026-05-09T23:13:59.679Z" },
     { url = "https://files.pythonhosted.org/packages/a9/29/92ff47f75990131ea4f24ba17819e5a9d141e10819807e09addd73409af6/regex-2026.5.9-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dfbe4579b9f08036aa7d101d1835437a20783574ac66327e6b29b4018a138081", size = 803453, upload-time = "2026-05-09T23:14:01.978Z" },
 ]
 
@@ -2564,10 +2388,10 @@ name = "requests"
 version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "charset-normalizer", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "idna", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "urllib3", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
@@ -2579,7 +2403,7 @@ name = "rfc3339-validator"
 version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "six", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "six" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/28/ea/a9387748e2d111c3c2b275ba970b735e04e15cdb1eb30693b6b5708c4dbd/rfc3339_validator-0.1.4.tar.gz", hash = "sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b", size = 5513, upload-time = "2021-05-12T16:37:54.178Z" }
 wheels = [
@@ -2600,7 +2424,7 @@ name = "rfc3987-syntax"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "lark", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "lark" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2c/06/37c1a5557acf449e8e406a830a05bf885ac47d33270aec454ef78675008d/rfc3987_syntax-1.1.0.tar.gz", hash = "sha256:717a62cbf33cffdd16dfa3a497d81ce48a660ea691b1ddd7be710c22f00b4a0d", size = 14239, upload-time = "2025-07-18T01:05:05.015Z" }
 wheels = [
@@ -2612,8 +2436,8 @@ name = "rich"
 version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markdown-it-py", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pygments", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "markdown-it-py" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
@@ -2625,7 +2449,7 @@ name = "rlp"
 version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "eth-utils", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "eth-utils" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1b/2d/439b0728a92964a04d9c88ea1ca9ebb128893fbbd5834faa31f987f2fd4c/rlp-4.1.0.tar.gz", hash = "sha256:be07564270a96f3e225e2c107db263de96b5bc1f27722d2855bd3459a08e95a9", size = 33429, upload-time = "2025-02-04T22:05:59.089Z" }
 wheels = [
@@ -2640,29 +2464,17 @@ sdist = { url = "https://files.pythonhosted.org/packages/2e/43/25a8dcd3feedd7350
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/43/35e3f136343aef451e545ce8c38d36c2f93c0ed88703db8b64ba2b205c68/rpds_py-2026.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:58b1d94308ddf0b1982f61f2eb54bf92997c9ece8a8093ef014250f4a517906c", size = 345775, upload-time = "2026-05-28T11:59:13.827Z" },
     { url = "https://files.pythonhosted.org/packages/20/e1/0f2160c5982d3157734d5cb3ed63d8b2d583a73c9864f77b666449f32cf8/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0fa92420128dadce7f54bd73ba1825a273e9268fe9e35dbf7e6362890efa4e08", size = 376329, upload-time = "2026-05-28T11:59:15.271Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/11/ee0ba42aff83bf4effdbc576673c6be64c5e173978c3f6d537e94482f77d/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ca653c6546386227cd9800d1bef6a348099acf8db4250341da6d90f663d6dfcb", size = 383539, upload-time = "2026-05-28T11:59:16.665Z" },
-    { url = "https://files.pythonhosted.org/packages/11/df/d94aa6a499d4ac40afe2d7620f2c597fd3c0f182e854ad7cf3f596a81cb6/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:66c93681c4729e4e3ecba31b8179fae083ff3118841672835140338b4b9867c1", size = 494674, upload-time = "2026-05-28T11:59:17.991Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/75/33d30f43bb2f458de11979486a591b1bf6e5651765ed1704c6197c2dc773/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:40ff257542e04796880e011e15cd4dc21c2599975df2aaa8f2c8495ca574e1a5", size = 389268, upload-time = "2026-05-28T11:59:19.434Z" },
     { url = "https://files.pythonhosted.org/packages/f4/1e/2c9096fc19d5fd084b0184ca2b651e659aa0a37e6fdbecf6ece47f147fe1/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b6825cc329b290e93c5f6a9be2393118a763f6ccf6abd83704e0c102ca583644", size = 376280, upload-time = "2026-05-28T11:59:21Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/e5/61ec9f8be8211ea7f48448195549e4aaf02004083475493b0e137702ecb2/rpds_py-2026.5.1-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:de42116e69cb53b911cc34aee5ab98f36c597b822545045d49e938818b99e5e4", size = 387233, upload-time = "2026-05-28T11:59:22.454Z" },
     { url = "https://files.pythonhosted.org/packages/72/e6/4d5718c5cf26c522dc7c9999e238da1e77380b81d0c5d1df11e271ddfeb1/rpds_py-2026.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0408a24e44feb919423dc6d9da677cb5cddb894d2ca9e763967d156d9c60fab4", size = 553113, upload-time = "2026-05-28T11:59:25.184Z" },
     { url = "https://files.pythonhosted.org/packages/6a/c1/7d4c26f167f8c41501cc073d30ee22082b16ce358cf5b00ec97cbc7804ea/rpds_py-2026.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4be8b1d2a705cc37d08256004e1d07de143fa0075c8e85a3df020b776f62b732", size = 582436, upload-time = "2026-05-28T11:59:28.11Z" },
     { url = "https://files.pythonhosted.org/packages/ca/bb/d1b85117967c11191441a7274ae616c65d93901d082c588f89a50a8da5ae/rpds_py-2026.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c39f5b67a8a2e67179ada2a954227d670fe65fa9098457f698f56ddf248709b3", size = 345179, upload-time = "2026-05-28T11:59:35Z" },
     { url = "https://files.pythonhosted.org/packages/7c/46/d84105f062e626a1b233f863907288a4708c2d833b8b4c6fb2764bc080c0/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5c30f3f04eef4fbd362226a6f31d7c8895ca4fbb6e0b790f6890a98d8da8559", size = 376173, upload-time = "2026-05-28T11:59:36.43Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/ae/469d7959ce5b1201e1de135dc735b86db3b35dd0d1734f6a44246d5f061c/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:277f6c82f0580848796c7ecc8a7173aa3bfb928e4ff831261c2f60a81dc270db", size = 383162, upload-time = "2026-05-28T11:59:37.995Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/a2/57853d31a1116a561aa072794602ad3f6341e18d70a8523f1bd5b9fc1e5a/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:63c2c4c213f1a4e3f3de28ecab029dbdee976324e729c0d7a55211be72576b02", size = 495093, upload-time = "2026-05-28T11:59:39.453Z" },
-    { url = "https://files.pythonhosted.org/packages/99/63/3a8eabcad9314b7daf5c65f451d2c33d989235cd8a5762186cf2c3f5a4f8/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3350ec808fb538fe71a1f94dfaa0e29c598dfad805ce49f0caec5ae3183c652b", size = 389829, upload-time = "2026-05-28T11:59:40.896Z" },
     { url = "https://files.pythonhosted.org/packages/4b/25/05678d97fc25e2622df14dc530fb82023174ecfff6733991ed0d78f167bd/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b1b964e3ab599e718dc46c018d104b1ebc007cbc6567d827c94a687fca56d77e", size = 374786, upload-time = "2026-05-28T11:59:42.626Z" },
-    { url = "https://files.pythonhosted.org/packages/88/d1/8c90b6431e80a3b91b284a5c7c8c0c4f9c006444d90477a740d6e0f9c694/rpds_py-2026.5.1-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:19cb09fab7b7fc96b2a6e28f2e34b72a3705ff27b37edb77455316e5d3f3dc9b", size = 386920, upload-time = "2026-05-28T11:59:44.124Z" },
     { url = "https://files.pythonhosted.org/packages/66/3f/3546524b6eb4cc2e1f363a3d638fa52f6c24faae3500c25fb488b02f1740/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8bff7073db3899158fff55ebf57b113a67030af26f80a18978f9f0aa60250ddf", size = 553030, upload-time = "2026-05-28T11:59:48.603Z" },
     { url = "https://files.pythonhosted.org/packages/61/1e/a3cb07f2795075d1d88efddae2f541359fde5f08c81ee114c29c2949c90a/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4860b603ddda0475a8885499b3729e90229d480105b42651962a5397d995fa89", size = 581178, upload-time = "2026-05-28T11:59:51.673Z" },
     { url = "https://files.pythonhosted.org/packages/8d/58/5c4a43436843c90d0f6d19f82c200c80e3843ca9fa07b237623327f6d384/rpds_py-2026.5.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:cacedb7a6e167680acba45ad5716e89067d225dc80da0d7040cae8c81d4572fa", size = 347033, upload-time = "2026-05-28T11:59:58.881Z" },
     { url = "https://files.pythonhosted.org/packages/fb/c2/1a71acdacaf4e259b10278fb87b039ded3cf80041bcd89dd8a3ea702ded6/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:68700371c5d7ae1412862ddfa719090925c93ecf351c566d66f09d04b136ea00", size = 376891, upload-time = "2026-05-28T12:00:00.516Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/c8/535f3d9b65addd8e28aa87b83c6e526799c3717a88273db8ea795beeef7a/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:296c799becfa849c779c8725494fe9ed94959ed886787df4364b058465bad7f0", size = 385646, upload-time = "2026-05-28T12:00:02.394Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/91/dc033f313345c354ade914dbe73cdb90b615a4409ea02430d5356794f3d8/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d3858b908218ee108d0bbfb2095ccc237648053c9bf98affad7cb079acaf1d97", size = 498830, upload-time = "2026-05-28T12:00:04.189Z" },
-    { url = "https://files.pythonhosted.org/packages/27/fc/90fcbea459dbb8ddc18a2e0fd1de9412b48bc84ffff2db771cf714bacfd6/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4fb8d2e7cb2f850b169806d61d1b991738acec96500a75c30f49caf064ce7cef", size = 392830, upload-time = "2026-05-28T12:00:05.797Z" },
     { url = "https://files.pythonhosted.org/packages/b2/1d/46cd11a228c9750684a798d98f878be6f614aa762438da7378f035e79e35/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:27b74c10ed6a8f190f4287f53bcfea348b92a84a9c9f70d30183d1e6172d580d", size = 379613, upload-time = "2026-05-28T12:00:07.433Z" },
-    { url = "https://files.pythonhosted.org/packages/24/4a/d9b0c6af3a1de03eb93741bbe8be2bdce84d8fda8224f3005451d86df389/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:b9a6528956191c48c52294a592dbd4a8386d7048bdb25c0efcb6b966466c6d83", size = 388183, upload-time = "2026-05-28T12:00:09.227Z" },
     { url = "https://files.pythonhosted.org/packages/08/d6/070f6a41cbb343e2ac4171859bf3f3623e0ab002f72619d6d505313ec2de/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fea6e836d10abbe191d557d33bd58bd5987725fe63aa1eefe557d230209855bd", size = 553573, upload-time = "2026-05-28T12:00:12.443Z" },
     { url = "https://files.pythonhosted.org/packages/8a/22/9bf80a56069c0c443fcfefac639a86a744550a2898817a6dfd3e26654924/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e0b360f316d966b048b085857630b3cc51f3db2f07b06f440eac8f695374d1e3", size = 585633, upload-time = "2026-05-28T12:00:15.66Z" },
 ]
@@ -2673,16 +2485,10 @@ version = "0.15.16"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a6/bd/5f7ec371001337d8fa61701c186ff8b613ecac1651848c5950f4c4d5f2e9/ruff-0.15.16.tar.gz", hash = "sha256:d05e78d38c78caf020b03789e25106c93017db5a0cb6e2819885018c61343b78", size = 4714267, upload-time = "2026-06-04T16:33:09.974Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/42/53ef1c3953f157956db9bf7861e3bc50b9b887ce93300aa48cdba8336fe6/ruff-0.15.16-py3-none-linux_armv6l.whl", hash = "sha256:6ac3c0b3969cc6cf6b158c4e2f8f682acb58e7d700d8a44b65ecdc72d66ab0b2", size = 10709025, upload-time = "2026-06-04T16:32:51.935Z" },
     { url = "https://files.pythonhosted.org/packages/bc/72/3ce2ac000a5299ec238e01f51397b3b653c93b077d9b1bfe8715bb895f20/ruff-0.15.16-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3a39fec45ab316cc23e7558f23fea4a70403ddb5648ea9a4a3854a16973d0071", size = 10421345, upload-time = "2026-06-04T16:32:37.251Z" },
     { url = "https://files.pythonhosted.org/packages/b0/c2/cc7fad3ec9169373f5b6a18f1917b91080feec40c3f9658334a1d28e2f03/ruff-0.15.16-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ba93191d79003116b95128c9d306e045200fdbd0bccb782b110f3cd1d4abc5cf", size = 10757217, upload-time = "2026-06-04T16:32:54.722Z" },
-    { url = "https://files.pythonhosted.org/packages/69/d2/3474009eaa0a65b31fa7152a2fad5e2f050c640ceb1e6b02ee6922e94c82/ruff-0.15.16-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c6ee4b90520630120ef032aa5cc10db483852dff950e78b1d717e2993a61ac8d", size = 10507035, upload-time = "2026-06-04T16:33:05.343Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/e1/46e526f1a7cc90857ce6ddf25fbb77eb6568651ac38d71b033af07076dd5/ruff-0.15.16-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7c8d26be963b090f10e29abc8b3e74a2a321f6fa34e02424e30b5af89350ecbb", size = 12124922, upload-time = "2026-06-04T16:33:07.821Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/da/5c791b088b596b24d0deb967fa28ae02ad751a140c0b9ea81c5ab915d6c0/ruff-0.15.16-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f198cf4123602a2280ed46c307bcbafe41758d6fee5b456b6b6058ca1514b3b4", size = 11332186, upload-time = "2026-06-04T16:33:02.971Z" },
     { url = "https://files.pythonhosted.org/packages/72/11/5da87abe20047c8962361473923ebb2f62b595250126aadfad8c20649c1e/ruff-0.15.16-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb27515fa6240fb586ae82b901a59e67d24acff86f2190b433dc542fe0435aeb", size = 11373541, upload-time = "2026-06-04T16:32:47.007Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/2a/8554754c23a854ae3fd6b507e36ad61ddb121e298c6d5d617dec94ed0f14/ruff-0.15.16-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a267c46ba1593fc26b8eecbea050b39d40c0b6bb7781ee11c90a02cd10032951", size = 11353014, upload-time = "2026-06-04T16:32:34.795Z" },
     { url = "https://files.pythonhosted.org/packages/62/25/62ea41529ec89f742ea3fed9cb1059c72877ec7cf9b9e99ac9cf3294d1d9/ruff-0.15.16-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:528c68f39a91498a8d50e91ff5985df3d105782bab49cc378e73ac26bff083e8", size = 10737467, upload-time = "2026-06-04T16:32:26.348Z" },
-    { url = "https://files.pythonhosted.org/packages/90/17/334d3ad9de4d40f9dd58fdd09e35ce64553bb501e2f19a839e2fb6be14fc/ruff-0.15.16-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:7ed55c58950df60589a9a7a5d2f8fa5f54ebd287163be805adfe6ee95a9de123", size = 10521910, upload-time = "2026-06-04T16:32:32.54Z" },
     { url = "https://files.pythonhosted.org/packages/33/d7/609546e6a413c3f216fbf2a50c928f97c80939154f6a0503114094a86191/ruff-0.15.16-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1e15bc8c94513dae2a40cc9ef07c94fdd4ecc9e29dabebeebe170f952322c9e3", size = 11477014, upload-time = "2026-06-04T16:32:44.687Z" },
 ]
 
@@ -2700,8 +2506,8 @@ name = "sentry-sdk"
 version = "2.62.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "urllib3", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "certifi" },
+    { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f6/5d/a343201726150e05f2036eeb6e493e2e2f8bf8a66f5aa70f2f4ac96f9ca3/sentry_sdk-2.62.0.tar.gz", hash = "sha256:3c870b9f50d9fd15b58c817dbde1c7cfaa9fe3f05df0a4c6edd5571cb82f5491", size = 463986, upload-time = "2026-06-08T13:23:49.223Z" }
 wheels = [
@@ -2758,8 +2564,8 @@ name = "sqlalchemy"
 version = "2.0.50"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "greenlet", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "greenlet", marker = "sys_platform == 'linux'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/57/da/6fbf010c8ebb347679d0d100b22fe9ba5e13fd04046c5df7280d2f0bf706/sqlalchemy-2.0.50.tar.gz", hash = "sha256:af5607d11ef90fd6a5c0549fe0045dce1663d427426bcfb506dcb5346a85a3b9", size = 9907424, upload-time = "2026-05-24T19:20:04.018Z" }
 wheels = [
@@ -2781,9 +2587,9 @@ name = "stack-data"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "asttokens", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "executing", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pure-eval", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "asttokens" },
+    { name = "executing" },
+    { name = "pure-eval" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
 wheels = [
@@ -2795,7 +2601,7 @@ name = "starlette"
 version = "0.46.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "anyio" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ce/20/08dfcd9c983f6a6f4a1000d934b9e6d626cff8d2eeb77a89a68eef20a2b7/starlette-0.46.2.tar.gz", hash = "sha256:7f7361f34eed179294600af672f565727419830b54b7b084efe44bb82d2fccd5", size = 2580846, upload-time = "2025-04-13T13:56:17.942Z" }
 wheels = [
@@ -2807,7 +2613,7 @@ name = "sympy"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mpmath", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "mpmath" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
@@ -2819,8 +2625,8 @@ name = "terminado"
 version = "0.18.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "(os_name != 'nt' and platform_machine == 'arm64' and sys_platform == 'darwin') or (os_name != 'nt' and platform_machine == 'aarch64' and sys_platform == 'linux') or (os_name != 'nt' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "tornado", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "ptyprocess", marker = "os_name != 'nt'" },
+    { name = "tornado" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8a/11/965c6fd8e5cc254f1fe142d547387da17a8ebfd75a3455f637c663fb38a0/terminado-0.18.1.tar.gz", hash = "sha256:de09f2c4b85de4765f7714688fff57d3e75bad1f909b589fde880460c753fd2e", size = 32701, upload-time = "2024-03-12T14:34:39.026Z" }
 wheels = [
@@ -2832,7 +2638,7 @@ name = "tinycss2"
 version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "webencodings", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "webencodings" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/ae/2ca4913e5c0f09781d75482874c3a95db9105462a92ddd303c7d285d3df2/tinycss2-1.5.1.tar.gz", hash = "sha256:d339d2b616ba90ccce58da8495a78f46e55d4d25f9fd71dfd526f07e7d53f957", size = 88195, upload-time = "2025-11-23T10:29:10.082Z" }
 wheels = [
@@ -2857,13 +2663,13 @@ resolution-markers = [
     "python_full_version < '3.13' and platform_machine == 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "filelock", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
-    { name = "fsspec", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
-    { name = "jinja2", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
-    { name = "networkx", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
-    { name = "setuptools", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
-    { name = "sympy", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
-    { name = "typing-extensions", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:b41339df93d491435e790ff8bcbae1c0ce777175889bfd1281d119862793e6a2", upload-time = "2026-05-12T16:20:12Z" },
@@ -2882,22 +2688,19 @@ resolution-markers = [
     "python_full_version < '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "filelock", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "fsspec", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "jinja2", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "networkx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "setuptools", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "sympy", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typing-extensions", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp312-cp312-linux_s390x.whl", hash = "sha256:b9d0e8eed0af9321ffb12b75f4aca371b071254f12cf75875d5a8e7cc8f52b51", upload-time = "2026-05-12T23:16:33Z" },
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:ce2ddb880b0813fcc91a737f08fdd973a8115a74c64ccb34e9c09a7964b4d448", upload-time = "2026-05-12T23:16:40Z" },
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:5e3dc83725581fa38b7b2e45c58692e30b2a3cde19191af54b675ffcac3840a6", upload-time = "2026-05-12T23:16:48Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp313-cp313-linux_s390x.whl", hash = "sha256:5e0da19e1c3bfdc9b92638c552579eac678354485d61fc8921b0461fd6c40449", upload-time = "2026-05-12T23:17:05Z" },
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:68b7ddd4db4603a03e106e74c7098c8d8c8943d33c1e5ada009ca4cd885759c3", upload-time = "2026-05-12T23:17:12Z" },
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:ada78018bdfa30d1c766596cd32d910dbf5b03424cd859231b6d2a00533de922", upload-time = "2026-05-12T23:17:20Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp313-cp313t-linux_s390x.whl", hash = "sha256:32b9b7a0974cd6149cb98def0a28a49d92d7c14a384273d5539da9624239e950", upload-time = "2026-05-12T23:17:36Z" },
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:93ed8dc52c113580daf6124982b3232629045dccc5cd83a8f5ed478f7bac7340", upload-time = "2026-05-12T23:17:43Z" },
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:6a1c86abd4ed15a0736cf2663ad69642ae5d1288c99e30346070e6241018a0a9", upload-time = "2026-05-12T23:17:54Z" },
 ]
@@ -2929,9 +2732,9 @@ name = "typer"
 version = "0.26.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "annotated-doc", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "rich", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "shellingham", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "annotated-doc" },
+    { name = "rich" },
+    { name = "shellingham" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/ed/ef06584ccdd5c410df0837951ecd7e15d9a6144ea1bd4c73cecab1a89891/typer-0.26.7.tar.gz", hash = "sha256:e314a34c617e419c091b2830dda3ea1f257134ff593061a8f5b9717ab8dddb3a", size = 201709, upload-time = "2026-06-03T07:18:06.843Z" }
 wheels = [
@@ -2952,7 +2755,7 @@ name = "types-requests"
 version = "2.33.0.20260518"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "urllib3", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e0/01/c5a19253fe1ac159159ddf9a3a07cec8bb5e486ec4d9002ad2821da0e5d2/types_requests-2.33.0.20260518.tar.gz", hash = "sha256:df7bd3bfe0ca8402dfb841e7d9be714bb5578203283d66d7dc4ef69343449a5e", size = 24752, upload-time = "2026-05-18T06:07:37.966Z" }
 wheels = [
@@ -2973,8 +2776,8 @@ name = "typing-inspect"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mypy-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "mypy-extensions" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/dc/74/1789779d91f1961fa9438e9a8710cdae6bd138c80d7303996933d117264a/typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78", size = 13825, upload-time = "2023-05-24T20:25:47.612Z" }
 wheels = [
@@ -2986,7 +2789,7 @@ name = "typing-inspection"
 version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
@@ -3025,8 +2828,8 @@ name = "uvicorn"
 version = "0.34.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "h11", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "click" },
+    { name = "h11" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/de/ad/713be230bcda622eaa35c28f0d328c3675c371238470abdea52417f17a8e/uvicorn-0.34.3.tar.gz", hash = "sha256:35919a9a979d7a59334b6b10e05d77c1d0d574c50e0fc98b8b1a0f165708b55a", size = 76631, upload-time = "2025-06-01T07:48:17.531Z" }
 wheels = [
@@ -3038,16 +2841,16 @@ name = "wandb"
 version = "0.27.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "gitpython", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "packaging", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "platformdirs", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "protobuf", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pydantic", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pyyaml", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "requests", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "sentry-sdk", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "click" },
+    { name = "gitpython" },
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "sentry-sdk" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/14/a2/53ca062f430178e3af48ebc137396481d0ee885fb94a554c0df464cd8afa/wandb-0.27.2.tar.gz", hash = "sha256:c81ff93ab63f4dabc5a27b90ac3d12310fbfa6a14ca99201626921c99b2845be", size = 40300451, upload-time = "2026-06-06T01:47:02.74Z" }
 wheels = [
@@ -3072,19 +2875,19 @@ name = "web3"
 version = "7.16.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "eth-abi", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "eth-account", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "eth-hash", extra = ["pycryptodome"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "eth-typing", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "eth-utils", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "hexbytes", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pydantic", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pyunormalize", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "requests", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "types-requests", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "websockets", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "aiohttp" },
+    { name = "eth-abi" },
+    { name = "eth-account" },
+    { name = "eth-hash", extra = ["pycryptodome"] },
+    { name = "eth-typing" },
+    { name = "eth-utils" },
+    { name = "hexbytes" },
+    { name = "pydantic" },
+    { name = "pyunormalize" },
+    { name = "requests" },
+    { name = "types-requests" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f1/d9/bdfa9e715804020c3f3676346065c18adbc207c9343a3458246d7430f45c/web3-7.16.0.tar.gz", hash = "sha256:b4a75a3fa94fef4d23d502eb3c2244146ef9a1ee0082cf1cb0a91586ba0510c3", size = 2211469, upload-time = "2026-05-01T21:22:20.666Z" }
 wheels = [
@@ -3153,39 +2956,23 @@ name = "yarl"
 version = "1.24.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "idna", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "multidict", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "propcache", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "idna" },
+    { name = "multidict" },
+    { name = "propcache" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/79/12/1e8f37460ea0f7eb59c221fdaf0ed75e7ac43e97f8093b9c6f411df50a78/yarl-1.24.2.tar.gz", hash = "sha256:9ac374123c6fd7abf64d1fec93962b0bd4ee2c19751755a762a72dd96c0378f8", size = 210798, upload-time = "2026-05-19T21:31:05.599Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f0/da/866bcb01076ba49d2b42b309867bed3826421f1c479655eb7a607b44f20b/yarl-1.24.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b975866c184564c827e0877380f0dae57dcca7e52782128381b72feff6dfceb8", size = 129957, upload-time = "2026-05-19T21:28:51.695Z" },
     { url = "https://files.pythonhosted.org/packages/29/b6/170e2b8d4e3bc30e6bfdcca53556537f5bf595e938632dfcb059311f3ff6/yarl-1.24.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8ae44649b00947634ab0dab2a374a638f52923a6e67083f2c156cd5cbd1a881d", size = 91688, upload-time = "2026-05-19T21:28:54.865Z" },
     { url = "https://files.pythonhosted.org/packages/fe/a5/c9f655d5553ea0b99fdac9d6a99ad3f9b3e73b8e5758bb46f58c9831f74c/yarl-1.24.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:507cc19f0b45454e2d6dcd62ff7d062b9f77a2812404e62dbdaec05b50faa035", size = 102902, upload-time = "2026-05-19T21:28:56.963Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/bc/6b9664d815d79af4ee553337f9d606c56bbf269186ada9172de45f1b5f60/yarl-1.24.2-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c4c17bad5a530912d2111825d3f05e89bab2dd376aaa8cbc77e449e6db63e576", size = 97931, upload-time = "2026-05-19T21:28:58.56Z" },
-    { url = "https://files.pythonhosted.org/packages/98/ec/32ba48acae30fecd60928f5791188b80a9d6ee3840507ffda29fecd37b71/yarl-1.24.2-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f5f0cbb112838a4a293985b6ed73948a547dadcc1ba6d2089938e7abdedceef8", size = 111030, upload-time = "2026-05-19T21:29:00.148Z" },
-    { url = "https://files.pythonhosted.org/packages/82/5a/6f4cd081e5f4934d2ae3a8ef4abe3afacc010d26f0035ee91b35cd7d7c37/yarl-1.24.2-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5ec8356b8a6afcf81fc7aeeef13b1ff7a49dec00f313394bbb9e83830d32ccd7", size = 110392, upload-time = "2026-05-19T21:29:02.155Z" },
     { url = "https://files.pythonhosted.org/packages/7a/da/323a01c349bd5fb01bb6652e314d9bb218cee630a736bdb810ad50e4013f/yarl-1.24.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7e7ebcdef69dec6c6451e616f32b622a6d4a2e92b445c992f7c8e5274a6bbc4c", size = 105612, upload-time = "2026-05-19T21:29:04.247Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/80/264ab684f181e1a876389374519ff05d10248725535ae2ac4e8ac4e563d6/yarl-1.24.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:47a55d6cf6db2f401017a9e96e5288844e5051911fb4e0c8311a3980f5e59a7d", size = 104487, upload-time = "2026-05-19T21:29:06.491Z" },
     { url = "https://files.pythonhosted.org/packages/41/07/efabe5df87e96d7ad5959760b888344be48cd6884db127b407c6b5503adc/yarl-1.24.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3065657c80a2321225e804048597ad55658a7e76b32d6f5ee4074d04c50401db", size = 102333, upload-time = "2026-05-19T21:29:08.267Z" },
-    { url = "https://files.pythonhosted.org/packages/44/0c/bcf7c42603e1009295f586d8890f2ba032c8b53310e815adf0a202c73d9f/yarl-1.24.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:cb84b80d88e19ede158619b80813968713d8d008b0e2497a576e6a0557d50712", size = 99025, upload-time = "2026-05-19T21:29:10.682Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/82/84482ab1a57a0f21a08afe6a7004c61d741f8f2ecc3b05c321577c612164/yarl-1.24.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:990de4f680b1c217e77ff0d6aa0029f9eb79889c11fb3e9a3942c7eba29c1996", size = 110507, upload-time = "2026-05-19T21:29:12.954Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/8d/a546ba1dfe1b0f290e05fef145cd07614c0f15df1a707195e512d1e39d1d/yarl-1.24.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:abb8ec0323b80161e3802da3150ef660b41d0e9be2048b76a363d93eee992c2b", size = 103719, upload-time = "2026-05-19T21:29:14.893Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/b6/267f2a09213138473adfce6b8a6e17791d7fee70bd4d9003218e4dec58b0/yarl-1.24.2-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:e7977781f83638a4c73e0f88425563d70173e0dfd90ac006a45c65036293ee3c", size = 110438, upload-time = "2026-05-19T21:29:16.485Z" },
     { url = "https://files.pythonhosted.org/packages/48/2d/1c8d89c7c5f9cad9fb2902445d94e2ab1d7aa35de029afbb8ae95c42d00f/yarl-1.24.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e30dd55825dc554ec5b66a94953b8eda8745926514c5089dfcacecb9c99b5bd1", size = 105719, upload-time = "2026-05-19T21:29:18.367Z" },
     { url = "https://files.pythonhosted.org/packages/82/62/fcf0ce677f17e5c471c06311dd25964be38a4c586993632910d2e75278bc/yarl-1.24.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:491ac9141decf49ee8030199e1ee251cdff0e131f25678817ff6aa5f837a3536", size = 128978, upload-time = "2026-05-19T21:29:23.83Z" },
     { url = "https://files.pythonhosted.org/packages/c1/24/16748d5dab6daec8b0ed81ccec639a1cded0f18dcc62a4f696b4fe366c37/yarl-1.24.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cdfcce633b4a4bb8281913c57fcafd4b5933fbc19111a5e3930bbd299d6102f1", size = 91113, upload-time = "2026-05-19T21:29:26.928Z" },
     { url = "https://files.pythonhosted.org/packages/1b/66/b63fff7b71211e866624b21432d5943cbb633eb0c2872d9ee3070648f22c/yarl-1.24.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:863297ddede92ee49024e9a9b11ecb59f310ca85b60d8537f56bed9bbb5b1986", size = 103899, upload-time = "2026-05-19T21:29:28.842Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/ac/ba1974b8533909636f7733fe86cf677e3619527c3c2fa913e0ea89c48757/yarl-1.24.2-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:374423f70754a2c96942ede36a29d37dc6b0cb8f92f8d009ddf3ed78d3da5488", size = 97862, upload-time = "2026-05-19T21:29:31.086Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/a5/123ac993b5c2ba6f554a140305620cb8f150fa543711bbc49be3ec0a65a4/yarl-1.24.2-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:33a29b5d00ccbf3219bb3e351d7875739c19481e030779f48cc46a7a71681a9b", size = 111060, upload-time = "2026-05-19T21:29:32.657Z" },
-    { url = "https://files.pythonhosted.org/packages/23/37/c472d3af3509688392134a88a825276770a187f1daa4de3f6dc0a327a751/yarl-1.24.2-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a9532c57211730c515341af11fef6e9b61d157487272a096d0c04da445642592", size = 110613, upload-time = "2026-05-19T21:29:34.379Z" },
     { url = "https://files.pythonhosted.org/packages/df/88/09c28dad91e662ccfaa1b78f1c57badde74fc9d0b23e74aef644750ecd73/yarl-1.24.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:91e72cf093fd833483a97ee648e0c053c7c629f51ff4a0e7edd84f806b0c5617", size = 107012, upload-time = "2026-05-19T21:29:36.216Z" },
-    { url = "https://files.pythonhosted.org/packages/07/ab/9d4f69d571a94f4d112fa7e2e007200f5a54d319f58c82ac7b7baa61f5c6/yarl-1.24.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b3177bc0a768ef3bacceb4f272632990b7bea352f1b2f1eee9d6d6ff16516f92", size = 105887, upload-time = "2026-05-19T21:29:38.746Z" },
     { url = "https://files.pythonhosted.org/packages/8e/9a/000b2b66c0d772a499fc531d21dab92dfeb73b640a12eed6ba89f49bb2d0/yarl-1.24.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e196952aacaf3b232e265ff02980b64d483dc0972bd49bcb061171ff22ac203a", size = 103620, upload-time = "2026-05-19T21:29:40.368Z" },
-    { url = "https://files.pythonhosted.org/packages/41/7c/7c1050f73450fbdaa3f0c72017059f00ce5e13366692f3dba25275a1083d/yarl-1.24.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:204e7a61ce99919c0de1bf904ab5d7aa188a129ea8f690a8f76cfb6e2844dc44", size = 100599, upload-time = "2026-05-19T21:29:42.66Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/b1/29e5756b3926705f5f6089bd5b9f50a56eaac550da6e260bf713ead44d04/yarl-1.24.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:4b156914620f0b9d78dc1adb3751141daee561cfec796088abb89ed49d220f1a", size = 110604, upload-time = "2026-05-19T21:29:44.632Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/4b/8415bc96e9b150cde942fbac9a8182985e58f40ce5c54c34ed015407d3ee/yarl-1.24.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:8372a2b976cf70654b2be6619ab6068acabb35f724c0fda7b277fbf53d66a5cf", size = 105161, upload-time = "2026-05-19T21:29:46.755Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/d4/cde059abfa229553b7298a2eadde2752e723d50aeedaef86ce59da2718ee/yarl-1.24.2-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:f9a1e9b622ca284143aab5d885848686dcd85453bb1ca9abcdb7503e64dc0056", size = 110619, upload-time = "2026-05-19T21:29:48.972Z" },
     { url = "https://files.pythonhosted.org/packages/e7/2c/d6a6c9a61549f7b6c7e6dc6937d195bcf069582b47b7200dcd0e7b256acf/yarl-1.24.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:810e19b685c8c3c5862f6a38160a1f4e4c0916c9390024ec347b6157a45a0992", size = 107362, upload-time = "2026-05-19T21:29:51Z" },
     { url = "https://files.pythonhosted.org/packages/fd/4d/4b880086bd0d3e034d25647be1d830afc3e3f610e98c4ab3490af6b1b6d5/yarl-1.24.2-py3-none-any.whl", hash = "sha256:2783d9226db8797636cd6896e4de81feed252d1db72265686c9558d97a4d94b9", size = 53576, upload-time = "2026-05-19T21:31:03.909Z" },
 ]

--- a/kit/Makefile
+++ b/kit/Makefile
@@ -1,4 +1,6 @@
-.PHONY: test test-alkahest test-config test-identity test-policy
+.PHONY: test test-alkahest test-config test-identity test-policy dist dist-site dist-resource-pools
+
+DIST_DIR ?= $(abspath ../.dist)
 
 test: test-alkahest test-config test-identity test-policy
 
@@ -13,3 +15,17 @@ test-identity:
 
 test-policy:
 	cd policy && make test
+
+dist: dist-site dist-resource-pools
+
+dist-site:
+	-mkdir -p $(DIST_DIR)
+	cd site && $(MAKE) build DIST_DIR=$(DIST_DIR)
+	@ls $(DIST_DIR)/arkhai_kit_site-*-none-any.whl > /dev/null 2>&1 || \
+		(echo "ERROR: arkhai-kit-site produced a platform-specific wheel — must build inside Docker" && exit 1)
+
+dist-resource-pools:
+	-mkdir -p $(DIST_DIR)
+	cd resource-pools && $(MAKE) build DIST_DIR=$(DIST_DIR)
+	@ls $(DIST_DIR)/arkhai_kit_resource_pools-*-none-any.whl > /dev/null 2>&1 || \
+		(echo "ERROR: arkhai-kit-resource-pools produced a platform-specific wheel — must build inside Docker" && exit 1)

--- a/kit/resource-pools/Makefile
+++ b/kit/resource-pools/Makefile
@@ -1,0 +1,9 @@
+DIST_DIR ?= ../../.dist
+
+.PHONY: build test
+
+build: ## Build the wheel into the shared .dist/
+	uv build --wheel --out-dir $(DIST_DIR)
+
+test: ## Run the test suite
+	uv run --find-links $(DIST_DIR) pytest tests/unit -q

--- a/kit/resource-pools/pyproject.toml
+++ b/kit/resource-pools/pyproject.toml
@@ -1,0 +1,27 @@
+[project]
+name = "arkhai-kit-resource-pools"
+version = "0.1.0"
+license = "MIT"
+description = "Provider-neutral resource-pool administration: persistence, YAML reconciliation, and the pool-config handler protocol."
+requires-python = ">=3.12"
+dependencies = [
+    "pydantic>=2.7",
+    "sqlalchemy>=2.0",
+    "pyyaml>=6.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/market_resource_pools"]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests/unit"]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.3.4,<9.0.0",
+]

--- a/kit/resource-pools/src/market_resource_pools/__init__.py
+++ b/kit/resource-pools/src/market_resource_pools/__init__.py
@@ -1,0 +1,49 @@
+"""Provider-neutral resource-pool administration."""
+
+from .db import DEFAULT_POOL_ID, ResourcePool
+from .pool_config_handler import PoolConfigHandler, PoolConfigValidationProblem
+from .pools import (
+    PoolCreate,
+    PoolImportDiff,
+    PoolImportRequest,
+    PoolImportResponse,
+    PoolListResponse,
+    PoolReplace,
+    PoolResponse,
+    PoolUpdate,
+    PoolValidateResponse,
+    PoolValidationProblem,
+)
+from .service import (
+    DocumentValidationResult,
+    PoolAlreadyExistsError,
+    PoolDefinition,
+    PoolNotFoundError,
+    PoolValidationError,
+    ReconciliationPlan,
+    ResourcePoolService,
+)
+
+__all__ = [
+    "DEFAULT_POOL_ID",
+    "DocumentValidationResult",
+    "PoolAlreadyExistsError",
+    "PoolConfigHandler",
+    "PoolConfigValidationProblem",
+    "PoolCreate",
+    "PoolDefinition",
+    "PoolImportDiff",
+    "PoolImportRequest",
+    "PoolImportResponse",
+    "PoolListResponse",
+    "PoolNotFoundError",
+    "PoolReplace",
+    "PoolResponse",
+    "PoolUpdate",
+    "PoolValidateResponse",
+    "PoolValidationError",
+    "PoolValidationProblem",
+    "ReconciliationPlan",
+    "ResourcePool",
+    "ResourcePoolService",
+]

--- a/kit/resource-pools/src/market_resource_pools/db.py
+++ b/kit/resource-pools/src/market_resource_pools/db.py
@@ -1,0 +1,53 @@
+"""Provider-neutral resource-pool persistence model.
+
+Owns its own declarative ``Base``/metadata, matching the shape
+``market_site`` already uses for the site-authority ledger: a domain
+service composes this package's ``Base.metadata`` alongside its own at
+``create_all`` time, and re-exports the ORM classes it needs through its
+own ``db.models`` module so existing call sites keep working unchanged.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import JSON, Boolean, Column, DateTime, String, func
+from sqlalchemy.orm import declarative_base
+
+Base = declarative_base()
+
+DEFAULT_POOL_ID = "default"
+
+
+class ResourcePool(Base):
+    """A provider-neutral resource pool: identity, lifecycle, and policy tags.
+
+    id:
+        Operator-chosen slug (e.g. "hetzner-eu-central"). Not a UUID — pool
+        ids appear in YAML definitions and are meant to be human-legible.
+    enabled:
+        False pools are excluded from scheduling eligibility. Delete is
+        soft — disable — by default; pools are never hard-deleted by the
+        admin API so that ``hosts.pool_id`` and any settlement records
+        referencing this id remain resolvable.
+    policy_tags:
+        Free-form tag map (e.g. {"region": "eu", "provider": "hetzner"})
+        used for tag-filtered pool lookup.
+
+    Provider-specific configuration lives in a provider-owned side table
+    (e.g. ``ansible_pool_configs``, domain-owned), resolved through the
+    ``PoolConfigHandler`` protocol by explicit ``pool_id`` lookup — this
+    model intentionally carries no ORM relationship to any provider-specific
+    table, since a provider's config table lives in a different service's
+    declarative registry.
+    """
+
+    __tablename__ = "resource_pools"
+
+    id = Column(String, primary_key=True)
+    label = Column(String, nullable=False)
+    provider = Column(String, nullable=False)
+    enabled = Column(Boolean, nullable=False, default=True)
+    policy_tags = Column(JSON, nullable=False, default=dict)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )

--- a/kit/resource-pools/src/market_resource_pools/pool_config_handler.py
+++ b/kit/resource-pools/src/market_resource_pools/pool_config_handler.py
@@ -1,0 +1,47 @@
+"""Provider-specific resource-pool configuration boundary.
+
+Implementations validate and persist the configuration associated with one
+resource-pool provider.  The caller owns the unit of work: handlers must not
+commit or roll back transactions themselves.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Protocol, TypeVar
+
+UnitOfWorkT = TypeVar("UnitOfWorkT")
+
+
+@dataclass(frozen=True)
+class PoolConfigValidationProblem:
+    """One provider-specific configuration problem, relative to provider_config."""
+
+    path: str
+    code: str
+    message: str
+
+
+class PoolConfigHandler(Protocol[UnitOfWorkT]):
+    """Validate and persist one provider's pool configuration."""
+
+    provider: str
+
+    def validate_config(self, config: Mapping[str, Any]) -> dict[str, Any]: ...
+
+    def validate_config_problems(
+        self, config: Mapping[str, Any]
+    ) -> tuple[dict[str, Any] | None, tuple[PoolConfigValidationProblem, ...]]: ...
+
+    def read_config(
+        self, unit_of_work: UnitOfWorkT, pool_id: str
+    ) -> dict[str, Any]: ...
+
+    def replace_config(
+        self,
+        unit_of_work: UnitOfWorkT,
+        pool_id: str,
+        config: Mapping[str, Any],
+    ) -> None: ...
+
+    def delete_config(self, unit_of_work: UnitOfWorkT, pool_id: str) -> None: ...

--- a/kit/resource-pools/src/market_resource_pools/pools.py
+++ b/kit/resource-pools/src/market_resource_pools/pools.py
@@ -1,0 +1,99 @@
+"""Executor-neutral resource-pool wire models."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class PoolCreate(BaseModel):
+    """Body accepted by ``POST /api/v1/pools``."""
+
+    id: str = Field(description="Operator-chosen pool slug, e.g. 'hetzner-eu-central'.")
+    label: str = Field(description="Human-readable pool name.")
+    provider: str = Field(description="Fulfillment provider kind, e.g. 'ansible'.")
+    enabled: bool = True
+    policy_tags: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Free-form tags for policy-driven pool lookup.",
+    )
+    provider_config: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Provider-owned configuration validated by the selected handler.",
+    )
+
+
+class PoolReplace(BaseModel):
+    """Complete replacement body accepted by ``PUT /api/v1/pools/{pool_id}``."""
+
+    label: str
+    provider: str
+    enabled: bool
+    policy_tags: dict[str, Any] = Field(default_factory=dict)
+    provider_config: dict[str, Any] = Field(default_factory=dict)
+
+
+class PoolUpdate(BaseModel):
+    """Partial update body accepted by ``PATCH /api/v1/pools/{pool_id}``."""
+
+    label: str | None = None
+    provider: str | None = None
+    enabled: bool | None = None
+    policy_tags: dict[str, Any] | None = None
+    provider_config: dict[str, Any] | None = None
+
+
+class PoolResponse(BaseModel):
+    """Serialized pool row returned by all pool endpoints."""
+
+    id: str
+    label: str
+    provider: str
+    enabled: bool
+    policy_tags: dict[str, Any]
+    provider_config: dict[str, Any]
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class PoolListResponse(BaseModel):
+    pools: list[PoolResponse]
+    total: int
+
+
+class PoolImportRequest(BaseModel):
+    yaml_text: str = Field(
+        description="Authoritative resource-pool YAML with a top-level 'pools' list."
+    )
+
+
+class PoolImportDiff(BaseModel):
+    """Reconciliation diff produced for a valid authoritative document."""
+
+    created: list[str] = Field(default_factory=list)
+    updated: list[str] = Field(default_factory=list)
+    disabled: list[str] = Field(default_factory=list)
+    unchanged: list[str] = Field(default_factory=list)
+
+
+class PoolValidationProblem(BaseModel):
+    """One problem found while validating an authoritative pool document."""
+
+    path: str
+    code: str
+    message: str
+
+
+class PoolImportResponse(BaseModel):
+    diff: PoolImportDiff
+    applied: bool
+
+
+class PoolValidateResponse(BaseModel):
+    valid: bool
+    problems: list[PoolValidationProblem] = Field(default_factory=list)
+    diff: PoolImportDiff | None = None

--- a/kit/resource-pools/src/market_resource_pools/service.py
+++ b/kit/resource-pools/src/market_resource_pools/service.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Mapping, Optional
+from typing import Any, Callable, Mapping, Optional
 
 import yaml
 from sqlalchemy.orm import Session, sessionmaker
 
-from compute_provisioning import (
-    PoolConfigHandler,
+from .pool_config_handler import PoolConfigHandler
+from .pools import (
     PoolCreate,
     PoolImportDiff,
     PoolReplace,
@@ -17,7 +17,7 @@ from compute_provisioning import (
     PoolValidateResponse,
     PoolValidationProblem,
 )
-from db.models import DEFAULT_POOL_ID, ResourcePool
+from .db import DEFAULT_POOL_ID, ResourcePool
 
 
 class PoolNotFoundError(Exception):
@@ -61,6 +61,20 @@ class ReconciliationPlan:
 
 
 class ResourcePoolService:
+    """Provider-neutral resource-pool administration.
+
+    ``handlers`` must be supplied by the caller — this service does not
+    default to any concrete provider implementation (e.g. Ansible), keeping
+    it free of any domain-specific import.
+
+    ``active_binding_check``, if supplied, is called with a pool id whenever
+    an operation would disable that pool; it should return ``True`` if the
+    pool has at least one active settlement-resource binding, in which case
+    the disable is rejected. Late-bound (settable after construction) so a
+    composition root can wire this service and its scheduler in either
+    order without a circular dependency.
+    """
+
     _ROOT_FIELDS = frozenset({"pools"})
     _POOL_FIELDS = frozenset(
         {"id", "label", "provider", "enabled", "policy_tags", "provider_config"}
@@ -69,14 +83,12 @@ class ResourcePoolService:
     def __init__(
         self,
         session_factory: sessionmaker[Session],
-        handlers: Mapping[str, PoolConfigHandler[Session]] | None = None,
+        handlers: Mapping[str, PoolConfigHandler[Session]],
+        active_binding_check: Callable[[str], bool] | None = None,
     ) -> None:
         self._session_factory = session_factory
-        if handlers is None:
-            from services.ansible_pool_config_handler import AnsiblePoolConfigHandler
-
-            handlers = {"ansible": AnsiblePoolConfigHandler()}
         self._handlers = dict(handlers)
+        self.active_binding_check = active_binding_check
 
     def _handler(self, provider: str) -> PoolConfigHandler[Session]:
         handler = self._handlers.get(provider)
@@ -96,10 +108,13 @@ class ResourcePoolService:
         except ValueError as exc:
             raise PoolValidationError(str(exc)) from exc
 
-    @staticmethod
-    def _ensure_default_pool_enabled(pool_id: str, enabled: bool | None) -> None:
-        if pool_id == DEFAULT_POOL_ID and enabled is False:
-            raise PoolValidationError("the default pool cannot be disabled")
+    def _ensure_no_active_binding(self, pool_id: str, enabled: bool | None) -> None:
+        if enabled is False and self.active_binding_check is not None:
+            if self.active_binding_check(pool_id):
+                raise PoolValidationError(
+                    f"pool '{pool_id}' has an active settlement-resource "
+                    "binding and cannot be disabled"
+                )
 
     def _attach_provider_config(self, db: Session, pool: ResourcePool) -> None:
         pool.provider_config = self._handler(pool.provider).read_config(db, pool.id)
@@ -142,7 +157,7 @@ class ResourcePoolService:
         return pool
 
     def create_pool(self, data: PoolCreate) -> ResourcePool:
-        self._ensure_default_pool_enabled(data.id, data.enabled)
+        self._ensure_no_active_binding(data.id, data.enabled)
         config = self._normalize_config(data.provider, data.provider_config)
         with self._session_factory() as db, db.begin():
             if db.query(ResourcePool).filter(ResourcePool.id == data.id).one_or_none():
@@ -160,7 +175,7 @@ class ResourcePoolService:
         return self.get_pool(data.id)  # type: ignore[return-value]
 
     def replace_pool(self, pool_id: str, data: PoolReplace) -> ResourcePool:
-        self._ensure_default_pool_enabled(pool_id, data.enabled)
+        self._ensure_no_active_binding(pool_id, data.enabled)
         config = self._normalize_config(data.provider, data.provider_config)
         with self._session_factory() as db, db.begin():
             pool = self._require_pool(db, pool_id)
@@ -175,7 +190,7 @@ class ResourcePoolService:
         return self.get_pool(pool_id)  # type: ignore[return-value]
 
     def update_pool(self, pool_id: str, data: PoolUpdate) -> ResourcePool:
-        self._ensure_default_pool_enabled(pool_id, data.enabled)
+        self._ensure_no_active_binding(pool_id, data.enabled)
         with self._session_factory() as db, db.begin():
             pool = self._require_pool(db, pool_id)
             provider = data.provider or pool.provider
@@ -213,8 +228,6 @@ class ResourcePoolService:
         internal caller cannot accidentally introduce hard deletion without
         revisiting the pool lifecycle and referential-integrity rules.
         """
-        if pool_id == DEFAULT_POOL_ID:
-            raise PoolValidationError("the default pool cannot be deleted")
         raise PoolValidationError(
             "resource pools use disable semantics and cannot be hard-deleted"
         )
@@ -342,15 +355,6 @@ class ResourcePoolService:
                         path=f"{base}.enabled",
                         code="invalid_type",
                         message="enabled must be boolean",
-                    )
-                )
-                entry_valid = False
-            elif pool_id == DEFAULT_POOL_ID and enabled is False:
-                problems.append(
-                    PoolValidationProblem(
-                        path=f"{base}.enabled",
-                        code="default_pool_disabled",
-                        message="the default pool must remain enabled",
                     )
                 )
                 entry_valid = False
@@ -498,6 +502,13 @@ class ResourcePoolService:
         for definition in (*plan.created, *plan.updated):
             self._apply_definition(db, definition)
         if plan.disabled:
+            if self.active_binding_check is not None:
+                bound = [pid for pid in plan.disabled if self.active_binding_check(pid)]
+                if bound:
+                    raise PoolValidationError(
+                        "cannot disable pool(s) with an active settlement-resource "
+                        f"binding: {', '.join(bound)}"
+                    )
             db.query(ResourcePool).filter(ResourcePool.id.in_(plan.disabled)).update(
                 {ResourcePool.enabled: False}, synchronize_session=False
             )

--- a/kit/resource-pools/src/market_resource_pools/service.py
+++ b/kit/resource-pools/src/market_resource_pools/service.py
@@ -67,12 +67,9 @@ class ResourcePoolService:
     default to any concrete provider implementation (e.g. Ansible), keeping
     it free of any domain-specific import.
 
-    ``active_binding_check``, if supplied, is called with a pool id whenever
-    an operation would disable that pool; it should return ``True`` if the
-    pool has at least one active settlement-resource binding, in which case
-    the disable is rejected. Late-bound (settable after construction) so a
-    composition root can wire this service and its scheduler in either
-    order without a circular dependency.
+    Disabling a pool is a draining operation: it excludes the pool from new
+    scheduling decisions without invalidating existing reservations,
+    assignments, or active workloads.
     """
 
     _ROOT_FIELDS = frozenset({"pools"})
@@ -84,11 +81,9 @@ class ResourcePoolService:
         self,
         session_factory: sessionmaker[Session],
         handlers: Mapping[str, PoolConfigHandler[Session]],
-        active_binding_check: Callable[[str], bool] | None = None,
     ) -> None:
         self._session_factory = session_factory
         self._handlers = dict(handlers)
-        self.active_binding_check = active_binding_check
 
     def _handler(self, provider: str) -> PoolConfigHandler[Session]:
         handler = self._handlers.get(provider)
@@ -107,14 +102,6 @@ class ResourcePoolService:
             return self._handler(provider).validate_config(config)
         except ValueError as exc:
             raise PoolValidationError(str(exc)) from exc
-
-    def _ensure_no_active_binding(self, pool_id: str, enabled: bool | None) -> None:
-        if enabled is False and self.active_binding_check is not None:
-            if self.active_binding_check(pool_id):
-                raise PoolValidationError(
-                    f"pool '{pool_id}' has an active settlement-resource "
-                    "binding and cannot be disabled"
-                )
 
     def _attach_provider_config(self, db: Session, pool: ResourcePool) -> None:
         pool.provider_config = self._handler(pool.provider).read_config(db, pool.id)
@@ -157,7 +144,6 @@ class ResourcePoolService:
         return pool
 
     def create_pool(self, data: PoolCreate) -> ResourcePool:
-        self._ensure_no_active_binding(data.id, data.enabled)
         config = self._normalize_config(data.provider, data.provider_config)
         with self._session_factory() as db, db.begin():
             if db.query(ResourcePool).filter(ResourcePool.id == data.id).one_or_none():
@@ -175,7 +161,6 @@ class ResourcePoolService:
         return self.get_pool(data.id)  # type: ignore[return-value]
 
     def replace_pool(self, pool_id: str, data: PoolReplace) -> ResourcePool:
-        self._ensure_no_active_binding(pool_id, data.enabled)
         config = self._normalize_config(data.provider, data.provider_config)
         with self._session_factory() as db, db.begin():
             pool = self._require_pool(db, pool_id)
@@ -190,7 +175,6 @@ class ResourcePoolService:
         return self.get_pool(pool_id)  # type: ignore[return-value]
 
     def update_pool(self, pool_id: str, data: PoolUpdate) -> ResourcePool:
-        self._ensure_no_active_binding(pool_id, data.enabled)
         with self._session_factory() as db, db.begin():
             pool = self._require_pool(db, pool_id)
             provider = data.provider or pool.provider
@@ -502,13 +486,6 @@ class ResourcePoolService:
         for definition in (*plan.created, *plan.updated):
             self._apply_definition(db, definition)
         if plan.disabled:
-            if self.active_binding_check is not None:
-                bound = [pid for pid in plan.disabled if self.active_binding_check(pid)]
-                if bound:
-                    raise PoolValidationError(
-                        "cannot disable pool(s) with an active settlement-resource "
-                        f"binding: {', '.join(bound)}"
-                    )
             db.query(ResourcePool).filter(ResourcePool.id.in_(plan.disabled)).update(
                 {ResourcePool.enabled: False}, synchronize_session=False
             )

--- a/kit/resource-pools/tests/unit/test_resource_pool_service.py
+++ b/kit/resource-pools/tests/unit/test_resource_pool_service.py
@@ -398,40 +398,16 @@ class TestEnableDisablePool:
         assert still_there is not None
         assert still_there.enabled is False
 
-    def test_disable_rejected_when_active_binding_exists(self, session_factory):
-        service = ResourcePoolService(
-            session_factory=session_factory,
-            handlers={"ansible": _AnsibleLikePoolConfigHandler()},
-            active_binding_check=lambda pool_id: pool_id == "bound-pool",
-        )
-        service.create_pool(
+    def test_disabling_pool_is_a_draining_operation(self, svc):
+        svc.create_pool(
             PoolCreate(
-                id="bound-pool",
-                label="Bound",
+                id="draining-pool",
+                label="Draining",
                 provider="ansible",
                 provider_config=_ANSIBLE_CONFIG,
             )
         )
-        with pytest.raises(PoolValidationError, match="active settlement-resource"):
-            service.disable_pool("bound-pool")
-        assert service.get_pool("bound-pool").enabled is True
-
-    def test_disable_allowed_when_no_active_binding(self, session_factory):
-        service = ResourcePoolService(
-            session_factory=session_factory,
-            handlers={"ansible": _AnsibleLikePoolConfigHandler()},
-            active_binding_check=lambda pool_id: False,
-        )
-        service.create_pool(
-            PoolCreate(
-                id="free-pool",
-                label="Free",
-                provider="ansible",
-                provider_config=_ANSIBLE_CONFIG,
-            )
-        )
-        disabled = service.disable_pool("free-pool")
-        assert disabled.enabled is False
+        assert svc.disable_pool("draining-pool").enabled is False
 
 
 # ---------------------------------------------------------------------------
@@ -517,15 +493,8 @@ pools:
         assert pool is not None
         assert pool.enabled is False
 
-    def test_import_disabling_a_pool_with_active_binding_rejects_entire_import(
-        self, session_factory
-    ):
-        service = ResourcePoolService(
-            session_factory=session_factory,
-            handlers={"ansible": _AnsibleLikePoolConfigHandler()},
-            active_binding_check=lambda pool_id: pool_id == "equinix-us-west",
-        )
-        service.import_pools(_YAML)
+    def test_import_can_disable_pool_as_draining_operation(self, svc):
+        svc.import_pools(_YAML)
         one_pool_yaml = """
 pools:
   - id: default
@@ -534,17 +503,10 @@ pools:
     provider_config:
       playbook_path: playbooks/vm-operations.yaml
       inventory_group: kvm_hosts
-  - id: hetzner-eu-central
-    label: Hetzner EU Central
-    provider: ansible
-    provider_config:
-      playbook_path: playbooks/vm-operations-frp.yaml
-      inventory_group: kvm_hosts_eu
 """
-        with pytest.raises(PoolValidationError, match="active settlement-resource"):
-            service.import_pools(one_pool_yaml)
-        # Rejected atomically — equinix-us-west remains enabled.
-        assert service.get_pool("equinix-us-west").enabled is True
+        diff = svc.import_pools(one_pool_yaml)
+        assert "equinix-us-west" in diff.disabled
+
 
     def test_invalid_entry_rejects_entire_document(self, svc):
         mixed_yaml = """

--- a/kit/resource-pools/tests/unit/test_resource_pool_service.py
+++ b/kit/resource-pools/tests/unit/test_resource_pool_service.py
@@ -4,29 +4,42 @@ Unit tests for ResourcePoolService.
 Scope (per ARCHITECTURE.md — Unit Tests jurisdiction):
   - CRUD: create/get/list/replace/patch/enable/disable
   - Tag-filtered lookup
-  - Provider config validation (ansible required fields; unknown providers rejected)
+  - Provider config validation (required fields; unknown providers rejected)
   - YAML import: created/updated/disabled/unchanged diff, idempotency,
     validate_only (no writes)
+  - Active-binding guardrail on disable
 
-External boundary: SQLAlchemy with an in-memory SQLite DB (not mocked) —
-consistent with test_host_service.py's rationale.
+External boundary: SQLAlchemy with an in-memory SQLite DB (not mocked).
+
+This package is provider-neutral kit code, so tests use a local
+ansible-shaped stub handler rather than the real VM-domain
+AnsiblePoolConfigHandler — the "ansible" provider string is just test data
+here, not a dependency on the VM service.
 """
 
 from __future__ import annotations
+
+from typing import Any
 
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.pool import StaticPool
 
-from db.database import create_session_factory
-from db.models import Base
-from compute_provisioning import PoolCreate, PoolReplace, PoolUpdate
-from services.resource_pool_service import (
+from market_resource_pools import (
     PoolAlreadyExistsError,
+    PoolCreate,
     PoolNotFoundError,
+    PoolReplace,
+    PoolUpdate,
     PoolValidationError,
     ResourcePoolService,
 )
+from market_resource_pools.db import Base
+from sqlalchemy.orm import sessionmaker
+
+
+def create_session_factory(engine):
+    return sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 
 # ---------------------------------------------------------------------------
@@ -50,9 +63,86 @@ def session_factory(db_engine):
     return create_session_factory(db_engine)
 
 
+class _AnsibleLikePoolConfigHandler:
+    """Test stand-in shaped like the real (VM-domain) Ansible handler.
+
+    Requires playbook_path/inventory_group, same as the real handler — the
+    CRUD/validation tests below exercise that shape without importing
+    VM-domain code into this kit package's own test suite.
+    """
+
+    provider = "ansible"
+    _FIELDS = frozenset({"playbook_path", "inventory_group", "extra_vars"})
+
+    def validate_config(self, config):
+        normalized, problems = self.validate_config_problems(config)
+        if problems:
+            raise ValueError(problems[0].message)
+        return normalized
+
+    def validate_config_problems(self, config):
+        from market_resource_pools import PoolConfigValidationProblem
+
+        problems: list[PoolConfigValidationProblem] = []
+        for field in sorted(set(config) - self._FIELDS):
+            problems.append(
+                PoolConfigValidationProblem(
+                    path=field, code="unknown_field",
+                    message=f"unknown ansible provider_config field '{field}'",
+                )
+            )
+        playbook_path = config.get("playbook_path")
+        inventory_group = config.get("inventory_group")
+        extra_vars = config.get("extra_vars", {})
+        if not isinstance(playbook_path, str) or not playbook_path.strip():
+            problems.append(
+                PoolConfigValidationProblem(
+                    path="playbook_path", code="required_field",
+                    message="provider_config.playbook_path is required for provider='ansible'",
+                )
+            )
+        if not isinstance(inventory_group, str) or not inventory_group.strip():
+            problems.append(
+                PoolConfigValidationProblem(
+                    path="inventory_group", code="required_field",
+                    message="provider_config.inventory_group is required for provider='ansible'",
+                )
+            )
+        if not isinstance(extra_vars, dict):
+            problems.append(
+                PoolConfigValidationProblem(
+                    path="extra_vars", code="invalid_type",
+                    message="provider_config.extra_vars must be a mapping",
+                )
+            )
+        if problems:
+            return None, tuple(problems)
+        return {
+            "playbook_path": playbook_path,
+            "inventory_group": inventory_group,
+            "extra_vars": dict(extra_vars),
+        }, ()
+
+    def read_config(self, db, pool_id: str) -> dict[str, Any]:
+        row = self._configs.get(pool_id) if hasattr(self, "_configs") else None
+        return dict(row) if row else {}
+
+    def replace_config(self, db, pool_id: str, config) -> None:
+        if not hasattr(self, "_configs"):
+            self._configs: dict[str, dict] = {}
+        self._configs[pool_id] = dict(config)
+
+    def delete_config(self, db, pool_id: str) -> None:
+        if hasattr(self, "_configs"):
+            self._configs.pop(pool_id, None)
+
+
 @pytest.fixture
 def svc(session_factory):
-    return ResourcePoolService(session_factory=session_factory)
+    return ResourcePoolService(
+        session_factory=session_factory,
+        handlers={"ansible": _AnsibleLikePoolConfigHandler()},
+    )
 
 
 _ANSIBLE_CONFIG = {
@@ -289,7 +379,11 @@ class TestEnableDisablePool:
         with pytest.raises(PoolNotFoundError):
             svc.disable_pool("does-not-exist")
 
-    def test_default_pool_cannot_be_disabled(self, svc):
+    def test_default_pool_can_be_disabled(self, svc):
+        """Corrected POOLS-1 behavior: disabling `default` only excludes it
+        from scheduling — it never stops being the system-owned pool that
+        exists. (Host fallback-to-default-on-omission is a VM-service
+        concern, covered in the integration suite, not here.)"""
         svc.create_pool(
             PoolCreate(
                 id="default",
@@ -298,9 +392,46 @@ class TestEnableDisablePool:
                 provider_config=_ANSIBLE_CONFIG,
             )
         )
+        disabled = svc.disable_pool("default")
+        assert disabled.enabled is False
+        still_there = svc.get_pool("default")
+        assert still_there is not None
+        assert still_there.enabled is False
 
-        with pytest.raises(PoolValidationError, match="cannot be disabled"):
-            svc.disable_pool("default")
+    def test_disable_rejected_when_active_binding_exists(self, session_factory):
+        service = ResourcePoolService(
+            session_factory=session_factory,
+            handlers={"ansible": _AnsibleLikePoolConfigHandler()},
+            active_binding_check=lambda pool_id: pool_id == "bound-pool",
+        )
+        service.create_pool(
+            PoolCreate(
+                id="bound-pool",
+                label="Bound",
+                provider="ansible",
+                provider_config=_ANSIBLE_CONFIG,
+            )
+        )
+        with pytest.raises(PoolValidationError, match="active settlement-resource"):
+            service.disable_pool("bound-pool")
+        assert service.get_pool("bound-pool").enabled is True
+
+    def test_disable_allowed_when_no_active_binding(self, session_factory):
+        service = ResourcePoolService(
+            session_factory=session_factory,
+            handlers={"ansible": _AnsibleLikePoolConfigHandler()},
+            active_binding_check=lambda pool_id: False,
+        )
+        service.create_pool(
+            PoolCreate(
+                id="free-pool",
+                label="Free",
+                provider="ansible",
+                provider_config=_ANSIBLE_CONFIG,
+            )
+        )
+        disabled = service.disable_pool("free-pool")
+        assert disabled.enabled is False
 
 
 # ---------------------------------------------------------------------------
@@ -386,6 +517,35 @@ pools:
         assert pool is not None
         assert pool.enabled is False
 
+    def test_import_disabling_a_pool_with_active_binding_rejects_entire_import(
+        self, session_factory
+    ):
+        service = ResourcePoolService(
+            session_factory=session_factory,
+            handlers={"ansible": _AnsibleLikePoolConfigHandler()},
+            active_binding_check=lambda pool_id: pool_id == "equinix-us-west",
+        )
+        service.import_pools(_YAML)
+        one_pool_yaml = """
+pools:
+  - id: default
+    label: Default Pool
+    provider: ansible
+    provider_config:
+      playbook_path: playbooks/vm-operations.yaml
+      inventory_group: kvm_hosts
+  - id: hetzner-eu-central
+    label: Hetzner EU Central
+    provider: ansible
+    provider_config:
+      playbook_path: playbooks/vm-operations-frp.yaml
+      inventory_group: kvm_hosts_eu
+"""
+        with pytest.raises(PoolValidationError, match="active settlement-resource"):
+            service.import_pools(one_pool_yaml)
+        # Rejected atomically — equinix-us-west remains enabled.
+        assert service.get_pool("equinix-us-west").enabled is True
+
     def test_invalid_entry_rejects_entire_document(self, svc):
         mixed_yaml = """
 pools:
@@ -442,16 +602,29 @@ pools:
         }
         assert svc.list_pools() == []
 
-    def test_validate_rejects_disabled_default_pool(self, svc):
+    def test_validate_accepts_disabled_default_pool(self, svc):
+        """Corrected POOLS-1 behavior: a disabled `default` in an
+        authoritative document is valid — only omitting `default` entirely
+        is rejected (test_missing_default_pool_rejected, below)."""
         response = svc.validate_pools(
             _YAML.replace("enabled: true", "enabled: false", 1)
         )
+        assert response.valid is True
+        assert response.diff is not None
 
+    def test_missing_default_pool_rejected(self, svc):
+        no_default_yaml = """
+pools:
+  - id: hetzner-eu-central
+    label: Hetzner EU Central
+    provider: ansible
+    provider_config:
+      playbook_path: playbooks/vm-operations-frp.yaml
+      inventory_group: kvm_hosts_eu
+"""
+        response = svc.validate_pools(no_default_yaml)
         assert response.valid is False
-        assert response.diff is None
-        assert "default_pool_disabled" in {
-            problem.code for problem in response.problems
-        }
+        assert "missing_default_pool" in {p.code for p in response.problems}
 
     def test_validate_accumulates_all_detectable_problems(self, svc):
         response = svc.validate_pools("""

--- a/kit/site/src/market_site/ledger.py
+++ b/kit/site/src/market_site/ledger.py
@@ -696,6 +696,19 @@ class CapacityLedgerService:
     # Internals
     # ------------------------------------------------------------------
 
+    def expire_due_holds(self) -> None:
+        """Public entry point for a periodic watchdog to sweep expired holds.
+
+        Every ``reserve``/``commit``/``release``/``probe`` call already runs
+        :meth:`_expire_stale_holds` lazily against its own open session, so
+        an uncommitted hold is self-healing the moment anything touches the
+        ledger again. This method exists for the case where nothing does —
+        an idle site with no incoming requests — so a hold doesn't sit
+        expired-but-unreleased indefinitely.
+        """
+        with self._lock, self._session_factory() as db:
+            self._expire_stale_holds(db)
+
     def _expire_stale_holds(self, db: Session) -> None:
         """Lapse TTL'd reservations whose hold expired without a commit.
 

--- a/kit/site/tests/unit/test_ledger.py
+++ b/kit/site/tests/unit/test_ledger.py
@@ -346,6 +346,33 @@ def test_ttl_hold_expires_without_commit(seeded: CapacityLedgerService):
     assert lapsed["failure_reason"] == "hold_expired"
 
 
+def test_expire_due_holds_reclaims_without_another_ledger_call(
+    seeded: CapacityLedgerService,
+):
+    """The watchdog's public entry point, exercised directly rather than
+    via the lazy sweep every reserve/commit/release already runs."""
+    reserved = seeded.reserve(
+        claim={"gpu_count": 8}, deal_ref={"escrow_uid": "0xwatchdog"}, ttl_seconds=60,
+    )
+    assert reserved["hold_expires_at"] is not None
+
+    from market_site.db import SiteAllocation
+    with seeded._session_factory() as db:
+        row = db.get(SiteAllocation, reserved["allocation_id"])
+        row.hold_expires_at = (
+            datetime.now(timezone.utc) - timedelta(seconds=1)
+        ).isoformat()
+        db.commit()
+
+    # No reserve/commit/release/probe call in between — only the public
+    # sweep entry point a periodic watchdog would call.
+    seeded.expire_due_holds()
+
+    lapsed = seeded.get_allocation(reserved["allocation_id"])
+    assert lapsed["state"] == "released"
+    assert lapsed["failure_reason"] == "hold_expired"
+
+
 def test_committed_hold_survives_ttl(seeded: CapacityLedgerService):
     reserved = seeded.reserve(
         claim={"gpu_count": 2}, deal_ref={"escrow_uid": "0xkeep"}, ttl_seconds=60,

--- a/openspec/README.md
+++ b/openspec/README.md
@@ -46,6 +46,43 @@ The change artifacts own requirements, design, readiness, and task state. This s
 
 The two tracks can start independently. Compute changes are ordered by their numeric prefix; the final proof also depends on the domain contract. A newly discovered prerequisite stays in the current task list when required for that change's acceptance criteria, otherwise it receives the same initiative prefix and is cross-linked as an independently archivable change.
 
+### Resource pool physical settlement
+
+**Goal:** Move from operator-managed pool administration to pool-aware
+physical settlement resource selection, provider execution, and a cleaned
+-up storefront capacity boundary.
+
+1. `pools-1-resource-pool-foundation` — archived
+   ([`changes/archive/2026-07-13-pools-1-resource-pool-foundation/`](changes/archive/2026-07-13-pools-1-resource-pool-foundation/)).
+   Resource pools, provider configuration, host membership, and the
+   administrative API.
+2. [`pools-2-physical-settlement-scheduler`](changes/pools-2-physical-settlement-scheduler/) —
+   bind a capacity reservation to a specific settlement resource through
+   `PhysicalSettlementScheduler`, without yet persisting the binding or
+   executing fulfillment against it. Design-reviewed; entering planning.
+3. [`pools-3-fulfillment-provider`](changes/pools-3-fulfillment-provider/) —
+   `FulfillmentProvider` ABC, `ProviderRegistry`, the Ansible provider, and
+   durable `SettlementRecord` persistence. Proposal/design recovered from
+   pre-migration planning and verified against current code; still carries
+   one unresolved design-review topic (`SettlementRecord` vs. the
+   storefront's `settlement_claims`/`ClaimsEngine` ownership boundary) and
+   has not had its own design-review session yet.
+4. [`pools-4-storefront-capacity-boundary`](changes/pools-4-storefront-capacity-boundary/) —
+   remove host-specific placement from the ordinary storefront reservation
+   path and apply `pools-2`'s reservation-expiry model storefront-side.
+   Recovered and corrected against current code (the `SiteLedger`/
+   `SiteResourcesService` rename it originally called for is already done).
+5. [`pools-5-shared-provisioning-package`](changes/pools-5-shared-provisioning-package/) —
+   **largely superseded.** The originally-planned `core/provisioning`
+   package already exists in a different shape
+   (`provisioning/compute`/`compute_provisioning`), and its remaining
+   extraction goal is already covered by the active
+   `market-platform-compute-30-extract-service` change. Taskless and
+   activation-gated; see its proposal.md.
+
+Final e2e verification (originally POOLS-6) is not yet drafted as a change
+directory.
+
 ### Imported change index — specification required
 
 The following proposals/designs are a normalized index of the former TODO and design documents, not implementation-ready plans. Their generated task lists were removed. Before implementation, audit the proposal against current code, rewrite its delta requirements and acceptance scenarios, make its design decisions explicit, and only then create a concrete task artifact. The audited market-platform changes above are no longer part of this imported set.

--- a/openspec/changes/pools-2-physical-settlement-scheduler/.openspec.yaml
+++ b/openspec/changes/pools-2-physical-settlement-scheduler/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-14

--- a/openspec/changes/pools-2-physical-settlement-scheduler/design.md
+++ b/openspec/changes/pools-2-physical-settlement-scheduler/design.md
@@ -1,332 +1,125 @@
-## Context
+# Design: Capacity Settlement Scheduler
 
-POOLS-1 gave operators durable, provider-neutral pool identity and
-administrative host membership, but deliberately stopped short of
-settlement selection: existing capacity reservation and allocation
-selection behavior was explicitly left unchanged, and the site ledger
-still hardcodes `pool_id: None` on allocation payloads. Today, physical
-placement is not a decision at all — it is either a caller-supplied
-`vm_target` or a static `default_vm_host` configuration fallback
-(`job_service.py`). There is no formal boundary that owns "which physical
-resource satisfies this allocation," which is exactly the conflation this
-change resolves.
+## Design goals
 
-This content — the scheduler/provider split, the request and resource
-shapes, the naming decision, and the pool-selection algorithm — previously
-lived in `docs/development/ARCHITECTURE.md` under "Physical Settlement
-Scheduler and FulfillmentProvider Architecture." That section was dropped
-during the migration to OpenSpec: the migration ledger recorded a
-destination change directory (`migrate-compute-provisioning`) that was
-never actually created, so the content had nowhere to land and was deleted
-along with the source. This design.md is that content's recovered and
-updated home.
+The design separates accepted capacity from the concrete scheduling decision and separates that decision from provider-specific execution. It favors a small, deterministic policy that can be understood and tested now while preserving an interface for richer policies later.
 
-## Goals / Non-Goals
+The scheduler is an orchestrator. A policy receives only an already-filtered set of eligible candidates and chooses one. Policies do not load allocations, inspect agreements, query provider models, persist assignments, or decide whether explicit requests are valid.
 
-**Goals:**
-- Give the system one durable, idempotent answer to "which physical
-  resource satisfies this allocation," keyed by `allocation_id`.
-- Balance load across pools without a static priority column (rejected in
-  POOLS-1: can't express live balance, duplicate priorities too common).
-- Support both the fungible (pool/capacity-attribute) path and the
-  specific-resource (explicit `resource_id`) path in the same request
-  shape.
-- Resolve the previously-blocking capacity-reservation-expiry question by
-  reusing the existing lease expiry model rather than inventing a new one.
-- Close the `disable_pool` guardrail gap now that there is something for it
-  to check.
+## Standard vocabulary
 
-**Non-Goals:** see `proposal.md` — persistence, `FulfillmentProvider`
-execution, specific-resource opt-in configuration, full DRF, and
-storefront-side reservation cleanup are all out of scope for this change.
+1. **Capacity Reservation** — accepted capacity plus agreement identity, requested shape or units, lifecycle state, and expiry.
+2. **Capacity Settlement Assignment** — the idempotent decision mapping one unchanged reservation to one concrete pooled resource.
+3. **Physical Settlement** — provider-specific execution on that assigned resource.
+4. **Provisioned Resource / Active Workload** — the resulting running resource or service.
 
-## Decisions
+An assignment does not imply that physical settlement has started, succeeded, or remains active.
 
-### 1. Scheduler is a separate step from fulfillment, called after capacity reserve
+## Responsibilities
 
-```python
-PhysicalSettlementScheduler.select_resource(...)
-    -> atomically binds the agreement/allocation to a settlement resource
+### `PhysicalSettlementScheduler`
 
-FulfillmentProvider.create(...)   # pools-3
-    -> performs provider-specific operations against the selected resource
-```
+- load and validate the Capacity Reservation;
+- validate represented agreement, market, and terms relationships;
+- reject inactive or expired reservations;
+- return an existing assignment without rerunning policy;
+- construct executor-neutral requirements and candidates;
+- enforce pool and resource eligibility;
+- handle exact-resource constraints;
+- invoke the configured policy for automatic selection;
+- record the Capacity Settlement Assignment.
 
-The scheduler owns placement; it does not execute anything. A provider
-(added in `pools-3`) receives an already-selected `SettlementResource` and
-must not independently substitute a different one. This keeps the boundary
-usable by future non-VM markets (bare metal, Kubernetes, power, storage,
-bandwidth) without teaching the generic path any one provider's vocabulary.
+### `SettlementSchedulingPolicy`
 
-```python
-from dataclasses import dataclass
-from typing import Any
+The protocol lives in `arkhai-compute-provisioning` so services can supply independent policies without importing one another. It selects one candidate from an already eligible sequence and does not own validation or persistence.
 
-@dataclass(frozen=True)
-class PhysicalSettlementRequest:
-    allocation_id: str
-    agreement_id: str
-    market: str
-    terms: dict[str, Any]
-    pool_id: str | None = None
-    resource_id: str | None = None
+### `DeterministicRoundRobinPolicy`
 
-@dataclass(frozen=True)
-class SettlementResource:
-    settlement_resource_id: str
-    pool_id: str
-    resource_kind: str
-    provider: str
-    attributes: dict[str, Any]
+The initial VM-service policy lives separately from scheduler orchestration because it is one member of a future policy family. It maintains a pool cursor and a per-pool resource cursor.
 
-class PhysicalSettlementScheduler:
-    async def select_resource(
-        self,
-        request: PhysicalSettlementRequest,
-    ) -> SettlementResource:
-        """Atomically bind request.allocation_id to a settlement resource.
+## Eligibility
 
-        Repeated calls for the same allocation_id return the existing
-        binding.
-        """
-        ...
-```
+Every resource eligible for physical settlement belongs to exactly one Resource Pool. A resource with no pool is not connected to physical settlement. A resource represented in multiple pools misrepresents true system capacity and is invalid configuration.
 
-An alternative considered was folding selection into
-`ExecutorLeaseService.register_lease` directly. Rejected: it blurs
-"registering a lease" with "making a scheduling decision" and denies
-scheduling its own idempotency/testing seam (scheduler idempotency,
-disabled/exhausted-pool exclusion, and no-match errors need to be testable
-in isolation from lease registration).
+An eligible candidate must:
 
-### 2. Naming: `Settlement Resource`, not `SettlementTarget`
+- exist and be enabled;
+- belong to exactly one existing enabled pool;
+- match the reserved resource kind;
+- match all required generic attributes;
+- have sufficient available units for the reservation;
+- expose the opaque provider metadata required by the downstream settlement boundary.
 
-`select_resource(...)` is the primary name; `select_target_resource(...)`
-is also acceptable where a call site benefits from emphasizing that the
-selected resource is the fulfillment target. The noun `SettlementTarget`
-is avoided throughout code and docs — the canonical domain noun is
-**Settlement Resource**, per the repository's official vocabulary
-(`openspec/config.yaml`).
+Provider reachability, credentials, executor topology, and actual provisioning success are evaluated during physical settlement rather than by generic policy code.
 
-### 3. Pool selection: bottleneck-normalized least-loaded
+An explicit resource request bypasses scheduling policy choice only. It passes every allocation, agreement, expiry, pool, resource, shape, attribute, and capacity check used by automatic scheduling. Explicit selection does not advance round-robin cursors.
 
-```text
-for each eligible pool:
-    utilization = max(
-        used_cpu / total_cpu,
-        used_ram / total_ram,
-        used_gpu / total_gpu,
-        used_disk / total_disk,
-    )   # the bottleneck dimension, not an average
-select the pool with the lowest utilization
-```
+## Deterministic round-robin policy
 
-Taking the `max` across dimensions rather than an average matters: a pool
-at 90% GPU utilization and 10% everywhere else is effectively full for
-GPU-bound requests even though its average looks healthy. This is a
-lightweight slice of Dominant Resource Fairness (Ghodsi et al.); full DRF
-also weights by each *request's* resource shape, not just each pool's
-current load — that fuller treatment is deliberately deferred. The
-approach requires no new schema or persistent state (no cursor, no
-counters) and degenerates to plain round-robin when fed only
-single-resource, equal-sized pools, so it is not a regression for the
-simple case.
+The MVP policy performs two deterministic choices:
 
-### 4. Specific-resource path is honored, not configured
+1. Group eligible candidates by pool, sort pool IDs, and select the pool after the last automatically selected pool.
+2. Sort resource IDs in the selected pool and select the resource after the last automatically selected resource for that pool.
 
-`PhysicalSettlementRequest.resource_id` is part of the shape from day one:
-if supplied, the scheduler binds exactly that resource and does not
-substitute another one. What remains unresolved — deliberately, not as an
-oversight — is *how* a seller opts a listing into exposing specific
-resources, and at what layer that authority lives (resource, pool,
-provisioning-service, or storefront level). Encoding an answer now would
-be premature; this stays open for a future change once real specific
--resource listings exist to design against.
+If the prior cursor value is no longer eligible, selection starts at the first sorted eligible value. Disabled or exhausted pools never enter the policy input. A retry that finds an existing assignment returns it and does not advance either cursor.
 
-### 5. Reservation expiry reuses the lease model; watchdog lives at the site authority, not the storefront
+This policy provides basic distribution and deterministic tie-breaking. It is not DRF: it does not identify competing consumers, track dominant shares, or compare multidimensional allocations.
 
-Decided this session. Capacity reservations gain the same `start`/`end`
-lease-window shape executor leases already use
-(`kit/site/src/market_site/ledger.py` already has `hold_expires_at` TTL and
-lazy `_expire_stale_holds()` invoked on every `reserve`/`commit`/`release`).
-What's added is a periodic sweep, mirroring the existing `LeaseWatchdog`
-thin-timer pattern (`domains/vms/provisioning/service/src/services/lease_watchdog.py`):
-an asyncio interval timer whose only job is scheduling, delegating all
-logic to the ledger's own expiry check, so uncommitted holds are reclaimed
-even without another request touching them.
+## Pool disablement
 
-This lives on the site-authority side, not the storefront: a storefront
-only ever holds a cached capacity projection and unions multiple sites'
-projections for an approximate view (`site-capacity`'s multi-site
-aggregation requirement). It has no independent capacity ledger to run a
-watchdog against; it only needs to request reservations and receive
-change notifications. `kit/site` cannot depend on domain composition roots
-(market-composition's from-below dependency rule), so the watchdog itself
-is composed at the same place `LeaseWatchdog` already is today — a
-provisioning service's composition root — pointed at the ledger's expiry
-check instead of VM lease lifecycle. Exact file placement is a `tasks.md`
-concern for the implementation plan, not a design decision.
+Disabling a pool is a draining operation. It immediately removes the pool from new Capacity Settlement Assignments. Existing reservations, assignments, physical settlements, and active workloads do not prevent disablement and are not invalidated by it.
 
-### 6. No persistence this change; binding lives only for this change's own test/process scope
+POOLS-2 does not migrate unassigned reservations or existing assignments to another pool. A reservation constrained to a concrete resource in a disabled pool fails eligibility.
 
-`pools-3` introduces `FulfillmentProvider` and is expected to extend the
-same binding identity with `provider_metadata` / `credentials_ref` /
-`state` rather than create a second, competing record:
+## Domain boundary
 
-```python
-@dataclass
-class SettlementRecord:
-    allocation_id: str
-    agreement_id: str
-    market: str
-    pool_id: str
-    provider: str
-    resource: SettlementResource
-    provider_metadata: dict[str, Any]
-    credentials_ref: str | None
-    state: str
-```
+Generic scheduling consumes allocation identity, agreement identity, market, requested units, resource kind, pool identity, available units, provider identity, and opaque attributes. It must not import VM hosts, hypervisors, Kubernetes nodes, inference workers, storage-provider models, or their ORM sessions.
 
-This change is not deployed to production ahead of `pools-3`, so shipping
-without durable storage is acceptable as long as scheduler idempotency is
-fully exercised within this change's own test doubles.
+A VM resource may carry an opaque provider reference in its attributes. The VM fulfillment provider resolves that reference during physical settlement. Other domains can supply different resource kinds and opaque attributes while reusing the same scheduler and policy contracts.
 
-### 7. `disable_pool` guardrail
+## Validation errors
 
-Once the scheduler can create a binding, `ResourcePoolService.disable_pool`
-must reject disabling (via DELETE, PUT, or PATCH) a pool with at least one
-active settlement-resource binding. Previously a documented no-op — "the
-check will be added once the scheduler creates something to check" — this
-change is what creates that something.
+- `SettlementEntityNotFoundError` — a referenced allocation, agreement, pool, or resource does not exist.
+- `SettlementRequestMismatchError` — existing entities or terms do not correspond to the request, or the allocation is not active.
+- `CapacityReservationExpiredError` — the allocation existed but its hold expired.
+- `NoEligibleSettlementResourceError` — the request is valid but no candidate can currently satisfy it.
 
-### 8. The default pool can be disabled; it cannot stop being the fallback
+The error taxonomy is intentionally small. Entity type and identity should be retained in messages or structured fields rather than introducing a class for every noun.
 
-Corrected this session. POOLS-1 implemented `_ensure_default_pool_enabled`
-in `resource_pool_service.py`, which rejects `enabled=false` for `default`
-on create, replace, patch, and YAML import (`default_pool_disabled`). That
-invariant is wrong and this change relaxes it: `default` MUST remain
-present under its configured ID — it can never be hard-deleted, and hosts
-or create requests that omit a pool ID always resolve to it — but its
-`enabled` flag is otherwise ordinary. Disabling it only excludes it from
-new scheduler selection (decision 7's guardrail still applies: a disabled
-pool with an active binding cannot be disabled further, same as any pool).
+## Persistence and atomicity
 
-This matters operationally: there is currently no mechanism to change
-*which* pool ID is `default` other than reconfiguring and restarting the
-service. Allowing `default` to be disabled gives operators a real lever
-without that restart — e.g., to roll out updated Ansible playbooks pool by
-pool: stand up a new pool with the updated `AnsiblePoolConfig`, disable
-`default` so the scheduler stops placing new settlement onto it, reassign
-existing hosts to the new pool via ordinary host `PATCH`, and only update
-the `default` pool ID configuration once the old pool is empty. None of
-that requires blocking `default` from being disabled; it only requires
-`default` to keep existing and keep catching omitted pool IDs.
+The durable transaction is:
 
-### 9. `disable_pool` guardrail applies uniformly, including to `default`
+1. lock the reservation;
+2. validate state and request relationships;
+3. return an existing unchanged assignment if present;
+4. lock policy cursor state;
+5. re-evaluate eligible candidates;
+6. claim capacity on the selected concrete resource;
+7. persist the assignment;
+8. advance policy cursors;
+9. commit.
 
-Once decision 8 removes the default-specific block, the active-binding
-guardrail from decision 7 becomes the *only* thing that can reject
-disabling `default` — there is no longer a default-specific special case
-in the disable path.
+A Python lock protects only one scheduler object in one process and is not the final concurrency mechanism. Process-local assignment and cursor repositories are an explicitly documented intermediate implementation.
 
-## Error surface (carried forward, not newly decided)
+## Alternatives considered
 
-The planned failure taxonomy is broader than the initial VM path so future
-markets can reuse it. Names may be refined during implementation; each
-failure classifies as retryable, terminal, or operator-action-required:
+### Re-run selection on every request
 
-`pool_not_found`, `pool_disabled`, `pool_exhausted`, `resource_unavailable`,
-`target_resource_missing` / `settlement_resource_missing`,
-`provider_not_found`, `provider_unavailable`, `provider_config_invalid`,
-`settlement_already_bound`, `fulfillment_create_failed`,
-`fulfillment_status_failed`, `fulfillment_teardown_failed`,
-`credentials_publish_failed`, `capacity_projection_stale`.
+Rejected because retries could move an accepted reservation between resources and make downstream settlement non-idempotent.
 
-Only the selection-relevant subset (`pool_not_found`, `pool_disabled`,
-`pool_exhausted`, `resource_unavailable`, `settlement_already_bound`) is
-exercised by this change; the fulfillment-side errors apply once `pools-3`
-lands.
+### Let explicit resources bypass eligibility
 
-## Risks / Trade-offs
+Rejected because an exact-resource request is a placement constraint, not permission to use disabled, exhausted, orphaned, or incompatible capacity.
 
-- **No persistence yet.** A process crash between selection and (future)
-  provider execution loses the binding. Acceptable only because nothing
-  consumes bindings for real provisioning before `pools-3`, and this change
-  is explicitly not for production deployment ahead of it.
-- **Listing-authority question stays open.** The specific-resource path is
-  mechanically correct but has no operator-facing configuration surface;
-  it can only be exercised by directly supplying `resource_id` today.
-- **DRF-lite, not full DRF.** Bottleneck-normalized selection can still
-  make a suboptimal placement under heterogeneous request shapes relative
-  to full DRF. Deliberately deferred rather than under-designed.
-- **Watchdog composition location.** Reusing `LeaseWatchdog`'s pattern
-  instead of its code means some duplication until a shared thin-timer
-  utility is justified; not worth extracting for one additional caller.
+### Block pool disablement while assignments exist
 
-### 10. `ResourcePoolService` relocates to a new kit package, `kit/resource-pools`
+Rejected because assignment is not workload liveness. Disablement is better modeled as draining new work.
 
-Decided this session, prompted by evaluating where `PhysicalSettlementScheduler`
-should live (decision in "Carried-forward note," below — now superseded by
-this one). Audited `resource_pool_service.py` line by line for VM-specific
-coupling: the only VM/Ansible-specific code is a three-line default-import
-fallback for `AnsiblePoolConfigHandler` in `__init__`, trivially droppable.
-Everything else — CRUD, YAML validate/import/reconcile, provider-config
-normalization — already goes through the generic `PoolConfigHandler`
-protocol and the already-`compute_provisioning`-owned wire models.
+### Implement DRF in POOLS-2
 
-The remaining coupling is persistence-location, not domain logic:
-`ResourcePoolService` does direct SQLAlchemy against `ResourcePool`, an ORM
-class currently riding the VM service's own `Base`. This has an exact
-precedent already in the codebase: `CapacityLedgerService` is a concrete
-SQLAlchemy-touching class living in `kit/site` (`market_site`) alongside its
-own ORM models (`SiteResource`, `SiteAllocation`, `CapacityEvent`), and the
-VM service re-exports those classes into its own `db.models` so they "ride"
-its `Base.metadata` for migration purposes
-(`domains/vms/provisioning/service/src/db/models.py`, comment: "The tables
-ride market_site's own metadata — init_db creates both"). `compute_provisioning`
-was considered and rejected: its existing service classes
-(`LeaseLifecycleService`, `ExecutorLeaseService`) are protocol-mediated and
-never touch SQLAlchemy directly — a different shape than `ResourcePoolService`.
+Rejected as scope creep. The current problem is deterministic eligible placement, while classical DRF requires competing consumer identities and multidimensional share accounting. POOLS-6 preserves the design questions for a later session.
 
-A new kit package rather than folding into `kit/site` itself: `resource
--pool-management` is already its own top-level openspec capability, distinct
-from `site-capacity`. Conflating them into one kit package and one
-`Base.metadata` would blur a capability boundary the spec structure already
-respects. `kit/resource-pools` (`arkhai-kit-resource-pools`, import
-`market_resource_pools`) follows the same one-capability-per-kit-package
-shape as `kit/site`, `kit/policy`, `kit/identity`, `kit/config`.
+### Import an existing full scheduler
 
-`ResourcePool` (generic) moves; `AnsiblePoolConfig` (the Ansible provider's
-own side-table) and `AnsiblePoolConfigHandler` stay VM-domain-local — they
-were already correctly separated by the `PoolConfigHandler` protocol
-boundary POOLS-1 established, so this relocation only moves the
-provider-neutral half.
-
-This is additive scope beyond the original POOLS-2 design, prompted by
-avoiding a Protocol+adapter pair for `PhysicalSettlementScheduler`'s pool
--catalog dependency (see the now-superseded "Carried-forward note" below) —
-once `ResourcePoolService` is neutral, the scheduler can depend on it
-directly, same as it already will on the also-neutral `CapacityLedgerService`.
-
-## Migration Plan
-
-None. No schema or wire change in this change; nothing to roll back beyond
-reverting the added scheduler module, request/response shapes, watchdog
-wiring, and `disable_pool` guardrail.
-
-## Carried-forward note (superseded by decision 10)
-
-Drafting `pools-5-shared-provisioning-package` surfaced a placement
-question worth deciding during `pools-2`'s own plan step rather than
-building VM-service-local and reconsidering later: `compute_provisioning`
-(`provisioning/compute/src/compute_provisioning`) already owns the pool
-wire models and generic lease/contract shapes this scheduler is adjacent
-to. Building `PhysicalSettlementScheduler` directly there — rather than in
-`domains/vms/provisioning/service` and extracting afterward — may avoid
-`pools-5`'s residual-extraction step outright. Worth an explicit
-file-placement decision when we move to planning.
-
-This note is preserved for provenance; decision 10 resolves it differently
-than either option it originally posed — the scheduler stays VM-service
--local (still true), but its pool-catalog dependency is now the relocated,
-already-neutral `ResourcePoolService` rather than a same-service concern.
+Deferred. Established schedulers generally own worker models, queues, or cluster runtimes larger than this policy boundary. POOLS-6 will evaluate maintained libraries against the protocol before custom multidimensional policy is selected.

--- a/openspec/changes/pools-2-physical-settlement-scheduler/design.md
+++ b/openspec/changes/pools-2-physical-settlement-scheduler/design.md
@@ -1,0 +1,282 @@
+## Context
+
+POOLS-1 gave operators durable, provider-neutral pool identity and
+administrative host membership, but deliberately stopped short of
+settlement selection: existing capacity reservation and allocation
+selection behavior was explicitly left unchanged, and the site ledger
+still hardcodes `pool_id: None` on allocation payloads. Today, physical
+placement is not a decision at all — it is either a caller-supplied
+`vm_target` or a static `default_vm_host` configuration fallback
+(`job_service.py`). There is no formal boundary that owns "which physical
+resource satisfies this allocation," which is exactly the conflation this
+change resolves.
+
+This content — the scheduler/provider split, the request and resource
+shapes, the naming decision, and the pool-selection algorithm — previously
+lived in `docs/development/ARCHITECTURE.md` under "Physical Settlement
+Scheduler and FulfillmentProvider Architecture." That section was dropped
+during the migration to OpenSpec: the migration ledger recorded a
+destination change directory (`migrate-compute-provisioning`) that was
+never actually created, so the content had nowhere to land and was deleted
+along with the source. This design.md is that content's recovered and
+updated home.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Give the system one durable, idempotent answer to "which physical
+  resource satisfies this allocation," keyed by `allocation_id`.
+- Balance load across pools without a static priority column (rejected in
+  POOLS-1: can't express live balance, duplicate priorities too common).
+- Support both the fungible (pool/capacity-attribute) path and the
+  specific-resource (explicit `resource_id`) path in the same request
+  shape.
+- Resolve the previously-blocking capacity-reservation-expiry question by
+  reusing the existing lease expiry model rather than inventing a new one.
+- Close the `disable_pool` guardrail gap now that there is something for it
+  to check.
+
+**Non-Goals:** see `proposal.md` — persistence, `FulfillmentProvider`
+execution, specific-resource opt-in configuration, full DRF, and
+storefront-side reservation cleanup are all out of scope for this change.
+
+## Decisions
+
+### 1. Scheduler is a separate step from fulfillment, called after capacity reserve
+
+```python
+PhysicalSettlementScheduler.select_resource(...)
+    -> atomically binds the agreement/allocation to a settlement resource
+
+FulfillmentProvider.create(...)   # pools-3
+    -> performs provider-specific operations against the selected resource
+```
+
+The scheduler owns placement; it does not execute anything. A provider
+(added in `pools-3`) receives an already-selected `SettlementResource` and
+must not independently substitute a different one. This keeps the boundary
+usable by future non-VM markets (bare metal, Kubernetes, power, storage,
+bandwidth) without teaching the generic path any one provider's vocabulary.
+
+```python
+from dataclasses import dataclass
+from typing import Any
+
+@dataclass(frozen=True)
+class PhysicalSettlementRequest:
+    allocation_id: str
+    agreement_id: str
+    market: str
+    terms: dict[str, Any]
+    pool_id: str | None = None
+    resource_id: str | None = None
+
+@dataclass(frozen=True)
+class SettlementResource:
+    settlement_resource_id: str
+    pool_id: str
+    resource_kind: str
+    provider: str
+    attributes: dict[str, Any]
+
+class PhysicalSettlementScheduler:
+    async def select_resource(
+        self,
+        request: PhysicalSettlementRequest,
+    ) -> SettlementResource:
+        """Atomically bind request.allocation_id to a settlement resource.
+
+        Repeated calls for the same allocation_id return the existing
+        binding.
+        """
+        ...
+```
+
+An alternative considered was folding selection into
+`ExecutorLeaseService.register_lease` directly. Rejected: it blurs
+"registering a lease" with "making a scheduling decision" and denies
+scheduling its own idempotency/testing seam (scheduler idempotency,
+disabled/exhausted-pool exclusion, and no-match errors need to be testable
+in isolation from lease registration).
+
+### 2. Naming: `Settlement Resource`, not `SettlementTarget`
+
+`select_resource(...)` is the primary name; `select_target_resource(...)`
+is also acceptable where a call site benefits from emphasizing that the
+selected resource is the fulfillment target. The noun `SettlementTarget`
+is avoided throughout code and docs — the canonical domain noun is
+**Settlement Resource**, per the repository's official vocabulary
+(`openspec/config.yaml`).
+
+### 3. Pool selection: bottleneck-normalized least-loaded
+
+```text
+for each eligible pool:
+    utilization = max(
+        used_cpu / total_cpu,
+        used_ram / total_ram,
+        used_gpu / total_gpu,
+        used_disk / total_disk,
+    )   # the bottleneck dimension, not an average
+select the pool with the lowest utilization
+```
+
+Taking the `max` across dimensions rather than an average matters: a pool
+at 90% GPU utilization and 10% everywhere else is effectively full for
+GPU-bound requests even though its average looks healthy. This is a
+lightweight slice of Dominant Resource Fairness (Ghodsi et al.); full DRF
+also weights by each *request's* resource shape, not just each pool's
+current load — that fuller treatment is deliberately deferred. The
+approach requires no new schema or persistent state (no cursor, no
+counters) and degenerates to plain round-robin when fed only
+single-resource, equal-sized pools, so it is not a regression for the
+simple case.
+
+### 4. Specific-resource path is honored, not configured
+
+`PhysicalSettlementRequest.resource_id` is part of the shape from day one:
+if supplied, the scheduler binds exactly that resource and does not
+substitute another one. What remains unresolved — deliberately, not as an
+oversight — is *how* a seller opts a listing into exposing specific
+resources, and at what layer that authority lives (resource, pool,
+provisioning-service, or storefront level). Encoding an answer now would
+be premature; this stays open for a future change once real specific
+-resource listings exist to design against.
+
+### 5. Reservation expiry reuses the lease model; watchdog lives at the site authority, not the storefront
+
+Decided this session. Capacity reservations gain the same `start`/`end`
+lease-window shape executor leases already use
+(`kit/site/src/market_site/ledger.py` already has `hold_expires_at` TTL and
+lazy `_expire_stale_holds()` invoked on every `reserve`/`commit`/`release`).
+What's added is a periodic sweep, mirroring the existing `LeaseWatchdog`
+thin-timer pattern (`domains/vms/provisioning/service/src/services/lease_watchdog.py`):
+an asyncio interval timer whose only job is scheduling, delegating all
+logic to the ledger's own expiry check, so uncommitted holds are reclaimed
+even without another request touching them.
+
+This lives on the site-authority side, not the storefront: a storefront
+only ever holds a cached capacity projection and unions multiple sites'
+projections for an approximate view (`site-capacity`'s multi-site
+aggregation requirement). It has no independent capacity ledger to run a
+watchdog against; it only needs to request reservations and receive
+change notifications. `kit/site` cannot depend on domain composition roots
+(market-composition's from-below dependency rule), so the watchdog itself
+is composed at the same place `LeaseWatchdog` already is today — a
+provisioning service's composition root — pointed at the ledger's expiry
+check instead of VM lease lifecycle. Exact file placement is a `tasks.md`
+concern for the implementation plan, not a design decision.
+
+### 6. No persistence this change; binding lives only for this change's own test/process scope
+
+`pools-3` introduces `FulfillmentProvider` and is expected to extend the
+same binding identity with `provider_metadata` / `credentials_ref` /
+`state` rather than create a second, competing record:
+
+```python
+@dataclass
+class SettlementRecord:
+    allocation_id: str
+    agreement_id: str
+    market: str
+    pool_id: str
+    provider: str
+    resource: SettlementResource
+    provider_metadata: dict[str, Any]
+    credentials_ref: str | None
+    state: str
+```
+
+This change is not deployed to production ahead of `pools-3`, so shipping
+without durable storage is acceptable as long as scheduler idempotency is
+fully exercised within this change's own test doubles.
+
+### 7. `disable_pool` guardrail
+
+Once the scheduler can create a binding, `ResourcePoolService.disable_pool`
+must reject disabling (via DELETE, PUT, or PATCH) a pool with at least one
+active settlement-resource binding. Previously a documented no-op — "the
+check will be added once the scheduler creates something to check" — this
+change is what creates that something.
+
+### 8. The default pool can be disabled; it cannot stop being the fallback
+
+Corrected this session. POOLS-1 implemented `_ensure_default_pool_enabled`
+in `resource_pool_service.py`, which rejects `enabled=false` for `default`
+on create, replace, patch, and YAML import (`default_pool_disabled`). That
+invariant is wrong and this change relaxes it: `default` MUST remain
+present under its configured ID — it can never be hard-deleted, and hosts
+or create requests that omit a pool ID always resolve to it — but its
+`enabled` flag is otherwise ordinary. Disabling it only excludes it from
+new scheduler selection (decision 7's guardrail still applies: a disabled
+pool with an active binding cannot be disabled further, same as any pool).
+
+This matters operationally: there is currently no mechanism to change
+*which* pool ID is `default` other than reconfiguring and restarting the
+service. Allowing `default` to be disabled gives operators a real lever
+without that restart — e.g., to roll out updated Ansible playbooks pool by
+pool: stand up a new pool with the updated `AnsiblePoolConfig`, disable
+`default` so the scheduler stops placing new settlement onto it, reassign
+existing hosts to the new pool via ordinary host `PATCH`, and only update
+the `default` pool ID configuration once the old pool is empty. None of
+that requires blocking `default` from being disabled; it only requires
+`default` to keep existing and keep catching omitted pool IDs.
+
+### 9. `disable_pool` guardrail applies uniformly, including to `default`
+
+Once decision 8 removes the default-specific block, the active-binding
+guardrail from decision 7 becomes the *only* thing that can reject
+disabling `default` — there is no longer a default-specific special case
+in the disable path.
+
+## Error surface (carried forward, not newly decided)
+
+The planned failure taxonomy is broader than the initial VM path so future
+markets can reuse it. Names may be refined during implementation; each
+failure classifies as retryable, terminal, or operator-action-required:
+
+`pool_not_found`, `pool_disabled`, `pool_exhausted`, `resource_unavailable`,
+`target_resource_missing` / `settlement_resource_missing`,
+`provider_not_found`, `provider_unavailable`, `provider_config_invalid`,
+`settlement_already_bound`, `fulfillment_create_failed`,
+`fulfillment_status_failed`, `fulfillment_teardown_failed`,
+`credentials_publish_failed`, `capacity_projection_stale`.
+
+Only the selection-relevant subset (`pool_not_found`, `pool_disabled`,
+`pool_exhausted`, `resource_unavailable`, `settlement_already_bound`) is
+exercised by this change; the fulfillment-side errors apply once `pools-3`
+lands.
+
+## Risks / Trade-offs
+
+- **No persistence yet.** A process crash between selection and (future)
+  provider execution loses the binding. Acceptable only because nothing
+  consumes bindings for real provisioning before `pools-3`, and this change
+  is explicitly not for production deployment ahead of it.
+- **Listing-authority question stays open.** The specific-resource path is
+  mechanically correct but has no operator-facing configuration surface;
+  it can only be exercised by directly supplying `resource_id` today.
+- **DRF-lite, not full DRF.** Bottleneck-normalized selection can still
+  make a suboptimal placement under heterogeneous request shapes relative
+  to full DRF. Deliberately deferred rather than under-designed.
+- **Watchdog composition location.** Reusing `LeaseWatchdog`'s pattern
+  instead of its code means some duplication until a shared thin-timer
+  utility is justified; not worth extracting for one additional caller.
+
+## Migration Plan
+
+None. No schema or wire change in this change; nothing to roll back beyond
+reverting the added scheduler module, request/response shapes, watchdog
+wiring, and `disable_pool` guardrail.
+
+## Carried-forward note for the plan step
+
+Drafting `pools-5-shared-provisioning-package` surfaced a placement
+question worth deciding during `pools-2`'s own plan step rather than
+building VM-service-local and reconsidering later: `compute_provisioning`
+(`provisioning/compute/src/compute_provisioning`) already owns the pool
+wire models and generic lease/contract shapes this scheduler is adjacent
+to. Building `PhysicalSettlementScheduler` directly there — rather than in
+`domains/vms/provisioning/service` and extracting afterward — may avoid
+`pools-5`'s residual-extraction step outright. Worth an explicit
+file-placement decision when we move to planning.

--- a/openspec/changes/pools-2-physical-settlement-scheduler/design.md
+++ b/openspec/changes/pools-2-physical-settlement-scheduler/design.md
@@ -263,13 +263,58 @@ lands.
   instead of its code means some duplication until a shared thin-timer
   utility is justified; not worth extracting for one additional caller.
 
+### 10. `ResourcePoolService` relocates to a new kit package, `kit/resource-pools`
+
+Decided this session, prompted by evaluating where `PhysicalSettlementScheduler`
+should live (decision in "Carried-forward note," below — now superseded by
+this one). Audited `resource_pool_service.py` line by line for VM-specific
+coupling: the only VM/Ansible-specific code is a three-line default-import
+fallback for `AnsiblePoolConfigHandler` in `__init__`, trivially droppable.
+Everything else — CRUD, YAML validate/import/reconcile, provider-config
+normalization — already goes through the generic `PoolConfigHandler`
+protocol and the already-`compute_provisioning`-owned wire models.
+
+The remaining coupling is persistence-location, not domain logic:
+`ResourcePoolService` does direct SQLAlchemy against `ResourcePool`, an ORM
+class currently riding the VM service's own `Base`. This has an exact
+precedent already in the codebase: `CapacityLedgerService` is a concrete
+SQLAlchemy-touching class living in `kit/site` (`market_site`) alongside its
+own ORM models (`SiteResource`, `SiteAllocation`, `CapacityEvent`), and the
+VM service re-exports those classes into its own `db.models` so they "ride"
+its `Base.metadata` for migration purposes
+(`domains/vms/provisioning/service/src/db/models.py`, comment: "The tables
+ride market_site's own metadata — init_db creates both"). `compute_provisioning`
+was considered and rejected: its existing service classes
+(`LeaseLifecycleService`, `ExecutorLeaseService`) are protocol-mediated and
+never touch SQLAlchemy directly — a different shape than `ResourcePoolService`.
+
+A new kit package rather than folding into `kit/site` itself: `resource
+-pool-management` is already its own top-level openspec capability, distinct
+from `site-capacity`. Conflating them into one kit package and one
+`Base.metadata` would blur a capability boundary the spec structure already
+respects. `kit/resource-pools` (`arkhai-kit-resource-pools`, import
+`market_resource_pools`) follows the same one-capability-per-kit-package
+shape as `kit/site`, `kit/policy`, `kit/identity`, `kit/config`.
+
+`ResourcePool` (generic) moves; `AnsiblePoolConfig` (the Ansible provider's
+own side-table) and `AnsiblePoolConfigHandler` stay VM-domain-local — they
+were already correctly separated by the `PoolConfigHandler` protocol
+boundary POOLS-1 established, so this relocation only moves the
+provider-neutral half.
+
+This is additive scope beyond the original POOLS-2 design, prompted by
+avoiding a Protocol+adapter pair for `PhysicalSettlementScheduler`'s pool
+-catalog dependency (see the now-superseded "Carried-forward note" below) —
+once `ResourcePoolService` is neutral, the scheduler can depend on it
+directly, same as it already will on the also-neutral `CapacityLedgerService`.
+
 ## Migration Plan
 
 None. No schema or wire change in this change; nothing to roll back beyond
 reverting the added scheduler module, request/response shapes, watchdog
 wiring, and `disable_pool` guardrail.
 
-## Carried-forward note for the plan step
+## Carried-forward note (superseded by decision 10)
 
 Drafting `pools-5-shared-provisioning-package` surfaced a placement
 question worth deciding during `pools-2`'s own plan step rather than
@@ -280,3 +325,8 @@ to. Building `PhysicalSettlementScheduler` directly there — rather than in
 `domains/vms/provisioning/service` and extracting afterward — may avoid
 `pools-5`'s residual-extraction step outright. Worth an explicit
 file-placement decision when we move to planning.
+
+This note is preserved for provenance; decision 10 resolves it differently
+than either option it originally posed — the scheduler stays VM-service
+-local (still true), but its pool-catalog dependency is now the relocated,
+already-neutral `ResourcePoolService` rather than a same-service concern.

--- a/openspec/changes/pools-2-physical-settlement-scheduler/proposal.md
+++ b/openspec/changes/pools-2-physical-settlement-scheduler/proposal.md
@@ -36,6 +36,17 @@ before any provider executes against it.
   pattern, so uncommitted holds expire without depending on storefront-side
   polling. The storefront continues to hold only a cached capacity
   projection; the site authority remains the sole source of truth per site.
+- **Relocate `ResourcePoolService`.** Move `ResourcePoolService`, `ResourcePool`
+  (ORM model), `DEFAULT_POOL_ID`, and the `PoolNotFoundError`/
+  `PoolAlreadyExistsError`/`PoolValidationError` exceptions out of
+  `domains/vms/provisioning/service` into a new kit package,
+  `kit/resource-pools` (`arkhai-kit-resource-pools`, import
+  `market_resource_pools`), following the same shape `kit/site` already
+  uses for `CapacityLedgerService`. `AnsiblePoolConfig` and
+  `AnsiblePoolConfigHandler` stay VM-domain-local — only the
+  provider-neutral half moves. This makes `ResourcePoolService` a direct,
+  same-shape dependency for `PhysicalSettlementScheduler` rather than
+  requiring a new Protocol+adapter pair.
 - Add a guardrail to `ResourcePoolService.disable_pool`: a pool with an
   active settlement-resource binding cannot be disabled. (Previously a
   documented no-op — "the check will be added once the scheduler creates
@@ -101,16 +112,24 @@ fulfillment; it has simply not implemented the scheduler half yet.
 
 ## Impact
 
-- **Packages:** `provisioning/compute` (scheduler, selection algorithm,
-  request/response shapes), `kit/site` (lease-shaped reservation windows),
-  and the VM provisioning composition root (reservation-expiry watchdog,
-  `disable_pool` guardrail wiring).
-- **Database:** none. No migration in this change.
+- **Packages:** new `kit/resource-pools` (`ResourcePoolService` + `ResourcePool`
+  relocated from `domains/vms/provisioning/service`); `provisioning/compute`
+  (scheduler request/response shapes); `domains/vms/provisioning/service`
+  (scheduler itself, reservation-expiry watchdog composition, `disable_pool`
+  guardrail, updated imports/re-exports for the relocated pool model).
+- **Database:** no new tables. `resource_pools`/`ansible_pool_configs`
+  schema is unchanged; only which package defines the `ResourcePool` model
+  and which migration module creates its table move, mirroring how
+  `market_site`'s tables are already created from the VM service's own
+  `db/database.py` today.
 - **API:** none new. The scheduler is not yet wired to a caller-facing route;
   wiring it into a real settlement path is `pools-3` work.
-- **Compatibility:** no wire or persistence break. Existing pool and
-  reservation behavior is unchanged for callers that do not use the
-  scheduler, with one deliberate exception: `PoolReplace`/`PoolUpdate`/
-  import calls that set `default`'s `enabled=false` currently fail with
-  `default_pool_disabled` and will start succeeding. Any caller or test
-  relying on that rejection needs updating.
+- **Compatibility:** no wire or persistence break for pool CRUD/YAML
+  behavior. Internal-only: `from db.models import ResourcePool` call sites
+  and `from services.resource_pool_service import ...` imports move to
+  `from market_resource_pools import ...`; `arkhai-kit-resource-pools`
+  becomes a new dependency of `domains/vms/provisioning/service`. One
+  deliberate exception unrelated to the relocation: `PoolReplace`/
+  `PoolUpdate`/import calls that set `default`'s `enabled=false` currently
+  fail with `default_pool_disabled` and will start succeeding. Any caller
+  or test relying on that rejection needs updating.

--- a/openspec/changes/pools-2-physical-settlement-scheduler/proposal.md
+++ b/openspec/changes/pools-2-physical-settlement-scheduler/proposal.md
@@ -1,135 +1,64 @@
+# POOLS-2: Capacity Settlement Scheduler
+
+## Context
+
+POOLS-1 establishes Resource Pools as provider-configuration and physical-capacity boundaries. Capacity Reservations already let a seller accept a bounded amount of capacity, but the system still needs an explicit step that chooses the concrete pooled resource on which physical settlement will run.
+
+Without that boundary, reservation, placement, and provisioning become conflated. Retries can repeat placement decisions, provider-specific host models can leak into shared contracts, and pool administration cannot reliably express "stop assigning new work here" independently of existing workloads.
+
+The lifecycle used by this change is:
+
+**Capacity Reservation → Capacity Settlement Assignment → Physical Settlement → Provisioned Resource / Active Workload**
+
+A Capacity Settlement Assignment is a scheduling decision, not evidence that provisioning succeeded or that the resource remains active.
+
 ## Why
 
-The current path conflates capacity reservation, physical host placement, and
-provider execution into one step. That creates race conditions and leaves
-`resource_id` ambiguous — sometimes a physical scheduling decision, sometimes
-a market-level capacity commitment. POOLS-1 gave operators durable pool
-identity and administrative host membership but explicitly deferred
-settlement selection: `site-capacity`'s executor-neutral site authority
-requirement states administrative pool membership "MUST NOT alter settlement
-selection until integrated through the site-authority boundary," and
-`physical-provisioning` records `PhysicalSettlementScheduler` as not yet an
-implemented baseline contract.
+POOLS-2 introduces an explicit, idempotent scheduling boundary between accepted capacity and provider-specific physical settlement. The scheduler validates the reservation and its agreement relationship, filters concrete resources by generic eligibility, and records one assignment for the unchanged reservation.
 
-This change adds that missing boundary: a scheduler that binds an already
--reserved capacity allocation to one durable, idempotent settlement resource,
-before any provider executes against it.
+The first policy is intentionally modest. Deterministic round-robin provides basic fairness and proves that policy is replaceable without introducing multidimensional fairness, quotas, topology, or provider-specific placement into this change.
 
-## What Changes
+## Goals
 
-- Add `PhysicalSettlementScheduler.select_resource(request)`, keyed durably
-  and idempotently by `allocation_id`: repeated calls for the same
-  allocation return the existing binding rather than selecting another
-  resource.
-- Add the `PhysicalSettlementRequest` and `SettlementResource` shapes.
-  A request carries either fungible pool/capacity attributes or an explicit
-  `resource_id` for the specific-resource opt-in path; the scheduler honors
-  whichever is supplied.
-- Implement bottleneck-normalized least-loaded pool selection for the
-  fungible path: the eligible pool with the lowest maximum per-dimension
-  utilization (CPU/RAM/GPU/disk) is selected. This is a lightweight,
-  schema-free slice of Dominant Resource Fairness; full DRF (weighting by
-  each request's own resource shape) is deliberately deferred.
-- Extend capacity reservations to carry lease-shaped `start`/`end` windows
-  (mirroring executor leases) and add a periodic reservation-expiry
-  watchdog, generalized from the existing `LeaseWatchdog` thin-timer
-  pattern, so uncommitted holds expire without depending on storefront-side
-  polling. The storefront continues to hold only a cached capacity
-  projection; the site authority remains the sole source of truth per site.
-- **Relocate `ResourcePoolService`.** Move `ResourcePoolService`, `ResourcePool`
-  (ORM model), `DEFAULT_POOL_ID`, and the `PoolNotFoundError`/
-  `PoolAlreadyExistsError`/`PoolValidationError` exceptions out of
-  `domains/vms/provisioning/service` into a new kit package,
-  `kit/resource-pools` (`arkhai-kit-resource-pools`, import
-  `market_resource_pools`), following the same shape `kit/site` already
-  uses for `CapacityLedgerService`. `AnsiblePoolConfig` and
-  `AnsiblePoolConfigHandler` stay VM-domain-local — only the
-  provider-neutral half moves. This makes `ResourcePoolService` a direct,
-  same-shape dependency for `PhysicalSettlementScheduler` rather than
-  requiring a new Protocol+adapter pair.
-- Add a guardrail to `ResourcePoolService.disable_pool`: a pool with an
-  active settlement-resource binding cannot be disabled. (Previously a
-  documented no-op — "the check will be added once the scheduler creates
-  something to check.")
-- **Correct POOLS-1 behavior:** remove `_ensure_default_pool_enabled`'s
-  blanket rejection of disabling the `default` pool (create/replace/patch/
-  import all currently reject `enabled=false` for `default`). `default`
-  MUST still always exist under its configured ID and remain the fallback
-  for hosts/create-requests that omit a pool ID, but disabling it is
-  otherwise ordinary — it only excludes `default` from new scheduler
-  selection, and is subject to the same active-binding guardrail as any
-  other pool.
+- Establish executor-neutral request, candidate, assignment, result, error, and policy contracts.
+- Create at most one Capacity Settlement Assignment for an unchanged reservation.
+- Validate allocation identity, agreement relationship, state, expiry, market, terms, pool state, membership, resource kind, attributes, and capacity.
+- Select only resources that belong to exactly one enabled Resource Pool.
+- Treat explicit resource identifiers as policy bypasses, never eligibility bypasses.
+- Provide deterministic round-robin selection across eligible pools and then eligible resources.
+- Treat pool disablement as draining new assignments while preserving existing work.
+- Keep generic scheduling independent of VM hosts and other market-specific executor persistence.
+- Leave a stable policy interface for later scheduling algorithms.
 
-## Non-Goals
+## Non-goals
 
-- **Settlement-resource persistence.** No new table or durable row lands in
-  this change; idempotency is exercised at the scheduler's own boundary
-  within this change's test scope. Durable `SettlementRecord` storage
-  (`provider_metadata`, `credentials_ref`, `state`) is `pools-3` work, which
-  is expected to extend the same binding identity rather than introduce a
-  second one.
-- **`FulfillmentProvider` execution.** No provider ABC, `ProviderRegistry`,
-  or Ansible implementation change lands here. Nothing calls
-  `select_resource` from a real provisioning path yet.
-- **Specific-resource listing/opt-in configuration.** Whether opt-in lives at
-  resource, pool, provisioning-service, or storefront level is unresolved by
-  design; this change only ensures an explicit `resource_id`, if supplied, is
-  honored without substitution.
-- **Full Dominant Resource Fairness.** Weighting selection by each request's
-  own resource shape (not just each pool's current load) is deferred past
-  this change.
-- **Storefront-side reservation cleanup.** Removing the `vm_host` requirement
-  from `CapacityLedgerService`'s ordinary reservation path and renaming
-  `SiteLedger`/`SiteResourcesService` toward capacity language is `pools-4`
-  work; this change only supplies the lease-window/watchdog expiry model
-  that `pools-4` will apply to the storefront-facing path.
+- Caller-facing endpoint wiring or automatic invocation from the settlement flow.
+- Full Dominant Resource Fairness or other multidimensional fairness policies.
+- Buyer-selected pool constraints; current use cases request generic capacity or a specific concrete resource.
+- Provider health probing, credentials validation, or execution-time reachability checks.
+- Automatic migration of existing assignments when a pool is disabled.
+- Reassignment after provisioning failure.
+- Priority, quota, preemption, affinity, anti-affinity, cost, or topology-aware placement.
 
-## Capabilities
+## What changes
 
-### New Capabilities
+- Add executor-neutral scheduling contracts in `arkhai-compute-provisioning`.
+- Add a replaceable `SettlementSchedulingPolicy` protocol in the kit.
+- Add a deterministic round-robin policy implementation in the VM provisioning service.
+- Make `PhysicalSettlementScheduler` responsible for validation, idempotency, candidate construction, explicit-resource handling, and assignment recording.
+- Remove VM `Host` joins and executor-specific interpretation from generic scheduling.
+- Define Resource Pool disablement as draining new assignments.
+- Add normative deltas for site capacity, resource pools, and physical provisioning.
+- Add POOLS-6 as deferred work for multidimensional fair policies.
 
-None. `physical-provisioning`'s purpose already scopes scheduling and
-fulfillment; it has simply not implemented the scheduler half yet.
+## Intermediate-state limitations
 
-### Modified Capabilities
+The repository still reserves against a concrete site-ledger line item before POOLS-2 scheduling. The scheduler credits the reservation's own held units during eligibility checks. Capacity Settlement Assignments and round-robin cursors are also process-local, so retries are idempotent only within the running service instance.
 
-- `physical-provisioning`: adds the `PhysicalSettlementScheduler` contract,
-  idempotent allocation-keyed resource binding, and bottleneck-normalized
-  pool selection.
-- `site-capacity`: capacity reservations gain lease-shaped windows and a
-  watchdog-driven expiry path alongside the existing lazy TTL check.
-- `resource-pool-management`: `disable_pool` rejects disabling a pool with an
-  active settlement-resource binding.
+The durable target atomically locks the reservation, checks for an existing assignment, locks scheduling state, evaluates eligibility, claims concrete capacity, persists the assignment, advances cursors, and commits. Moving the concrete capacity claim and assignment state into that transaction remains follow-on work.
 
-## Dependencies and Related Changes
+## Operational impact
 
-- Requires `pools-1-resource-pool-foundation` (archived): pool identity,
-  provider configuration, and host membership.
-- Precedes not-yet-drafted `pools-3` (`FulfillmentProvider` ABC + Ansible
-  implementation + `SettlementRecord` persistence) and `pools-4` (storefront
-  capacity boundary cleanup, which applies this change's reservation-expiry
-  model to the storefront-facing path).
+Disabling a pool immediately prevents new assignments to its resources. Existing reservations, assignments, physical settlements, and workloads continue. Operators can therefore drain a pool without first terminating active work.
 
-## Impact
-
-- **Packages:** new `kit/resource-pools` (`ResourcePoolService` + `ResourcePool`
-  relocated from `domains/vms/provisioning/service`); `provisioning/compute`
-  (scheduler request/response shapes); `domains/vms/provisioning/service`
-  (scheduler itself, reservation-expiry watchdog composition, `disable_pool`
-  guardrail, updated imports/re-exports for the relocated pool model).
-- **Database:** no new tables. `resource_pools`/`ansible_pool_configs`
-  schema is unchanged; only which package defines the `ResourcePool` model
-  and which migration module creates its table move, mirroring how
-  `market_site`'s tables are already created from the VM service's own
-  `db/database.py` today.
-- **API:** none new. The scheduler is not yet wired to a caller-facing route;
-  wiring it into a real settlement path is `pools-3` work.
-- **Compatibility:** no wire or persistence break for pool CRUD/YAML
-  behavior. Internal-only: `from db.models import ResourcePool` call sites
-  and `from services.resource_pool_service import ...` imports move to
-  `from market_resource_pools import ...`; `arkhai-kit-resource-pools`
-  becomes a new dependency of `domains/vms/provisioning/service`. One
-  deliberate exception unrelated to the relocation: `PoolReplace`/
-  `PoolUpdate`/import calls that set `default`'s `enabled=false` currently
-  fail with `default_pool_disabled` and will start succeeding. Any caller
-  or test relying on that rejection needs updating.
+Scheduling failures distinguish missing entities, mismatched requests, expired reservations, and absence of eligible resources so callers can choose appropriate recovery behavior.

--- a/openspec/changes/pools-2-physical-settlement-scheduler/proposal.md
+++ b/openspec/changes/pools-2-physical-settlement-scheduler/proposal.md
@@ -1,0 +1,116 @@
+## Why
+
+The current path conflates capacity reservation, physical host placement, and
+provider execution into one step. That creates race conditions and leaves
+`resource_id` ambiguous — sometimes a physical scheduling decision, sometimes
+a market-level capacity commitment. POOLS-1 gave operators durable pool
+identity and administrative host membership but explicitly deferred
+settlement selection: `site-capacity`'s executor-neutral site authority
+requirement states administrative pool membership "MUST NOT alter settlement
+selection until integrated through the site-authority boundary," and
+`physical-provisioning` records `PhysicalSettlementScheduler` as not yet an
+implemented baseline contract.
+
+This change adds that missing boundary: a scheduler that binds an already
+-reserved capacity allocation to one durable, idempotent settlement resource,
+before any provider executes against it.
+
+## What Changes
+
+- Add `PhysicalSettlementScheduler.select_resource(request)`, keyed durably
+  and idempotently by `allocation_id`: repeated calls for the same
+  allocation return the existing binding rather than selecting another
+  resource.
+- Add the `PhysicalSettlementRequest` and `SettlementResource` shapes.
+  A request carries either fungible pool/capacity attributes or an explicit
+  `resource_id` for the specific-resource opt-in path; the scheduler honors
+  whichever is supplied.
+- Implement bottleneck-normalized least-loaded pool selection for the
+  fungible path: the eligible pool with the lowest maximum per-dimension
+  utilization (CPU/RAM/GPU/disk) is selected. This is a lightweight,
+  schema-free slice of Dominant Resource Fairness; full DRF (weighting by
+  each request's own resource shape) is deliberately deferred.
+- Extend capacity reservations to carry lease-shaped `start`/`end` windows
+  (mirroring executor leases) and add a periodic reservation-expiry
+  watchdog, generalized from the existing `LeaseWatchdog` thin-timer
+  pattern, so uncommitted holds expire without depending on storefront-side
+  polling. The storefront continues to hold only a cached capacity
+  projection; the site authority remains the sole source of truth per site.
+- Add a guardrail to `ResourcePoolService.disable_pool`: a pool with an
+  active settlement-resource binding cannot be disabled. (Previously a
+  documented no-op — "the check will be added once the scheduler creates
+  something to check.")
+- **Correct POOLS-1 behavior:** remove `_ensure_default_pool_enabled`'s
+  blanket rejection of disabling the `default` pool (create/replace/patch/
+  import all currently reject `enabled=false` for `default`). `default`
+  MUST still always exist under its configured ID and remain the fallback
+  for hosts/create-requests that omit a pool ID, but disabling it is
+  otherwise ordinary — it only excludes `default` from new scheduler
+  selection, and is subject to the same active-binding guardrail as any
+  other pool.
+
+## Non-Goals
+
+- **Settlement-resource persistence.** No new table or durable row lands in
+  this change; idempotency is exercised at the scheduler's own boundary
+  within this change's test scope. Durable `SettlementRecord` storage
+  (`provider_metadata`, `credentials_ref`, `state`) is `pools-3` work, which
+  is expected to extend the same binding identity rather than introduce a
+  second one.
+- **`FulfillmentProvider` execution.** No provider ABC, `ProviderRegistry`,
+  or Ansible implementation change lands here. Nothing calls
+  `select_resource` from a real provisioning path yet.
+- **Specific-resource listing/opt-in configuration.** Whether opt-in lives at
+  resource, pool, provisioning-service, or storefront level is unresolved by
+  design; this change only ensures an explicit `resource_id`, if supplied, is
+  honored without substitution.
+- **Full Dominant Resource Fairness.** Weighting selection by each request's
+  own resource shape (not just each pool's current load) is deferred past
+  this change.
+- **Storefront-side reservation cleanup.** Removing the `vm_host` requirement
+  from `CapacityLedgerService`'s ordinary reservation path and renaming
+  `SiteLedger`/`SiteResourcesService` toward capacity language is `pools-4`
+  work; this change only supplies the lease-window/watchdog expiry model
+  that `pools-4` will apply to the storefront-facing path.
+
+## Capabilities
+
+### New Capabilities
+
+None. `physical-provisioning`'s purpose already scopes scheduling and
+fulfillment; it has simply not implemented the scheduler half yet.
+
+### Modified Capabilities
+
+- `physical-provisioning`: adds the `PhysicalSettlementScheduler` contract,
+  idempotent allocation-keyed resource binding, and bottleneck-normalized
+  pool selection.
+- `site-capacity`: capacity reservations gain lease-shaped windows and a
+  watchdog-driven expiry path alongside the existing lazy TTL check.
+- `resource-pool-management`: `disable_pool` rejects disabling a pool with an
+  active settlement-resource binding.
+
+## Dependencies and Related Changes
+
+- Requires `pools-1-resource-pool-foundation` (archived): pool identity,
+  provider configuration, and host membership.
+- Precedes not-yet-drafted `pools-3` (`FulfillmentProvider` ABC + Ansible
+  implementation + `SettlementRecord` persistence) and `pools-4` (storefront
+  capacity boundary cleanup, which applies this change's reservation-expiry
+  model to the storefront-facing path).
+
+## Impact
+
+- **Packages:** `provisioning/compute` (scheduler, selection algorithm,
+  request/response shapes), `kit/site` (lease-shaped reservation windows),
+  and the VM provisioning composition root (reservation-expiry watchdog,
+  `disable_pool` guardrail wiring).
+- **Database:** none. No migration in this change.
+- **API:** none new. The scheduler is not yet wired to a caller-facing route;
+  wiring it into a real settlement path is `pools-3` work.
+- **Compatibility:** no wire or persistence break. Existing pool and
+  reservation behavior is unchanged for callers that do not use the
+  scheduler, with one deliberate exception: `PoolReplace`/`PoolUpdate`/
+  import calls that set `default`'s `enabled=false` currently fail with
+  `default_pool_disabled` and will start succeeding. Any caller or test
+  relying on that rejection needs updating.

--- a/openspec/changes/pools-2-physical-settlement-scheduler/specs/physical-provisioning/spec.md
+++ b/openspec/changes/pools-2-physical-settlement-scheduler/specs/physical-provisioning/spec.md
@@ -1,0 +1,50 @@
+## ADDED Requirements
+
+### Requirement: Idempotent physical settlement resource selection
+
+The provisioning service MUST expose a `PhysicalSettlementScheduler` that
+binds a `PhysicalSettlementRequest` to exactly one `SettlementResource`,
+keyed durably by `allocation_id`, and MUST return the existing binding
+rather than selecting a different resource on repeated calls for the same
+`allocation_id`.
+
+#### Scenario: Selection is retried for the same allocation
+
+- **WHEN** `select_resource` is called twice with the same `allocation_id`
+- **THEN** the second call returns the same `settlement_resource_id` as the first without creating a second binding
+
+#### Scenario: Concurrent selection races for the same allocation
+
+- **WHEN** two concurrent `select_resource` calls race for the same `allocation_id`
+- **THEN** exactly one settlement resource binding is created and both callers observe it
+
+### Requirement: Bottleneck-normalized pool selection
+
+When a `PhysicalSettlementRequest` carries fungible pool/capacity
+attributes rather than an explicit `resource_id`, the scheduler MUST select
+among enabled, eligible pools by the lowest bottleneck resource-dimension
+utilization — the maximum of per-dimension utilization ratios across
+CPU/RAM/GPU/disk — rather than a static priority ordering.
+
+#### Scenario: One eligible pool is GPU-saturated
+
+- **WHEN** an eligible pool is at high GPU utilization but low utilization on every other dimension
+- **THEN** the scheduler prefers another eligible pool whose bottleneck dimension is lower, even if its average utilization is higher
+
+#### Scenario: No eligible pool exists
+
+- **WHEN** every pool matching the request is disabled or exhausted
+- **THEN** selection fails with an actionable pool-unavailable error instead of binding a disabled or exhausted pool
+
+### Requirement: Specific-resource request path
+
+A `PhysicalSettlementRequest` MAY carry an explicit `resource_id` instead
+of pool/capacity attributes. When it does, the scheduler MUST bind exactly
+that resource and MUST NOT substitute a different one. Operator-facing
+configuration for opting a listing into this path is not defined by this
+requirement.
+
+#### Scenario: Explicit resource_id is honored
+
+- **WHEN** a request supplies `resource_id` instead of pool/capacity attributes
+- **THEN** the scheduler binds that `resource_id` or fails outright, without silently substituting a different resource

--- a/openspec/changes/pools-2-physical-settlement-scheduler/specs/physical-provisioning/spec.md
+++ b/openspec/changes/pools-2-physical-settlement-scheduler/specs/physical-provisioning/spec.md
@@ -1,50 +1,67 @@
+# Physical provisioning delta
+
 ## ADDED Requirements
 
-### Requirement: Idempotent physical settlement resource selection
+### Requirement: Capacity Settlement Assignment lifecycle
 
-The provisioning service MUST expose a `PhysicalSettlementScheduler` that
-binds a `PhysicalSettlementRequest` to exactly one `SettlementResource`,
-keyed durably by `allocation_id`, and MUST return the existing binding
-rather than selecting a different resource on repeated calls for the same
-`allocation_id`.
+The provisioning domain SHALL distinguish Capacity Reservation, Capacity Settlement Assignment, Physical Settlement, and Provisioned Resource / Active Workload. A Capacity Settlement Assignment SHALL identify one concrete Settlement Resource but SHALL NOT by itself indicate that provisioning succeeded or that a workload is active.
 
-#### Scenario: Selection is retried for the same allocation
+#### Scenario: Assignment precedes physical settlement
 
-- **WHEN** `select_resource` is called twice with the same `allocation_id`
-- **THEN** the second call returns the same `settlement_resource_id` as the first without creating a second binding
+- **GIVEN** an active Capacity Reservation
+- **WHEN** scheduling succeeds
+- **THEN** the service records a Capacity Settlement Assignment
+- **AND** provider-specific physical settlement remains a separate downstream operation.
 
-#### Scenario: Concurrent selection races for the same allocation
+### Requirement: Idempotent assignment
 
-- **WHEN** two concurrent `select_resource` calls race for the same `allocation_id`
-- **THEN** exactly one settlement resource binding is created and both callers observe it
+The provisioning domain SHALL create at most one Capacity Settlement Assignment for an unchanged Capacity Reservation. Retrying the same allocation SHALL return the existing assignment without rerunning scheduling policy or advancing policy cursors.
 
-### Requirement: Bottleneck-normalized pool selection
+#### Scenario: Retry returns the same resource
 
-When a `PhysicalSettlementRequest` carries fungible pool/capacity
-attributes rather than an explicit `resource_id`, the scheduler MUST select
-among enabled, eligible pools by the lowest bottleneck resource-dimension
-utilization — the maximum of per-dimension utilization ratios across
-CPU/RAM/GPU/disk — rather than a static priority ordering.
+- **GIVEN** a reservation already assigned to a Settlement Resource
+- **WHEN** the same unchanged reservation is scheduled again
+- **THEN** the existing assignment is returned
+- **AND** no new policy choice is made.
 
-#### Scenario: One eligible pool is GPU-saturated
+#### Scenario: Conflicting explicit retry
 
-- **WHEN** an eligible pool is at high GPU utilization but low utilization on every other dimension
-- **THEN** the scheduler prefers another eligible pool whose bottleneck dimension is lower, even if its average utilization is higher
+- **GIVEN** a reservation already assigned to one Settlement Resource
+- **WHEN** a retry requests a different explicit resource
+- **THEN** scheduling fails with a request-mismatch error.
 
-#### Scenario: No eligible pool exists
+### Requirement: Explicit selection preserves eligibility
 
-- **WHEN** every pool matching the request is disabled or exhausted
-- **THEN** selection fails with an actionable pool-unavailable error instead of binding a disabled or exhausted pool
+An explicit resource identifier SHALL bypass policy choice but SHALL NOT bypass allocation, agreement, expiry, pool, resource, shape, attribute, or capacity eligibility checks. Explicit selection SHALL NOT advance automatic round-robin cursors.
 
-### Requirement: Specific-resource request path
+#### Scenario: Explicit resource in disabled pool
 
-A `PhysicalSettlementRequest` MAY carry an explicit `resource_id` instead
-of pool/capacity attributes. When it does, the scheduler MUST bind exactly
-that resource and MUST NOT substitute a different one. Operator-facing
-configuration for opting a listing into this path is not defined by this
-requirement.
+- **GIVEN** an enabled resource in a disabled pool
+- **WHEN** that exact resource is requested
+- **THEN** scheduling rejects the request as ineligible.
 
-#### Scenario: Explicit resource_id is honored
+### Requirement: Replaceable executor-neutral policy
 
-- **WHEN** a request supplies `resource_id` instead of pool/capacity attributes
-- **THEN** the scheduler binds that `resource_id` or fails outright, without silently substituting a different resource
+Generic scheduling orchestration SHALL depend on a replaceable scheduling-policy protocol. Policy implementations SHALL receive eligible executor-neutral candidates and SHALL NOT depend on market-specific executor persistence models.
+
+#### Scenario: VM host model is not required
+
+- **GIVEN** generic candidates containing resource kind, units, pool identity, provider, and opaque attributes
+- **WHEN** the policy selects a candidate
+- **THEN** no VM Host ORM lookup is required.
+
+### Requirement: Deterministic MVP policy
+
+The initial automatic policy SHALL choose deterministically by round-robin across sorted eligible pool IDs and then sorted eligible resource IDs in the chosen pool.
+
+#### Scenario: Pool fairness
+
+- **GIVEN** two eligible pools with eligible resources
+- **WHEN** three independent reservations are automatically assigned
+- **THEN** the selected pools follow a stable alternating sequence.
+
+#### Scenario: Ineligible pool is skipped
+
+- **GIVEN** a previously selected pool that becomes disabled or has no eligible resource
+- **WHEN** the next assignment is selected
+- **THEN** the policy selects from the remaining eligible pools deterministically.

--- a/openspec/changes/pools-2-physical-settlement-scheduler/specs/resource-pool-management/spec.md
+++ b/openspec/changes/pools-2-physical-settlement-scheduler/specs/resource-pool-management/spec.md
@@ -1,26 +1,36 @@
-## MODIFIED Requirements
+# Resource pool management delta
 
-### Requirement: Non-destructive pool lifecycle
+## ADDED Requirements
 
-Pool removal MUST disable the pool rather than delete it. The system-owned
-`default` pool MUST always remain present under its configured ID and MUST
-remain the fallback for hosts and create requests that omit a pool ID
-regardless of its own enabled state; disabling it is otherwise ordinary and
-only excludes it from new scheduler selection. The service MUST reject
-disabling any pool — including `default` — that has at least one active
-settlement-resource binding.
+### Requirement: Exactly one scheduling pool
 
-#### Scenario: Operator deletes a non-default pool
+Every resource eligible for physical settlement SHALL belong to exactly one Resource Pool.
 
-- **WHEN** an operator sends DELETE for an existing non-default pool
-- **THEN** the service sets `enabled=false` and the pool remains retrievable by ID
+#### Scenario: Resource has no pool
 
-#### Scenario: Operator disables the default pool
+- **GIVEN** an otherwise enabled resource with no pool membership
+- **WHEN** settlement candidates are evaluated
+- **THEN** the resource is excluded as unschedulable.
 
-- **WHEN** an operator sends DELETE, PUT, or PATCH that disables `default` and it has no active settlement-resource binding
-- **THEN** the service sets `enabled=false`, `default` remains retrievable by ID, and hosts or create requests that omit a pool ID still resolve to it
+#### Scenario: Resource appears in multiple pools
 
-#### Scenario: Operator disables a pool with an active settlement-resource binding
+- **GIVEN** one physical resource represented as capacity in more than one pool
+- **WHEN** configuration is validated
+- **THEN** the configuration is rejected because it overstates true capacity.
 
-- **WHEN** an operator sends DELETE, PUT, or PATCH that would disable a pool — including `default` — with at least one active settlement-resource binding
-- **THEN** the service rejects the operation and the pool remains enabled
+### Requirement: Pool disablement drains new assignments
+
+Disabling a Resource Pool SHALL exclude it from new Capacity Settlement Assignments. Existing reservations, assignments, physical settlements, and active workloads SHALL NOT prevent disablement and SHALL NOT be invalidated solely by the disable action.
+
+#### Scenario: Disable pool with existing assignment
+
+- **GIVEN** a pool with an existing Capacity Settlement Assignment
+- **WHEN** an operator disables the pool
+- **THEN** disablement succeeds
+- **AND** the existing assignment remains readable.
+
+#### Scenario: New scheduling after disablement
+
+- **GIVEN** a disabled pool
+- **WHEN** a new automatic or explicit scheduling request is evaluated
+- **THEN** resources in that pool are ineligible.

--- a/openspec/changes/pools-2-physical-settlement-scheduler/specs/resource-pool-management/spec.md
+++ b/openspec/changes/pools-2-physical-settlement-scheduler/specs/resource-pool-management/spec.md
@@ -1,0 +1,26 @@
+## MODIFIED Requirements
+
+### Requirement: Non-destructive pool lifecycle
+
+Pool removal MUST disable the pool rather than delete it. The system-owned
+`default` pool MUST always remain present under its configured ID and MUST
+remain the fallback for hosts and create requests that omit a pool ID
+regardless of its own enabled state; disabling it is otherwise ordinary and
+only excludes it from new scheduler selection. The service MUST reject
+disabling any pool — including `default` — that has at least one active
+settlement-resource binding.
+
+#### Scenario: Operator deletes a non-default pool
+
+- **WHEN** an operator sends DELETE for an existing non-default pool
+- **THEN** the service sets `enabled=false` and the pool remains retrievable by ID
+
+#### Scenario: Operator disables the default pool
+
+- **WHEN** an operator sends DELETE, PUT, or PATCH that disables `default` and it has no active settlement-resource binding
+- **THEN** the service sets `enabled=false`, `default` remains retrievable by ID, and hosts or create requests that omit a pool ID still resolve to it
+
+#### Scenario: Operator disables a pool with an active settlement-resource binding
+
+- **WHEN** an operator sends DELETE, PUT, or PATCH that would disable a pool — including `default` — with at least one active settlement-resource binding
+- **THEN** the service rejects the operation and the pool remains enabled

--- a/openspec/changes/pools-2-physical-settlement-scheduler/specs/site-capacity/spec.md
+++ b/openspec/changes/pools-2-physical-settlement-scheduler/specs/site-capacity/spec.md
@@ -1,0 +1,19 @@
+## MODIFIED Requirements
+
+### Requirement: Reservation lifecycle
+
+Capacity reservation MUST use a hold/commit/release lifecycle keyed by
+durable allocation identity, MUST support lease-shaped `start`/`end`
+windows and expiry of uncommitted holds through both a lazy check on
+subsequent ledger access and a periodic watchdog sweep, and MUST be
+idempotent for retries.
+
+#### Scenario: Two buyers reserve the same final unit
+
+- **WHEN** concurrent requests race at one site
+- **THEN** the authoritative ledger commits at most one reservation
+
+#### Scenario: Uncommitted hold outlives its TTL without another ledger access
+
+- **WHEN** no subsequent `reserve`/`commit`/`release` call touches an expired uncommitted hold
+- **THEN** a periodic reservation-expiry watchdog still releases it without requiring storefront-side polling

--- a/openspec/changes/pools-2-physical-settlement-scheduler/specs/site-capacity/spec.md
+++ b/openspec/changes/pools-2-physical-settlement-scheduler/specs/site-capacity/spec.md
@@ -37,3 +37,17 @@ The durable architecture SHALL claim concrete-resource capacity and persist the 
 ### Requirement: Intermediate reservation constraint is documented
 
 Until the durable assignment transaction is implemented, the concrete site-ledger reservation and process-local assignment/cursor storage SHALL remain documented as intermediate constraints rather than distributed-idempotency guarantees.
+
+#### Scenario: Process restart loses in-memory assignment state
+
+- **GIVEN** a Capacity Settlement Assignment recorded only in process-local memory
+- **WHEN** the provisioning service process restarts
+- **THEN** the assignment and policy cursor state are lost
+- **AND** a retry of the same reservation is scheduled as if for the first time, rather than idempotently returning the prior assignment.
+
+#### Scenario: Multiple service instances do not share assignment state
+
+- **GIVEN** two running instances of the provisioning service, each with independent process-local assignment storage
+- **WHEN** the same reservation is scheduled against both instances
+- **THEN** each instance may independently record its own assignment
+- **AND** idempotency is guaranteed only within one process, not across the deployment, until the durable assignment transaction replaces process-local storage.

--- a/openspec/changes/pools-2-physical-settlement-scheduler/specs/site-capacity/spec.md
+++ b/openspec/changes/pools-2-physical-settlement-scheduler/specs/site-capacity/spec.md
@@ -1,19 +1,39 @@
-## MODIFIED Requirements
+# Site capacity delta
 
-### Requirement: Reservation lifecycle
+## ADDED Requirements
 
-Capacity reservation MUST use a hold/commit/release lifecycle keyed by
-durable allocation identity, MUST support lease-shaped `start`/`end`
-windows and expiry of uncommitted holds through both a lazy check on
-subsequent ledger access and a periodic watchdog sweep, and MUST be
-idempotent for retries.
+### Requirement: Reservation exposes settlement-validation data
 
-#### Scenario: Two buyers reserve the same final unit
+A Capacity Reservation SHALL expose sufficient identity, state, expiry, requested units or shape, resource kind, and deal relationship data for settlement validation.
 
-- **WHEN** concurrent requests race at one site
-- **THEN** the authoritative ledger commits at most one reservation
+#### Scenario: Unknown reservation
 
-#### Scenario: Uncommitted hold outlives its TTL without another ledger access
+- **WHEN** scheduling references an allocation identifier that does not exist
+- **THEN** scheduling fails with an entity-not-found error.
 
-- **WHEN** no subsequent `reserve`/`commit`/`release` call touches an expired uncommitted hold
-- **THEN** a periodic reservation-expiry watchdog still releases it without requiring storefront-side polling
+#### Scenario: Expired reservation
+
+- **GIVEN** a reservation whose hold expiry has passed
+- **WHEN** scheduling is requested
+- **THEN** scheduling fails with a reservation-expired error.
+
+#### Scenario: Agreement or represented terms mismatch
+
+- **GIVEN** a reservation whose recorded agreement, market, or terms differ from the request
+- **WHEN** scheduling is requested
+- **THEN** scheduling fails with a request-mismatch error.
+
+### Requirement: Concrete capacity claim and assignment are atomic
+
+The durable architecture SHALL claim concrete-resource capacity and persist the Capacity Settlement Assignment atomically with assignment idempotency and cursor advancement.
+
+#### Scenario: Concurrent assignments compete for one resource
+
+- **GIVEN** two concurrent reservations and capacity sufficient for only one
+- **WHEN** both assignments are attempted
+- **THEN** at most one transaction claims the capacity
+- **AND** the other request receives no eligible resource or retries against updated state.
+
+### Requirement: Intermediate reservation constraint is documented
+
+Until the durable assignment transaction is implemented, the concrete site-ledger reservation and process-local assignment/cursor storage SHALL remain documented as intermediate constraints rather than distributed-idempotency guarantees.

--- a/openspec/changes/pools-2-physical-settlement-scheduler/tasks.md
+++ b/openspec/changes/pools-2-physical-settlement-scheduler/tasks.md
@@ -1,46 +1,25 @@
-## 1. Relocate `ResourcePoolService` to `kit/resource-pools`
+# POOLS-2 tasks
 
-- [x] 1.1 Create `kit/resource-pools/` scaffold: `pyproject.toml` (`arkhai-kit-resource-pools`, deps `pydantic>=2.7`, `sqlalchemy>=2.0`), `Makefile` (copy `kit/site`'s build target shape), `src/market_resource_pools/__init__.py`, `tests/unit/`.
-- [x] 1.2 Move `ResourcePool` ORM model and `DEFAULT_POOL_ID` from `domains/vms/provisioning/service/src/db/models.py` into `kit/resource-pools/src/market_resource_pools/db.py` (own `Base`).
-- [x] 1.3 Move `ResourcePoolService`, `PoolDefinition`, `DocumentValidationResult`, `ReconciliationPlan`, `PoolNotFoundError`, `PoolAlreadyExistsError`, `PoolValidationError` from `domains/vms/provisioning/service/src/services/resource_pool_service.py` into `kit/resource-pools/src/market_resource_pools/service.py`; drop the `AnsiblePoolConfigHandler` default-import fallback, requiring `handlers` to be injected explicitly.
-- [x] 1.4 Update `domains/vms/provisioning/service/src/db/models.py` to re-export `ResourcePool`/`DEFAULT_POOL_ID` from `market_resource_pools.db`, matching the existing `market_site.db` re-export block.
-- [x] 1.5 Update `domains/vms/provisioning/service/src/db/database.py` to `create_all` the new package's `Base.metadata` alongside the existing two.
-- [x] 1.6 Update `_migrate_resource_pools_and_hosts_pool_id` in `db/migrations.py` to create the table from the new package's metadata.
-- [x] 1.7 Update `container.py`, `pools_controller.py`, `ansible_pool_config_handler.py` (if needed) import paths.
-- [x] 1.8 Add `arkhai-kit-resource-pools` to `domains/vms/provisioning/service/pyproject.toml` dependencies.
-- [x] 1.9 Add `dist-kit-resource-pools` to the root `Makefile` (`.PHONY`, target body, `dist:` list).
-- [x] 1.10 Move `test_resource_pool_service.py` into `kit/resource-pools/tests/unit/`, updating imports only.
-- [x] 1.11 Update `test_pools_api.py` and `test_database.py` import paths only.
-- [x] 1.12 Tombstone the old `resource_pool_service.py` and its old test location.
-- [x] 1.13 Run `kit/resource-pools` and VM provisioning service unit/integration suites; confirm no behavior change.
+## Implemented
 
-## 2. Correct default-pool disable behavior
+- [x] Extract provider-neutral Resource Pool administration into `kit/resource-pools`.
+- [x] Add capacity-reservation watchdog service and configuration.
+- [x] Add executor-neutral settlement request, requirement, candidate, assignment, policy, resource, and error contracts.
+- [x] Rename the process-local assignment map to `_capacity_settlement_assignments`.
+- [x] Replace pseudo-DRF selection with deterministic pool/resource round-robin.
+- [x] Remove VM `Host` imports and joins from the scheduler.
+- [x] Validate allocation existence, state, expiry, agreement, market, and terms when represented by the reservation.
+- [x] Apply normal eligibility checks to explicit resource requests.
+- [x] Treat pool disablement as draining and remove assignment-based disable guards.
+- [x] Add focused scheduler and contract tests.
+- [x] Add POOLS-6 deferred fair-scheduling change.
+- [x] Update ARCHITECTURE.md and POOLS-2 normative deltas.
 
-- [x] 2.1 Remove `_ensure_default_pool_enabled` and its three call sites from `market_resource_pools/service.py`.
-- [x] 2.2 Remove the `default_pool_disabled` validation-problem branch from the YAML import validator.
-- [x] 2.3 Replace "disabling default is rejected" test cases with "disabling default succeeds; omitted-pool-id hosts still resolve to it" in both the relocated unit tests and `test_pools_api.py`.
+## Remaining follow-on work
 
-## 3. Capacity reservation watchdog
-
-- [x] 3.1 Promote `_expire_stale_holds` to a public `expire_due_holds` on `CapacityLedgerService` (`kit/site/src/market_site/ledger.py`).
-- [x] 3.2 Add `kit/site/tests/unit/test_ledger.py` case exercising `expire_due_holds` directly (not only via `reserve`).
-- [x] 3.3 Add `domains/vms/provisioning/service/src/services/capacity_reservation_watchdog.py`, mirroring `lease_watchdog.py`.
-- [x] 3.4 Add `capacity_reservation_watchdog` provider to `container.py`.
-- [x] 3.5 Add startup wiring to `app_runtime.py`, mirroring the lease-watchdog block.
-- [x] 3.6 Add `capacity_reservation_watchdog_enabled`/`_poll_interval_seconds` to `settings.toml`.
-- [x] 3.7 Add `test_capacity_reservation_watchdog.py`.
-
-## 4. `PhysicalSettlementScheduler`
-
-- [x] 4.1 Add `PhysicalSettlementRequest`/`SettlementResource` pydantic models to `provisioning/compute/src/compute_provisioning/physical_settlement.py`.
-- [x] 4.2 Add `domains/vms/provisioning/service/src/services/physical_settlement_scheduler.py`: pool eligibility via `ResourcePoolService`, per-pool utilization via `CapacityLedgerService` + `Host.pool_id` join, dimension-agnostic bottleneck-normalized selection, in-memory `allocation_id → SettlementResource` binding store, explicit `resource_id` path honored without substitution.
-- [x] 4.3 Add `physical_settlement_scheduler` provider to `container.py`.
-- [x] 4.4 Add the active-binding guardrail to `ResourcePoolService.disable_pool`, wired to the scheduler via a late-bound lookup callable (mirroring `_resolved_job_queue`'s pattern), avoiding a circular DI dependency.
-- [x] 4.5 Add `provisioning/compute/tests/unit/test_physical_settlement.py`.
-- [x] 4.6 Add `test_physical_settlement_scheduler.py`: idempotency by `allocation_id`, disabled/exhausted-pool exclusion, explicit `resource_id` binding, no-match error, concurrent-selection race, multi-dimension bottleneck selection.
-- [x] 4.7 Add active-binding guardrail case to `test_pools_api.py`.
-
-## 5. Documentation sync
-
-- [x] 5.1 Update `docs/development/ARCHITECTURE.md` to reflect only what has actually landed and passed its tests at the point this task is done (per working-note: no unimplemented-feature prose).
-- [x] 5.2 Re-run `openspec validate --all --strict`.
+- [ ] Persist Capacity Settlement Assignments and round-robin cursors transactionally.
+- [ ] Move the concrete resource capacity claim from initial reservation into the assignment transaction.
+- [ ] Enforce exactly-one-pool membership at the database layer after migration/backfill.
+- [ ] Wire the scheduler into caller-facing settlement endpoints.
+- [ ] Add multi-process concurrency and restart integration tests for durable idempotency.
+- [ ] Run the complete repository integration suite and strict OpenSpec validation in the canonical development environment.

--- a/openspec/changes/pools-2-physical-settlement-scheduler/tasks.md
+++ b/openspec/changes/pools-2-physical-settlement-scheduler/tasks.md
@@ -1,0 +1,46 @@
+## 1. Relocate `ResourcePoolService` to `kit/resource-pools`
+
+- [x] 1.1 Create `kit/resource-pools/` scaffold: `pyproject.toml` (`arkhai-kit-resource-pools`, deps `pydantic>=2.7`, `sqlalchemy>=2.0`), `Makefile` (copy `kit/site`'s build target shape), `src/market_resource_pools/__init__.py`, `tests/unit/`.
+- [x] 1.2 Move `ResourcePool` ORM model and `DEFAULT_POOL_ID` from `domains/vms/provisioning/service/src/db/models.py` into `kit/resource-pools/src/market_resource_pools/db.py` (own `Base`).
+- [x] 1.3 Move `ResourcePoolService`, `PoolDefinition`, `DocumentValidationResult`, `ReconciliationPlan`, `PoolNotFoundError`, `PoolAlreadyExistsError`, `PoolValidationError` from `domains/vms/provisioning/service/src/services/resource_pool_service.py` into `kit/resource-pools/src/market_resource_pools/service.py`; drop the `AnsiblePoolConfigHandler` default-import fallback, requiring `handlers` to be injected explicitly.
+- [x] 1.4 Update `domains/vms/provisioning/service/src/db/models.py` to re-export `ResourcePool`/`DEFAULT_POOL_ID` from `market_resource_pools.db`, matching the existing `market_site.db` re-export block.
+- [x] 1.5 Update `domains/vms/provisioning/service/src/db/database.py` to `create_all` the new package's `Base.metadata` alongside the existing two.
+- [x] 1.6 Update `_migrate_resource_pools_and_hosts_pool_id` in `db/migrations.py` to create the table from the new package's metadata.
+- [x] 1.7 Update `container.py`, `pools_controller.py`, `ansible_pool_config_handler.py` (if needed) import paths.
+- [x] 1.8 Add `arkhai-kit-resource-pools` to `domains/vms/provisioning/service/pyproject.toml` dependencies.
+- [x] 1.9 Add `dist-kit-resource-pools` to the root `Makefile` (`.PHONY`, target body, `dist:` list).
+- [x] 1.10 Move `test_resource_pool_service.py` into `kit/resource-pools/tests/unit/`, updating imports only.
+- [x] 1.11 Update `test_pools_api.py` and `test_database.py` import paths only.
+- [x] 1.12 Tombstone the old `resource_pool_service.py` and its old test location.
+- [x] 1.13 Run `kit/resource-pools` and VM provisioning service unit/integration suites; confirm no behavior change.
+
+## 2. Correct default-pool disable behavior
+
+- [x] 2.1 Remove `_ensure_default_pool_enabled` and its three call sites from `market_resource_pools/service.py`.
+- [x] 2.2 Remove the `default_pool_disabled` validation-problem branch from the YAML import validator.
+- [x] 2.3 Replace "disabling default is rejected" test cases with "disabling default succeeds; omitted-pool-id hosts still resolve to it" in both the relocated unit tests and `test_pools_api.py`.
+
+## 3. Capacity reservation watchdog
+
+- [x] 3.1 Promote `_expire_stale_holds` to a public `expire_due_holds` on `CapacityLedgerService` (`kit/site/src/market_site/ledger.py`).
+- [x] 3.2 Add `kit/site/tests/unit/test_ledger.py` case exercising `expire_due_holds` directly (not only via `reserve`).
+- [x] 3.3 Add `domains/vms/provisioning/service/src/services/capacity_reservation_watchdog.py`, mirroring `lease_watchdog.py`.
+- [x] 3.4 Add `capacity_reservation_watchdog` provider to `container.py`.
+- [x] 3.5 Add startup wiring to `app_runtime.py`, mirroring the lease-watchdog block.
+- [x] 3.6 Add `capacity_reservation_watchdog_enabled`/`_poll_interval_seconds` to `settings.toml`.
+- [x] 3.7 Add `test_capacity_reservation_watchdog.py`.
+
+## 4. `PhysicalSettlementScheduler`
+
+- [x] 4.1 Add `PhysicalSettlementRequest`/`SettlementResource` pydantic models to `provisioning/compute/src/compute_provisioning/physical_settlement.py`.
+- [x] 4.2 Add `domains/vms/provisioning/service/src/services/physical_settlement_scheduler.py`: pool eligibility via `ResourcePoolService`, per-pool utilization via `CapacityLedgerService` + `Host.pool_id` join, dimension-agnostic bottleneck-normalized selection, in-memory `allocation_id → SettlementResource` binding store, explicit `resource_id` path honored without substitution.
+- [x] 4.3 Add `physical_settlement_scheduler` provider to `container.py`.
+- [x] 4.4 Add the active-binding guardrail to `ResourcePoolService.disable_pool`, wired to the scheduler via a late-bound lookup callable (mirroring `_resolved_job_queue`'s pattern), avoiding a circular DI dependency.
+- [x] 4.5 Add `provisioning/compute/tests/unit/test_physical_settlement.py`.
+- [x] 4.6 Add `test_physical_settlement_scheduler.py`: idempotency by `allocation_id`, disabled/exhausted-pool exclusion, explicit `resource_id` binding, no-match error, concurrent-selection race, multi-dimension bottleneck selection.
+- [x] 4.7 Add active-binding guardrail case to `test_pools_api.py`.
+
+## 5. Documentation sync
+
+- [x] 5.1 Update `docs/development/ARCHITECTURE.md` to reflect only what has actually landed and passed its tests at the point this task is done (per working-note: no unimplemented-feature prose).
+- [x] 5.2 Re-run `openspec validate --all --strict`.

--- a/openspec/changes/pools-2-physical-settlement-scheduler/tasks.md
+++ b/openspec/changes/pools-2-physical-settlement-scheduler/tasks.md
@@ -22,4 +22,4 @@
 - [ ] Enforce exactly-one-pool membership at the database layer after migration/backfill.
 - [ ] Wire the scheduler into caller-facing settlement endpoints.
 - [ ] Add multi-process concurrency and restart integration tests for durable idempotency.
-- [ ] Run the complete repository integration suite and strict OpenSpec validation in the canonical development environment.
+- [x] Run the complete repository integration suite and strict OpenSpec validation in the canonical development environment.

--- a/openspec/changes/pools-3-fulfillment-provider/.openspec.yaml
+++ b/openspec/changes/pools-3-fulfillment-provider/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-14

--- a/openspec/changes/pools-3-fulfillment-provider/design.md
+++ b/openspec/changes/pools-3-fulfillment-provider/design.md
@@ -1,0 +1,172 @@
+## Context
+
+This content previously lived in `docs/development/ARCHITECTURE.md`'s
+"Physical Settlement Scheduler and FulfillmentProvider Architecture"
+section, recovered the same way as `pools-2`'s design.md (see that
+document's Context for the provenance note — the migration ledger pointed
+at a change directory that was never created).
+
+`pools-3` builds directly on `pools-2`: the scheduler answers "which
+resource," the provider answers "what do I do with it." Verified against
+current code before writing this down: `AnsibleJobService`,
+`AnsibleService`, and `ProgrammableMockAnsibleService` still exist as
+described in `domains/vms/provisioning/service/src/services/`, and the
+storefront's `settlement_claims`/`mechanism_state`/`ClaimsEngine` still
+exist in `core/storefront/src/core_storefront/`.
+
+## Goals / Non-Goals
+
+See `proposal.md`.
+
+## Decisions
+
+### 1. Provider owns operations, not placement
+
+```python
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any
+
+@dataclass
+class FulfillmentResult:
+    """Provider result persisted on the settlement record."""
+    provider_metadata: dict[str, Any]
+    credentials: dict[str, Any]
+
+@dataclass
+class ProviderStatus:
+    state: str           # "running" | "stopped" | "gone" | "unknown"
+    detail: str | None = None
+
+class FulfillmentProvider(ABC):
+    """Minimum contract for any physical settlement provider.
+
+    The identity key is allocation_id. Infra-specific identifiers are
+    provider metadata, not generic lifecycle identity.
+
+    create() is idempotent on allocation_id: re-delivery must detect-or-create,
+    not double-provision. teardown() is idempotent: no-op if already gone.
+    status() and teardown() operate from the persisted settlement record.
+    """
+
+    @abstractmethod
+    async def create(
+        self,
+        request: "PhysicalSettlementRequest",   # from pools-2
+        resource: "SettlementResource",          # from pools-2
+    ) -> FulfillmentResult: ...
+
+    @abstractmethod
+    async def teardown(
+        self,
+        allocation_id: str,
+        resource: "SettlementResource",
+        provider_metadata: dict[str, Any],
+    ) -> None: ...
+
+    @abstractmethod
+    async def get_status(
+        self,
+        allocation_id: str,
+        resource: "SettlementResource",
+        provider_metadata: dict[str, Any],
+    ) -> ProviderStatus: ...
+```
+
+A provider may validate that the selected resource is usable, but must not
+independently select or substitute a different resource without returning
+to the scheduler boundary.
+
+### 2. `ProviderRegistry` maps provider strings to instances
+
+```python
+class ProviderRegistry:
+    def __init__(self, providers: dict[str, FulfillmentProvider]) -> None:
+        self._providers = providers
+
+    def require(self, provider: str) -> FulfillmentProvider:
+        if provider not in self._providers:
+            raise KeyError(f"No provider registered for '{provider}'")
+        return self._providers[provider]
+```
+
+The VM service starts as a degenerate singleton
+(`"ansible" -> AnsibleFulfillmentProvider`), constructed in the DI
+container at startup. New provider implementations extend the registry
+without adding provider branches to lifecycle code.
+
+### 3. Ansible provider owns variable construction and pool-level variation
+
+```python
+@dataclass
+class AnsiblePoolConfig:
+    playbook_path: str
+    inventory_group: str
+    extra_vars: dict[str, Any]
+```
+
+Pool-level variation in data-center infrastructure (different FRP servers,
+network bridges, firewall topologies, available utilities) is expressed via
+`AnsiblePoolConfig`, resolved from `ansible_pool_configs` at execution
+time. Different pools get different playbooks and extra vars without a new
+provider type. The mock seam stays at this layer:
+`ProgrammableMockAnsibleService` is selected by the `mockMode` profile flag
+inside the Ansible provider, not promoted to `FulfillmentProvider`. The
+`/test/*` controller and e2e gate pattern are unchanged.
+
+### 4. `SettlementRecord` extends the `pools-2` binding identity
+
+```python
+@dataclass
+class SettlementRecord:
+    allocation_id: str
+    agreement_id: str
+    market: str
+    pool_id: str
+    provider: str
+    resource: "SettlementResource"   # from pools-2
+    provider_metadata: dict[str, Any]
+    credentials_ref: str | None
+    state: str
+```
+
+`resource` records what the scheduler selected; `provider_metadata` records
+what the provider learned or created while executing settlement. Sensitive
+access material should be referenced (`credentials_ref`) rather than stored
+inline. This is the same `allocation_id`-keyed identity `pools-2`
+establishes non-durably — `pools-3` is what makes it durable, not a second
+parallel record.
+
+### 5. `release_delegate` becomes a thin adapter over `teardown`
+
+The `release_delegate` injected into `LeaseLifecycleService` wraps the
+registry-resolved provider's `teardown(...)`. The lifecycle state machine
+never learns whether the provider is Ansible, Kubernetes, storage, power,
+bandwidth, or another mechanism.
+
+## Error surface
+
+Shared with `pools-2`'s design.md (same taxonomy, this change exercises
+the fulfillment-side subset): `provider_not_found`,
+`provider_unavailable`, `provider_config_invalid`,
+`fulfillment_create_failed`, `fulfillment_status_failed`,
+`fulfillment_teardown_failed`, `credentials_publish_failed`.
+
+## Risks / Trade-offs
+
+- **`SettlementRecord`/`settlement_claims` ownership boundary is still
+  open.** See proposal.md's Open Design-Review Topic. Implementing
+  `SettlementRecord` without resolving this risks a second, silently
+  divergent settlement-tracking system if a future change tries to bridge
+  them without an explicit contract.
+- **Ansible-only.** The `FulfillmentProvider` boundary is designed to be
+  provider-neutral, but only one implementation exists until a second
+  domain needs a different provider.
+
+## Migration Plan
+
+Adds the `SettlementRecord` table (or extends `pools-2`'s table if that
+change lands with one instead of staying process-local — reconcile at
+implementation time against whatever `pools-2`'s task list actually
+produced). No wire break: `AnsibleJobService`/`AnsibleService`'s existing
+callers are wrapped, not replaced.

--- a/openspec/changes/pools-3-fulfillment-provider/proposal.md
+++ b/openspec/changes/pools-3-fulfillment-provider/proposal.md
@@ -1,0 +1,87 @@
+## Why
+
+The provisioning service has no formal abstraction separating physical
+settlement *operations* from lifecycle and job-management machinery.
+`pools-2-physical-settlement-scheduler` selects a `SettlementResource` but
+nothing yet executes against it, and `pools-2` explicitly defers durable
+storage of that binding. Without a provider boundary, future domain
+provisioning services would have to duplicate VM-domain execution code or
+depend on it directly.
+
+## What Changes
+
+- Define `FulfillmentProvider` (ABC), `FulfillmentResult`, and
+  `ProviderStatus` in the VM provisioning service. A provider receives an
+  already-selected `SettlementResource` and performs `create`/
+  `get_status`/`teardown` against it; it MUST NOT independently select or
+  substitute a different resource.
+- Add durable `SettlementRecord` persistence, extending the same binding
+  identity `pools-2` establishes (`allocation_id`) rather than creating a
+  second, competing record — `pools-2` is deliberately non-durable and this
+  is where that persistence lands.
+- Implement `AnsibleFulfillmentProvider` around the existing
+  `AnsibleJobService`/`AnsibleService`: resolve `AnsiblePoolConfig`, build
+  Ansible variables, dispatch jobs, normalize results, and extract
+  credentials for the selected resource. It owns execution, not placement.
+- Keep `ProgrammableMockAnsibleService`'s `mockMode`-flag test seam inside
+  the Ansible provider; do not promote it to the `FulfillmentProvider`
+  level.
+- Implement `ProviderRegistry.require(provider)`, constructed in the DI
+  container at startup, mapping provider strings to `FulfillmentProvider`
+  instances. Lifecycle code stays free of provider-specific branches.
+- Rewire `LeaseLifecycleService`'s `release_delegate` to become a thin
+  adapter around the selected provider's `teardown(...)`; the lifecycle
+  state machine never learns which concrete mechanism executed.
+
+## Non-Goals
+
+- Kubernetes, cloud, storage, power, or bandwidth providers — Ansible only.
+- Recreating the removed generic `provisioning_client` package.
+- Any storefront-side change (`pools-4`).
+- Extracting these contracts into a shared package (`pools-5` — conditional
+  on a second domain actually needing them).
+
+## Open Design-Review Topic (unresolved — not decided by this proposal)
+
+The ownership boundary between `SettlementRecord` (provisioning-side,
+physical-settlement state) and the storefront's `settlement_claims` /
+`mechanism_state` in `ClaimsEngine` (market-side, on-chain claim
+collection) is unresolved. These are parallel tracking systems for
+different concerns — physical settlement vs. financial claim collection —
+but the naming is close enough to invite confusion, and neither codebase
+states the boundary explicitly today. Whether they reference each other
+(and via what key), and whether `SettlementRecord` replaces any
+storefront-side state, needs a design-review session before
+implementation — this was true when originally written and remains true;
+no design discussion has resolved it yet.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `physical-provisioning`: adds `FulfillmentProvider`, `ProviderRegistry`,
+  and durable `SettlementRecord` persistence extending the `pools-2`
+  binding.
+
+## Dependencies and Related Changes
+
+- Requires `pools-2-physical-settlement-scheduler` (not yet implemented):
+  consumes its `SettlementResource` binding and extends its identity.
+- Loosely precedes `pools-4-storefront-capacity-boundary`.
+- `pools-5-shared-provisioning-package`'s residual scope (extracting these
+  contracts to a shared package) is conditional on this change landing
+  first.
+
+## Impact
+
+- **Packages:** `domains/vms/provisioning/service` (provider, registry,
+  persistence); no change to `provisioning/compute` unless the plan step
+  determines the scheduler itself should live there (see `pools-2`
+  `design.md`, "carried-forward note").
+- **Database:** new durable settlement-record storage, extending
+  `pools-2`'s binding identity rather than adding a second table for the
+  same key.
+- **API:** none new required by this change alone; a caller-facing route
+  wiring `select_resource` + `create` together is downstream work.
+- **Compatibility:** existing `AnsibleJobService`/`AnsibleService` tests
+  must pass unchanged — this change wraps, not replaces, that machinery.

--- a/openspec/changes/pools-3-fulfillment-provider/specs/physical-provisioning/spec.md
+++ b/openspec/changes/pools-3-fulfillment-provider/specs/physical-provisioning/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Provider-owned fulfillment execution
+
+The provisioning service MUST expose a `FulfillmentProvider` contract that
+performs create/status/teardown operations against an already-selected
+`SettlementResource`, and a provider MUST NOT independently select or
+substitute a different resource without returning to the scheduler
+boundary.
+
+#### Scenario: Provider executes against a selected resource
+
+- **WHEN** a `FulfillmentProvider` receives a `SettlementResource` selected by the scheduler
+- **THEN** it performs its operation against that resource without requesting or substituting another one
+
+#### Scenario: Create is retried after partial delivery
+
+- **WHEN** `create(...)` is called twice for the same `allocation_id`
+- **THEN** the provider detects the existing resource rather than double-provisioning
+
+### Requirement: Registry-resolved provider selection
+
+The provisioning service MUST resolve a `FulfillmentProvider` by provider
+string through a `ProviderRegistry`, and lifecycle code MUST NOT branch on
+concrete provider identity.
+
+#### Scenario: Unregistered provider is requested
+
+- **WHEN** a settlement record names a provider with no registered `FulfillmentProvider`
+- **THEN** resolution fails with an actionable provider-not-found error before any execution is attempted
+
+### Requirement: Durable settlement record
+
+The provisioning service MUST persist a `SettlementRecord` extending the
+scheduler's `allocation_id`-keyed binding with provider metadata,
+a credentials reference, and lifecycle state.
+
+#### Scenario: Fulfillment completes
+
+- **WHEN** a `FulfillmentProvider`'s `create(...)` succeeds
+- **THEN** the persisted settlement record carries the provider metadata and a credentials reference rather than inline sensitive material

--- a/openspec/changes/pools-4-storefront-capacity-boundary/.openspec.yaml
+++ b/openspec/changes/pools-4-storefront-capacity-boundary/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-14

--- a/openspec/changes/pools-4-storefront-capacity-boundary/design.md
+++ b/openspec/changes/pools-4-storefront-capacity-boundary/design.md
@@ -1,0 +1,55 @@
+## Context
+
+Recovered from `docs/development/ARCHITECTURE.md`'s "Physical Settlement
+Scheduler and FulfillmentProvider Architecture" section and the
+pre-migration `TODO.md`'s POOLS-4 item; see `pools-2`'s design.md Context
+for the provenance note. Verified and corrected against current code
+before writing this down — see proposal.md's "Correction from the original
+plan."
+
+## Goals / Non-Goals
+
+See proposal.md.
+
+## Decisions
+
+### 1. `fill_first`/`most_available` placement policies become moot for pool-shaped reservations
+
+Once the ordinary reservation path stops requiring `vm_host` and instead
+carries capacity/pool attributes, the storefront's own placement policies
+no longer decide *which physical host* — that decision moves to
+`pools-2`'s scheduler on the provisioning side. `AggregateCapacityClient`
+still decides *which site* to route a reservation to when multiple sites
+are aggregated (per `site-capacity`'s multi-site aggregation requirement,
+unchanged by this item); it stops deciding host placement within a site.
+
+### 2. Rename is schema + call sites, not a behavior change
+
+`compute_inventory_pools` → `compute_capacity_pools` is a pure rename: same
+columns, same foreign-key relationships, same reconciler behavior. Doing it
+as part of this change rather than deferring keeps the storefront's
+internal naming aligned with the capacity-shaped claim vocabulary this
+change also introduces, instead of landing capacity-language reservations
+on top of a table still named for the old host-inventory model.
+
+## Risks / Trade-offs
+
+- **Breaking claim-shape change.** Any external caller building
+  `vm_host`-shaped reservation claims directly needs to move to
+  capacity/pool attributes or the explicit specific-resource path.
+- **Ownership-rule prose drift.** The baseline `site-capacity` spec already
+  states the provisioning-owns-inventory / storefront-owns-projection rule;
+  this change should confirm current prose still matches rather than
+  assume it does, since the codebase has moved since this item was
+  originally written (see the `SiteLedger` correction above).
+
+## Migration Plan
+
+1. Add the `compute_capacity_pools` rename migration; keep it purely
+   additive/renaming, no data reshaping.
+2. Update reservation claim models and `RemoteCapacityClient`/
+   `AggregateCapacityClient` call sites together, since they share the
+   claim shape.
+3. Update or add tests asserting the ordinary path no longer requires
+   `vm_host` and that the specific-resource path still works for opted-in
+   listings.

--- a/openspec/changes/pools-4-storefront-capacity-boundary/proposal.md
+++ b/openspec/changes/pools-4-storefront-capacity-boundary/proposal.md
@@ -1,0 +1,81 @@
+## Why
+
+`required_attributes=("vm_host",)` in the storefront's capacity-reservation
+claim shape forces physical host selection into the storefront for the
+ordinary reservation path — verified still present today
+(`core_storefront/models/settle_models.py`, `vm_fulfillment_service.py`,
+`resource_capacity_validator.py`). The `AggregateCapacityClient`
+placement policies (`fill_first`, `most_available`, in
+`core_storefront/aggregation.py`) are symptoms of the same layering issue:
+the storefront is making a physical-placement decision that
+`pools-2-physical-settlement-scheduler` now gives provisioning a formal
+way to own.
+
+**Correction from the original plan (verified against current code, not
+assumed):** the `SiteLedger`/`SiteResourcesService` rename this item
+originally called for has already happened — the site authority is now
+`CapacityLedgerService`/`SiteAuthorityPort` in `kit/site/src/market_site/`.
+That work is done; it is not part of this change's remaining scope. The
+`compute_inventory_pools` table name, however, is still unrenamed
+(`domains/vms/storefront/src/market_storefront/utils/{sqlite_client,migrations}.py`,
+`domains/vms/listings/reconciler.py`) and remains this change's scope.
+
+## What Changes
+
+- Remove the `vm_host`-specific requirement from the ordinary capacity
+  reservation path. A `resource_id` path remains valid only for
+  intentionally specific-resource listings, using `pools-2`'s
+  specific-resource request shape.
+- Update the storefront reservation claim shape to use capacity/pool
+  attributes instead of VM-host attributes; update `RemoteCapacityClient`/
+  `AggregateCapacityClient` call sites that currently assume physical host
+  selection.
+- Rename `compute_inventory_pools` to `compute_capacity_pools` in the
+  storefront SQLite schema, and update `SQLiteClient`, the listings
+  reconciler, and their tests.
+- Apply `pools-2`'s reservation-expiry decision (lease-shaped windows,
+  watchdog-driven expiry at the site authority) to the storefront-facing
+  reservation path: update whatever watchdog/release/TTL wiring the
+  storefront side needs to match.
+- Confirm and, where prose has drifted, restate the ownership rule already
+  expressed in `site-capacity`'s baseline spec: provisioning is the source
+  of truth for physical inventory, resource pools, scheduling, and
+  settlement resources; the storefront owns capacity offerings/projections
+  and market reservations.
+
+## Non-Goals
+
+- Renaming the `SiteResource`/`SiteAllocation` ORM model names — the
+  service-level rename is done, but these model names still carry `Site`
+  prefixes. Left as naming debt, not blocking.
+- Any provider execution or scheduler behavior change — this change only
+  changes what the storefront asks for, not how provisioning fulfills it.
+- Package extraction (`pools-5`).
+
+## Capabilities
+
+### Modified Capabilities
+
+- `site-capacity`: capacity reservation claims become capacity/pool-shaped
+  rather than host-shaped for the ordinary path; the specific-resource path
+  remains available for explicit opt-in listings.
+
+## Dependencies and Related Changes
+
+- Requires `pools-2-physical-settlement-scheduler`'s specific-resource
+  request shape and reservation-expiry model.
+- Independent of `pools-3-fulfillment-provider` — does not require provider
+  execution to exist.
+
+## Impact
+
+- **Packages:** `core/storefront`, `domains/vms/storefront`,
+  `domains/vms/listings`.
+- **Database:** storefront SQLite migration renaming
+  `compute_inventory_pools` to `compute_capacity_pools`.
+- **API:** reservation claim wire shape changes from host-attribute-based
+  to capacity/pool-attribute-based; existing callers assuming `vm_host`
+  need updating.
+- **Compatibility:** breaking for any caller relying on `vm_host` in the
+  ordinary reservation path; the specific-resource path is the intended
+  replacement for genuinely host-specific listings.

--- a/openspec/changes/pools-4-storefront-capacity-boundary/specs/site-capacity/spec.md
+++ b/openspec/changes/pools-4-storefront-capacity-boundary/specs/site-capacity/spec.md
@@ -1,0 +1,21 @@
+## MODIFIED Requirements
+
+### Requirement: Site-authoritative capacity
+A site authority MUST own physical resource capacity and allocations; a
+storefront MUST reach capacity only through the CapacityClient boundary,
+MUST treat its own view as a projection, and MUST express ordinary
+reservation claims as capacity/pool attributes rather than host-specific
+attributes. A `resource_id`-based claim remains valid only for a listing
+that has explicitly opted into specific-resource selection.
+
+#### Scenario: Site authority is unavailable
+- **WHEN** listing reconciliation cannot obtain an authoritative snapshot
+- **THEN** it skips capacity-driven close/reopen actions rather than treating ignorance as zero capacity
+
+#### Scenario: Ordinary reservation omits a specific host
+- **WHEN** a buyer reserves through a listing that has not opted into specific-resource selection
+- **THEN** the reservation claim carries capacity/pool attributes and the storefront does not require or select a `vm_host`
+
+#### Scenario: Specific-resource listing reserves a named resource
+- **WHEN** a buyer reserves through a listing that has opted into specific-resource selection
+- **THEN** the reservation claim carries the explicit `resource_id` and the ordinary capacity-attribute path is not required

--- a/openspec/changes/pools-5-shared-provisioning-package/.openspec.yaml
+++ b/openspec/changes/pools-5-shared-provisioning-package/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-14

--- a/openspec/changes/pools-5-shared-provisioning-package/design.md
+++ b/openspec/changes/pools-5-shared-provisioning-package/design.md
@@ -1,0 +1,39 @@
+## Context
+
+See `proposal.md` for the supersession finding: the originally-planned
+`core/provisioning`/`core_provisioning` package should not be created,
+because `provisioning/compute`/`compute_provisioning` already exists and
+`market-platform-compute-30-extract-service` already owns extracting the
+remaining generic machinery there.
+
+This design.md intentionally stays minimal. Detailed decisions (exact
+module layout, what moves vs. what stays VM-local) belong to the
+design-review pass the activation condition triggers, not to this
+placeholder.
+
+## Goals / Non-Goals
+
+See proposal.md.
+
+## Decisions
+
+### 1. The ownership rule already exists; this change only extends its scope
+
+`physical-provisioning`'s "Compute-owned caller contract" requirement
+already establishes that shared, executor-neutral models belong in
+`compute_provisioning` rather than the VM domain. This change's only
+concrete claim is that `pools-2`/`pools-3`'s scheduler and provider
+contracts should eventually follow the same rule — not a new ownership
+principle, an extension of scope for one already decided.
+
+## Risks / Trade-offs
+
+- **Premature extraction risk.** Moving these contracts before a second
+  domain needs them risks designing a boundary against a sample size of
+  one, the same anti-pattern the original POOLS-5 plan was written to
+  avoid duplicating VM-domain code — just in the opposite direction.
+
+## Migration Plan
+
+None yet. A migration plan belongs to the design-review pass triggered by
+the activation condition, once its actual scope is known.

--- a/openspec/changes/pools-5-shared-provisioning-package/proposal.md
+++ b/openspec/changes/pools-5-shared-provisioning-package/proposal.md
@@ -1,0 +1,81 @@
+## Why
+
+The original plan (pre-migration `TODO.md` POOLS-5) called for extracting
+`AsyncJobQueue`, lease lifecycle/watchdog machinery, provider registry, and
+settlement scheduling/fulfillment contracts out of `arkhai-vms-provisioning`
+into a new `core/provisioning` (`arkhai-core-provisioning`,
+`core_provisioning`) package, so future domain provisioning services would
+not depend on a VM-domain package.
+
+**This has been substantially superseded — verified against current code,
+not assumed.** A `provisioning/compute/src/compute_provisioning` package
+already exists and already owns generic contracts, adapters, pool wire
+models, lease lifecycle, and events (`contracts.py`, `adapters.py`,
+`pools.py`, `lease_lifecycle.py`, `events.py`, `executor_leases.py`,
+`release.py`). `pools-1`'s own design.md recorded moving pool wire models
+there instead of a `provisioning_client` package. Separately, there is an
+**active, already-drafted** OpenSpec change,
+`market-platform-compute-30-extract-service`, whose entire purpose is
+moving the remaining generic API assembly, job lifecycle, executor-neutral
+lease lifecycle, watchdog scheduling, and capacity mounting from
+`domains/vms/provisioning/service` into `provisioning/compute/service` as
+an independently deployable service — this is POOLS-5's remaining goal,
+already scoped, under a different track.
+
+## What This Change Actually Covers
+
+Given the above, this proposal is narrowed rather than carried forward
+verbatim:
+
+- **Do not create a second, competing package.** `core/provisioning` /
+  `core_provisioning` as originally named should not be created;
+  `provisioning/compute` / `compute_provisioning` is the established
+  destination.
+- **Residual scope:** once `pools-2` and `pools-3` land, decide whether
+  `PhysicalSettlementScheduler`, `FulfillmentProvider`, `ProviderRegistry`,
+  and the `SettlementResource`/`SettlementRecord` shapes should move into
+  `compute_provisioning` alongside the pool wire models they're adjacent
+  to, or stay VM-service-local until a second domain (e.g. `bare_metal`,
+  which already exists and already shares the compute-provisioning
+  envelope per `physical-provisioning`'s adapter-owned execution
+  requirement) actually needs them.
+- **Reconcile, don't duplicate, with `market-platform-compute-30-extract-service`.**
+  That change is blocked on `market-platform-compute-20-provisioning-contract`
+  and covers the job/lease/watchdog/capacity-mount extraction already. This
+  proposal's residual scope should land after that cutover, against
+  whatever package shape it produces, rather than in parallel.
+
+## Non-Goals
+
+- Anything already covered by `market-platform-compute-30-extract-service`.
+- Creating `core/provisioning`/`core_provisioning` under the original name.
+- Extracting anything before `pools-2`/`pools-3` exist to extract.
+
+## Activation Condition
+
+This stays taskless until: (a) `pools-2` and `pools-3` are implemented, and
+(b) either a second domain needs `FulfillmentProvider`/`ProviderRegistry`,
+or `market-platform-compute-30-extract-service` completes its cutover and
+this change's residual scope needs reconciling against the resulting
+package shape. Whichever comes first should drive a fresh design-review
+pass, not a straight implementation of this document.
+
+## Capabilities
+
+### Modified Capabilities
+
+None yet — no requirement delta until the activation condition is met and
+the reconciled scope is design-reviewed.
+
+## Dependencies and Related Changes
+
+- Requires `pools-2-physical-settlement-scheduler` and
+  `pools-3-fulfillment-provider`.
+- Must be reconciled against `market-platform-compute-30-extract-service`
+  (itself blocked on `market-platform-compute-20-provisioning-contract`)
+  rather than implemented independently.
+
+## Impact
+
+Not assessed — package boundary and destination depend on how the
+activation condition resolves.

--- a/openspec/changes/pools-5-shared-provisioning-package/specs/physical-provisioning/spec.md
+++ b/openspec/changes/pools-5-shared-provisioning-package/specs/physical-provisioning/spec.md
@@ -1,0 +1,25 @@
+## MODIFIED Requirements
+
+### Requirement: Compute-owned caller contract
+
+Shared storefront/provisioner DTOs, executor-neutral resource-pool models,
+generic client behavior, and — once implemented — the physical-settlement
+scheduler, fulfillment-provider, and provider-registry contracts MUST be
+owned by compute provisioning rather than the VM domain, while direct VM
+operator APIs MAY retain VM-owned host, VM action, Ansible job, credential,
+and lease models.
+
+#### Scenario: Bare-metal storefront installs the shared client
+
+- **WHEN** a bare-metal caller installs the compute-provisioning client without VM execution extras
+- **THEN** it can submit and observe bare-metal lifecycle operations without importing VM request models
+
+#### Scenario: Provisioning service exposes resource-pool administration
+
+- **WHEN** the VM operator client or provisioning service creates, validates, imports, or returns a resource-pool model
+- **THEN** that executor-neutral model resolves from `compute_provisioning` and no removed generic provisioning-client package is required
+
+#### Scenario: A second domain needs fulfillment execution
+
+- **WHEN** a domain besides VM needs `FulfillmentProvider`/`ProviderRegistry` behavior
+- **THEN** those contracts resolve from `compute_provisioning` rather than being duplicated or imported from the VM-owned service

--- a/openspec/changes/pools-6-multidimensional-fair-scheduling/design.md
+++ b/openspec/changes/pools-6-multidimensional-fair-scheduling/design.md
@@ -1,0 +1,128 @@
+# Design notes: Multidimensional Fair Scheduling
+
+## Foundation inherited from POOLS-2
+
+POOLS-6 builds on the `SettlementSchedulingPolicy` protocol. The scheduler remains responsible for reservation validation, idempotency, eligibility, explicit-resource handling, assignment persistence, and transactional capacity claims. A policy receives a sequence of concrete eligible candidates and returns one candidate plus, potentially, an explanation object.
+
+Round-robin remains a valid policy and compatibility baseline. A second policy must be swappable without changing `PhysicalSettlementRequest`, Capacity Settlement Assignment identity, or provider-facing physical settlement.
+
+## Why the earlier aggregate algorithm was insufficient
+
+The previous draft grouped independent resource rows by `resource_type`, calculated the maximum used/total ratio for each pool, and chose the least utilized pool. That approach had several flaws:
+
+- it did not evaluate the requested reservation shape;
+- it could aggregate CPU, memory, GPU, or other dimensions across unrelated physical resources;
+- it did not prove that one concrete resource could satisfy all dimensions;
+- it selected a concrete resource independently after scoring the pool;
+- it had no consumer identity or dominant-share history;
+- it used unstable tie-breaking.
+
+A future policy must score actual concrete candidates or explicitly model a schedulable resource bundle whose dimensions are co-located.
+
+## Candidate capacity model
+
+A future candidate may expose maps such as:
+
+```python
+class MultidimensionalCandidate:
+    resource_id: str
+    pool_id: str
+    total: Mapping[str, Decimal]
+    allocated: Mapping[str, Decimal]
+    attributes: Mapping[str, object]
+```
+
+A reservation may expose:
+
+```python
+class MultidimensionalRequirement:
+    dimensions: Mapping[str, Decimal]
+    attributes: Mapping[str, object]
+```
+
+Hard fit is evaluated before fairness. For every required dimension, the candidate must define positive total capacity and have enough unallocated capacity. Dimensions on different concrete resources cannot be combined unless the resource model explicitly declares them one schedulable bundle.
+
+## Projected dominant utilization
+
+One possible placement score is the maximum projected utilization among requested dimensions:
+
+```text
+max((allocated[d] + requested[d]) / total[d])
+```
+
+Selecting the lowest score can spread heterogeneous requests while accounting for their shape. This is more accurately called lowest projected dominant utilization than DRF because it does not by itself allocate fairly among competing consumers.
+
+Pool fairness could be layered by selecting the pool whose best eligible candidate has the lowest projected score, then selecting the best candidate in that pool. Alternatives include scoring candidates globally or weighting pools by usable capacity.
+
+## Consumer-aware DRF
+
+Classical DRF requires:
+
+- a defined consumer identity;
+- multidimensional allocations attributed to each consumer;
+- total capacity for the fairness scope;
+- each consumer's dominant share;
+- an allocation loop that favors the consumer with the lowest dominant share while respecting fit.
+
+Before this term is used, POOLS-6 must specify the consumer, scope, accounting history, treatment of exact-resource requests, weights, quotas, and recovery behavior.
+
+## Policy composition
+
+A likely future pipeline is:
+
+1. hard reservation and entity validation;
+2. concrete candidate eligibility and fit;
+3. quota and policy constraints;
+4. fairness or utilization scoring;
+5. topology and affinity adjustments;
+6. deterministic tie-breaking;
+7. atomic capacity claim and assignment persistence;
+8. decision explanation and metrics.
+
+The ordering is a design decision because each layer can change fairness and starvation behavior.
+
+## Determinism and idempotency
+
+Policies must define stable tie-breakers such as pool ID and resource ID after numerical scores. Retrying an unchanged reservation returns the durable assignment and never recomputes a policy decision. Historical fairness state and score inputs must be transactionally consistent with capacity claims if they affect selection.
+
+## External dependency evaluation
+
+A library is suitable only if it can operate behind the policy protocol without requiring Arkhai to adopt its worker registration, queue, task graph, control plane, or cluster lifecycle. Evaluation should cover maintenance, license, concurrency model, multidimensional and indivisible resources, deterministic behavior, persistence assumptions, observability, and extensibility.
+
+Using a large scheduler merely to avoid owning a scoring function may increase rather than reduce operational ownership.
+
+## Observability
+
+A future policy should provide a structured explanation containing at least:
+
+- eligible and rejected candidate counts;
+- hard rejection reasons;
+- fairness subject and scope;
+- score dimensions and normalized values;
+- weights, quotas, or priorities applied;
+- deterministic tie-breaker;
+- selected pool and resource;
+- policy name and version.
+
+Explanations must avoid leaking opaque provider secrets.
+
+## Testing strategy
+
+The policy should be tested through simulations and invariants rather than only examples:
+
+- all selected candidates fit the complete shape;
+- no dimension is overclaimed under concurrency;
+- deterministic results for identical durable state;
+- restart-safe idempotency;
+- fairness convergence over long sequences;
+- behavior with unequal pool sizes;
+- indivisible and scarce resources;
+- adversarial request shapes;
+- starvation and quota boundaries;
+- exact-resource accounting;
+- topology-constrained candidate sets;
+- failure and explicit reassignment workflows.
+
+## Non-Work / Deferred Decisions
+
+The proposal's deferred questions are intentionally unresolved. This design must be revised in a later discuss → plan → implement session before normative requirements or code are added.

--- a/openspec/changes/pools-6-multidimensional-fair-scheduling/proposal.md
+++ b/openspec/changes/pools-6-multidimensional-fair-scheduling/proposal.md
@@ -33,6 +33,10 @@ A richer scheduler must still preserve the durable properties established by POO
 - Treating abstract aggregate capacity as proof that one concrete resource can fit a request.
 - Changing Capacity Settlement Assignment or physical-settlement caller contracts solely to accommodate one algorithm.
 
+## Status of the requirement delta
+
+The `## ADDED Requirements` in this change's `specs/physical-provisioning/spec.md` use the standard openspec delta header — openspec's delta model has no separate "proposed but not yet decided" state, every change is a proposal until archived. That header does **not** mean this is implementation-ready: the "Non-Work / Deferred Decisions" list below and the open questions in `design.md` must be resolved in a dedicated design session before any of these requirements are implemented or this change is archived. Treat this change directory as a placeholder for problem framing, not a ready-to-build spec.
+
 ## Candidate directions
 
 Potential designs include:

--- a/openspec/changes/pools-6-multidimensional-fair-scheduling/proposal.md
+++ b/openspec/changes/pools-6-multidimensional-fair-scheduling/proposal.md
@@ -1,0 +1,76 @@
+# POOLS-6: Multidimensional Fair Scheduling Policies
+
+## Context
+
+POOLS-2 deliberately chooses a deterministic round-robin MVP. That policy is easy to explain and proves the scheduler/policy boundary, but it treats eligible pools and resources as equal line items. It does not account for heterogeneous reservation shapes, unequal pool capacity, consumer shares, utilization, topology, priority, or historical allocations.
+
+The earlier POOLS-2 draft used a maximum aggregate utilization by resource type and described it as DRF. That was misleading. Classical Dominant Resource Fairness allocates multiple dimensions among competing consumers and tracks each consumer's dominant share. Aggregating unrelated capacity rows across different physical resources neither proves that one concrete resource can satisfy a reservation nor establishes consumer fairness.
+
+POOLS-6 preserves the problem analysis and design questions needed to select a richer policy later without expanding POOLS-2.
+
+## Why
+
+Future domains may schedule requests with very different shapes: CPU and memory for VMs or pods, GPUs and accelerator memory for inference, indivisible bare-metal nodes, throughput and storage for object services, or provider-specific capabilities. Equal round-robin may be unfair to larger pools, ignore stranded capacity, and produce poor utilization.
+
+A richer scheduler must still preserve the durable properties established by POOLS-2: idempotent Capacity Settlement Assignments, deterministic tie-breaking, concrete candidate locality, atomic capacity claims, draining pool semantics, explicit-resource eligibility, and executor-neutral contracts.
+
+## Goals
+
+- Define multidimensional reservation and candidate capacity vectors.
+- Evaluate maintained external scheduler libraries against the existing policy protocol.
+- Define one or more fair or utilization-aware policies without changing caller contracts.
+- Distinguish pool balancing, concrete placement, and fairness among consumers.
+- Make policy decisions explainable and observable.
+- Preserve deterministic behavior under equal scores.
+- Prove policy generality by implementing a second policy beside round-robin.
+- Specify persistence, concurrency, simulation, and adversarial testing requirements.
+
+## Non-goals
+
+- Selecting a final fairness subject or algorithm in this placeholder change.
+- Replacing round-robin before a policy is specified and tested.
+- Moving provider-specific health, credentials, or execution checks into generic policy code.
+- Treating abstract aggregate capacity as proof that one concrete resource can fit a request.
+- Changing Capacity Settlement Assignment or physical-settlement caller contracts solely to accommodate one algorithm.
+
+## Candidate directions
+
+Potential designs include:
+
+- lowest projected dominant utilization on each concrete candidate;
+- capacity-weighted pool fairness followed by resource placement;
+- consumer-aware DRF using buyer, agreement, organization, queue, or workload-class shares;
+- policy composition where hard eligibility precedes quotas, fairness, placement, and deterministic tie-breaking;
+- external scheduler integration behind the `SettlementSchedulingPolicy` protocol.
+
+No candidate is selected by this change.
+
+## Risks and concerns
+
+- Dimensions may use incompatible units or represent indivisible resources.
+- Pool-level aggregation can hide that dimensions live on different physical resources.
+- A utilization policy can conflict with consumer fairness or operational spreading.
+- Historical accounting can make retries and recovery nondeterministic unless assignment state is durable.
+- Weights, quotas, priorities, and preemption can undermine intuitive fairness.
+- Topology and affinity can sharply reduce the candidate set and produce starvation.
+- External scheduler dependencies may bring worker, queue, or cluster-runtime assumptions larger than the policy boundary.
+- Explainability is required so operators can understand why a resource won or why no candidate fit.
+
+## Non-Work / Deferred Decisions
+
+This change records questions for a future design session; it does not answer them now.
+
+- What is the fairness subject: buyer, agreement, organization, queue, workload class, or another principal?
+- What is the fairness scope: provisioning domain, market, provider, compatible pool group, or global installation?
+- Which dimensions are first-class, what units do they use, and how are quantities normalized?
+- Are pools equal participants or weighted by total usable capacity?
+- Is the primary objective spreading, dominant-share fairness, utilization, bin packing, cost, or an ordered combination?
+- How are indivisible resources such as bare-metal nodes represented?
+- How is historical usage retained, decayed, and recovered after restart?
+- How do quotas, reservations, priorities, and preemption interact with fairness?
+- How are topology, affinity, anti-affinity, failure domains, and data locality represented?
+- When the fairest candidate cannot fit, what fallback ordering applies?
+- Do exact-resource requests affect fairness accounting even though they bypass policy choice?
+- What happens after provider failure: preserve assignment, explicitly invalidate it, or reschedule?
+- Which policy decisions and score components must be emitted for observability?
+- Can a maintained external library satisfy the contracts without importing an incompatible runtime model?

--- a/openspec/changes/pools-6-multidimensional-fair-scheduling/specs/physical-provisioning/spec.md
+++ b/openspec/changes/pools-6-multidimensional-fair-scheduling/specs/physical-provisioning/spec.md
@@ -1,10 +1,15 @@
 # Physical provisioning future delta
 
-## PROPOSED Requirements — not yet approved or implemented
+## ADDED Requirements
+
+> These requirements are provisional — see proposal.md's "Status of the
+> requirement delta" note. POOLS-6 must resolve the documented Non-Work
+> decisions in a dedicated design session before implementation or
+> archival.
 
 ### Requirement: Pluggable multidimensional policy
 
-A future physical-provisioning scheduler MAY support multidimensional scheduling policies behind the existing `SettlementSchedulingPolicy` boundary without changing Capacity Settlement Assignment identity or provider-facing settlement contracts.
+The `SettlementSchedulingPolicy` boundary SHALL remain capable of supporting a multidimensional scheduling policy without changing Capacity Settlement Assignment identity or provider-facing settlement contracts.
 
 #### Scenario: Second policy proves interface generality
 
@@ -27,4 +32,14 @@ A future multidimensional policy SHALL select only a concrete resource or explic
 
 A future fair policy SHALL define deterministic tie-breaking and produce an operator-safe explanation of eligibility, score inputs, fairness scope, and the selected candidate.
 
-> These requirements remain proposed. POOLS-6 must resolve the documented Non-Work decisions before approval or implementation.
+#### Scenario: Tie-break is deterministic
+
+- **GIVEN** two or more candidates with identical fairness scores
+- **WHEN** the policy selects among them
+- **THEN** the same input state always yields the same selected candidate.
+
+#### Scenario: Selection is explainable
+
+- **GIVEN** a completed policy selection or a policy failure to find a candidate
+- **WHEN** an operator inspects the decision
+- **THEN** the recorded explanation identifies which candidates were eligible, the score inputs considered, the fairness scope applied, and the resulting choice or reason for no choice.

--- a/openspec/changes/pools-6-multidimensional-fair-scheduling/specs/physical-provisioning/spec.md
+++ b/openspec/changes/pools-6-multidimensional-fair-scheduling/specs/physical-provisioning/spec.md
@@ -1,0 +1,30 @@
+# Physical provisioning future delta
+
+## PROPOSED Requirements — not yet approved or implemented
+
+### Requirement: Pluggable multidimensional policy
+
+A future physical-provisioning scheduler MAY support multidimensional scheduling policies behind the existing `SettlementSchedulingPolicy` boundary without changing Capacity Settlement Assignment identity or provider-facing settlement contracts.
+
+#### Scenario: Second policy proves interface generality
+
+- **GIVEN** deterministic round-robin and a future multidimensional policy
+- **WHEN** either policy is injected into the scheduler
+- **THEN** reservation validation, idempotency, eligibility, assignment persistence, and physical settlement use the same orchestration contracts.
+
+### Requirement: Concrete candidate fit precedes fairness
+
+A future multidimensional policy SHALL select only a concrete resource or explicitly modeled resource bundle that satisfies every required dimension.
+
+#### Scenario: Pool aggregates fit but no resource fits
+
+- **GIVEN** aggregate pool capacity sufficient across multiple unrelated resources
+- **AND** no one concrete candidate satisfies the reservation shape
+- **WHEN** scheduling is evaluated
+- **THEN** the pool is not treated as an eligible placement solely because its aggregate totals fit.
+
+### Requirement: Deterministic and explainable selection
+
+A future fair policy SHALL define deterministic tie-breaking and produce an operator-safe explanation of eligibility, score inputs, fairness scope, and the selected candidate.
+
+> These requirements remain proposed. POOLS-6 must resolve the documented Non-Work decisions before approval or implementation.

--- a/openspec/changes/pools-6-multidimensional-fair-scheduling/tasks.md
+++ b/openspec/changes/pools-6-multidimensional-fair-scheduling/tasks.md
@@ -1,0 +1,25 @@
+# POOLS-6 tasks
+
+## Design resolution
+
+- [ ] Confirm domain boundaries and whether VM and pod compute share a provisioning domain.
+- [ ] Choose the fairness subject and fairness scope.
+- [ ] Define multidimensional units, normalization, and concrete resource-bundle semantics.
+- [ ] Choose pool weighting and the precedence of fit, fairness, utilization, spreading, cost, and topology.
+- [ ] Specify indivisible resources, quotas, priorities, preemption, and starvation behavior.
+- [ ] Specify historical accounting, persistence, decay, restart recovery, and exact-resource accounting.
+- [ ] Specify provider-failure and explicit reassignment behavior.
+
+## Evaluation
+
+- [ ] Evaluate maintained external scheduler libraries against the policy protocol and operational constraints.
+- [ ] Compare lowest projected dominant utilization, capacity-weighted pool fairness, and consumer-aware DRF through simulations.
+- [ ] Define policy explanation, metrics, and debugging surfaces.
+
+## Implementation after design approval
+
+- [ ] Add multidimensional requirement and candidate contracts.
+- [ ] Implement a second policy beside round-robin to prove interface generality.
+- [ ] Persist fairness state transactionally with capacity claims and assignments.
+- [ ] Add simulation, concurrency, restart, starvation, and adversarial-shape tests.
+- [ ] Promote approved requirements into baseline OpenSpec and update architecture pointers only after behavior becomes current state.

--- a/openspec/specs/physical-provisioning/spec.md
+++ b/openspec/specs/physical-provisioning/spec.md
@@ -91,3 +91,9 @@ Shared storefront/provisioner DTOs, executor-neutral resource-pool models, and g
 - Executor-specific release, failed-release capacity retention, retry, and force release: `domains/vms/provisioning/service/tests/integration/test_bare_metal_leases_api.py`, `test_leases_api.py`, and `unit/services/test_ledger_lease_lifecycle.py`.
 
 `PhysicalSettlementScheduler`, `FulfillmentProvider`, and a durable mechanism-neutral settlement record are not implemented baseline contracts. Deployment relocation remains proposed in `market-platform-compute-30-extract-service`.
+
+## Capacity settlement lifecycle
+
+Physical provisioning distinguishes **Capacity Reservation → Capacity Settlement Assignment → Physical Settlement → Provisioned Resource / Active Workload**. Generic scheduling chooses an eligible Settlement Resource. Physical Settlement is provider-specific execution on that assigned resource. Provider-specific reachability, credentials, topology, and execution failures remain downstream of generic scheduling eligibility.
+
+The current scheduling policy is deterministic round-robin through a replaceable policy interface. Generic policy and orchestration code use resource kind, units, pool identity, and opaque attributes and do not import market-specific executor persistence models.

--- a/openspec/specs/resource-pool-management/spec.md
+++ b/openspec/specs/resource-pool-management/spec.md
@@ -100,3 +100,9 @@ Pool YAML import MUST treat the supplied definitions as authoritative, validate 
 - Pool persistence, provider validation, strict import, dry-run, idempotency, lifecycle, and provider replacement: `domains/vms/provisioning/service/src/tests/unit/services/test_resource_pool_service.py`.
 - Typed administrative API, default-pool invariant, canonical round trip, and host assignment: `domains/vms/provisioning/service/src/tests/integration/test_pools_api.py`.
 - Migration ordering, legacy host backfill, and schema-drift rejection: `domains/vms/provisioning/service/src/tests/unit/test_database.py`.
+
+## Scheduling membership and draining
+
+Every resource eligible for physical settlement belongs to exactly one Resource Pool. Zero memberships makes the resource unschedulable; multiple memberships misrepresent system capacity and are invalid configuration.
+
+Disabling a Resource Pool is a draining action. It blocks new Capacity Settlement Assignments to that pool but does not invalidate existing reservations, assignments, physical settlements, or active workloads, and those existing records do not prevent disablement.

--- a/openspec/specs/site-capacity/spec.md
+++ b/openspec/specs/site-capacity/spec.md
@@ -78,3 +78,9 @@ Capacity projection events MUST remain anonymous and versioned, while deal-scope
 - “Do not close on ignorance” reconciliation: `domains/vms/storefront/tests/unit/test_cli_publish_helpers.py`.
 
 Job-kind dispatch and deal-event routing across multiple storefront domains are not established by this capacity baseline; they remain proposed in `prove-multi-domain-capacity`.
+
+## Capacity settlement lifecycle
+
+A **Capacity Reservation** records accepted capacity, the agreement/deal relationship, requested shape or units, lifecycle state, and any hold expiry. A reservation is not itself a concrete provisioning decision.
+
+A **Capacity Settlement Assignment** is the idempotent scheduling decision that maps one unchanged Capacity Reservation to one concrete pooled Settlement Resource. Retrying assignment for the same unchanged reservation returns the existing decision rather than rerunning scheduling policy. An assignment alone does not imply that physical settlement succeeded or that a workload is active.

--- a/provisioning/compute/pyproject.toml
+++ b/provisioning/compute/pyproject.toml
@@ -1,11 +1,12 @@
 [project]
 name = "arkhai-compute-provisioning"
-version = "0.4.0"
+version = "0.5.0"
 license = "MIT"
 description = "Shared helpers for cross-domain compute provisioning services"
 requires-python = ">=3.12"
 dependencies = [
     "arkhai-kit-site>=0.2.0",
+    "arkhai-kit-resource-pools>=0.1.0",
     "httpx>=0.27",
     "pydantic>=2",
 ]
@@ -30,3 +31,4 @@ dev = [
 
 [tool.uv.sources]
 arkhai-kit-site = { path = "../../kit/site", editable = true }
+arkhai-kit-resource-pools = { path = "../../kit/resource-pools", editable = true }

--- a/provisioning/compute/src/compute_provisioning/__init__.py
+++ b/provisioning/compute/src/compute_provisioning/__init__.py
@@ -44,7 +44,19 @@ from .app import (
     build_compute_provisioning_app,
 )
 from .lifecycle import cancel_background_tasks, create_background_task
-from .physical_settlement import PhysicalSettlementRequest, SettlementResource
+from .physical_settlement import (
+    CapacityReservationExpiredError,
+    CapacitySettlementAssignment,
+    NoEligibleSettlementResourceError,
+    PhysicalSettlementError,
+    PhysicalSettlementRequest,
+    SettlementCandidate,
+    SettlementEntityNotFoundError,
+    SettlementRequestMismatchError,
+    SettlementRequirement,
+    SettlementResource,
+)
+from .scheduling import SettlementSchedulingPolicy
 from market_resource_pools import (
     PoolConfigHandler,
     PoolConfigValidationProblem,
@@ -112,8 +124,17 @@ __all__ = [
     "PoolUpdate",
     "PoolValidateResponse",
     "PoolValidationProblem",
+    "PhysicalSettlementError",
+    "SettlementEntityNotFoundError",
+    "SettlementRequestMismatchError",
+    "CapacityReservationExpiredError",
+    "NoEligibleSettlementResourceError",
     "PhysicalSettlementRequest",
+    "SettlementRequirement",
+    "SettlementCandidate",
     "SettlementResource",
+    "CapacitySettlementAssignment",
+    "SettlementSchedulingPolicy",
     "ResultEnvelope",
     "UnsupportedExecutorActionError",
     "contract_major",

--- a/provisioning/compute/src/compute_provisioning/__init__.py
+++ b/provisioning/compute/src/compute_provisioning/__init__.py
@@ -44,8 +44,10 @@ from .app import (
     build_compute_provisioning_app,
 )
 from .lifecycle import cancel_background_tasks, create_background_task
-from .pool_config_handler import PoolConfigHandler, PoolConfigValidationProblem
-from .pools import (
+from .physical_settlement import PhysicalSettlementRequest, SettlementResource
+from market_resource_pools import (
+    PoolConfigHandler,
+    PoolConfigValidationProblem,
     PoolCreate,
     PoolImportDiff,
     PoolImportRequest,
@@ -110,6 +112,8 @@ __all__ = [
     "PoolUpdate",
     "PoolValidateResponse",
     "PoolValidationProblem",
+    "PhysicalSettlementRequest",
+    "SettlementResource",
     "ResultEnvelope",
     "UnsupportedExecutorActionError",
     "contract_major",

--- a/provisioning/compute/src/compute_provisioning/physical_settlement.py
+++ b/provisioning/compute/src/compute_provisioning/physical_settlement.py
@@ -1,0 +1,53 @@
+"""Executor-neutral physical-settlement scheduling shapes.
+
+See openspec/changes/pools-2-physical-settlement-scheduler/design.md for
+the design behind PhysicalSettlementScheduler.select_resource(...), which
+consumes and returns these models.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class PhysicalSettlementRequest(BaseModel):
+    """What the scheduler needs to bind an allocation to a settlement resource.
+
+    Carries either fungible pool/capacity attributes (``pool_id``, or
+    neither field for "any eligible pool") or an explicit ``resource_id``
+    for a specific-resource opt-in listing — never both.
+    """
+
+    allocation_id: str = Field(description="Durable idempotency key for this binding.")
+    agreement_id: str = Field(description="The market agreement/deal this settlement serves.")
+    market: str = Field(description="Market domain identity, e.g. 'vms'.")
+    terms: dict[str, Any] = Field(default_factory=dict)
+    pool_id: str | None = Field(
+        default=None,
+        description="Restrict fungible selection to this pool. None means any eligible pool.",
+    )
+    resource_id: str | None = Field(
+        default=None,
+        description="Bind exactly this resource (specific-resource opt-in path).",
+    )
+
+    @model_validator(mode="after")
+    def _pool_and_resource_are_mutually_exclusive(self) -> "PhysicalSettlementRequest":
+        if self.pool_id is not None and self.resource_id is not None:
+            raise ValueError(
+                "pool_id and resource_id are mutually exclusive on a "
+                "PhysicalSettlementRequest"
+            )
+        return self
+
+
+class SettlementResource(BaseModel):
+    """The durable selected physical resource for one allocation's settlement."""
+
+    settlement_resource_id: str
+    pool_id: str
+    resource_kind: str
+    provider: str
+    attributes: dict[str, Any] = Field(default_factory=dict)

--- a/provisioning/compute/src/compute_provisioning/physical_settlement.py
+++ b/provisioning/compute/src/compute_provisioning/physical_settlement.py
@@ -1,53 +1,81 @@
-"""Executor-neutral physical-settlement scheduling shapes.
-
-See openspec/changes/pools-2-physical-settlement-scheduler/design.md for
-the design behind PhysicalSettlementScheduler.select_resource(...), which
-consumes and returns these models.
-"""
+"""Executor-neutral contracts for capacity settlement scheduling."""
 
 from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field
+
+
+class PhysicalSettlementError(Exception):
+    """Base error for settlement scheduling failures."""
+
+
+class SettlementEntityNotFoundError(PhysicalSettlementError):
+    """A referenced allocation, agreement, pool, or resource does not exist."""
+
+
+class SettlementRequestMismatchError(PhysicalSettlementError):
+    """Existing entities do not correspond to the supplied request."""
+
+
+class CapacityReservationExpiredError(PhysicalSettlementError):
+    """The referenced capacity reservation has expired."""
+
+
+class NoEligibleSettlementResourceError(PhysicalSettlementError):
+    """No enabled resource can satisfy the validated reservation."""
 
 
 class PhysicalSettlementRequest(BaseModel):
-    """What the scheduler needs to bind an allocation to a settlement resource.
+    """Request to create or retrieve one Capacity Settlement Assignment."""
 
-    Carries either fungible pool/capacity attributes (``pool_id``, or
-    neither field for "any eligible pool") or an explicit ``resource_id``
-    for a specific-resource opt-in listing — never both.
-    """
-
-    allocation_id: str = Field(description="Durable idempotency key for this binding.")
-    agreement_id: str = Field(description="The market agreement/deal this settlement serves.")
-    market: str = Field(description="Market domain identity, e.g. 'vms'.")
+    allocation_id: str = Field(description="Capacity Reservation identifier and idempotency key.")
+    agreement_id: str = Field(description="Agreement served by this settlement.")
+    market: str = Field(description="Market domain identity, for example 'vms'.")
     terms: dict[str, Any] = Field(default_factory=dict)
-    pool_id: str | None = Field(
-        default=None,
-        description="Restrict fungible selection to this pool. None means any eligible pool.",
-    )
     resource_id: str | None = Field(
         default=None,
-        description="Bind exactly this resource (specific-resource opt-in path).",
+        description=(
+            "Optional exact resource constraint. Explicit selection bypasses policy "
+            "choice, never eligibility validation."
+        ),
     )
 
-    @model_validator(mode="after")
-    def _pool_and_resource_are_mutually_exclusive(self) -> "PhysicalSettlementRequest":
-        if self.pool_id is not None and self.resource_id is not None:
-            raise ValueError(
-                "pool_id and resource_id are mutually exclusive on a "
-                "PhysicalSettlementRequest"
-            )
-        return self
+
+class SettlementRequirement(BaseModel):
+    """Generic capacity shape used to evaluate concrete candidates."""
+
+    resource_kind: str
+    units: int = Field(gt=0)
+    attributes: dict[str, Any] = Field(default_factory=dict)
+
+
+class SettlementCandidate(BaseModel):
+    """One concrete resource eligible for physical settlement evaluation."""
+
+    resource_id: str
+    pool_id: str
+    resource_kind: str
+    available_units: int
+    enabled: bool = True
+    provider: str
+    attributes: dict[str, Any] = Field(default_factory=dict)
 
 
 class SettlementResource(BaseModel):
-    """The durable selected physical resource for one allocation's settlement."""
+    """The selected physical resource in a Capacity Settlement Assignment."""
 
     settlement_resource_id: str
     pool_id: str
     resource_kind: str
     provider: str
     attributes: dict[str, Any] = Field(default_factory=dict)
+
+
+class CapacitySettlementAssignment(BaseModel):
+    """Idempotent allocation-to-resource scheduling decision."""
+
+    allocation_id: str
+    agreement_id: str
+    resource: SettlementResource

--- a/provisioning/compute/src/compute_provisioning/scheduling.py
+++ b/provisioning/compute/src/compute_provisioning/scheduling.py
@@ -1,0 +1,18 @@
+"""Replaceable policy contracts for capacity settlement scheduling."""
+
+from __future__ import annotations
+
+from typing import Protocol, Sequence
+
+from .physical_settlement import SettlementCandidate, SettlementRequirement
+
+
+class SettlementSchedulingPolicy(Protocol):
+    """Select one eligible concrete candidate without owning orchestration."""
+
+    def select(
+        self,
+        *,
+        requirement: SettlementRequirement,
+        candidates: Sequence[SettlementCandidate],
+    ) -> SettlementCandidate: ...

--- a/provisioning/compute/tests/unit/test_physical_settlement.py
+++ b/provisioning/compute/tests/unit/test_physical_settlement.py
@@ -1,51 +1,52 @@
-"""Unit tests for PhysicalSettlementRequest/SettlementResource shapes."""
+"""Unit tests for executor-neutral physical-settlement contracts."""
 
-from __future__ import annotations
+from compute_provisioning import (
+    CapacitySettlementAssignment,
+    PhysicalSettlementRequest,
+    SettlementCandidate,
+    SettlementRequirement,
+    SettlementResource,
+)
 
-import pytest
-from pydantic import ValidationError
 
-from compute_provisioning import PhysicalSettlementRequest, SettlementResource
-
-
-def test_minimal_request_defaults_to_any_eligible_pool():
+def test_request_keeps_optional_explicit_resource_constraint():
     request = PhysicalSettlementRequest(
-        allocation_id="alloc-1", agreement_id="agree-1", market="vms",
+        allocation_id="alloc-1",
+        agreement_id="agree-1",
+        market="vms",
+        resource_id="node-7",
     )
-    assert request.pool_id is None
-    assert request.resource_id is None
+    assert request.resource_id == "node-7"
     assert request.terms == {}
 
 
-def test_request_accepts_pool_id_alone():
-    request = PhysicalSettlementRequest(
-        allocation_id="alloc-1", agreement_id="agree-1", market="vms",
-        pool_id="hetzner-eu",
+def test_generic_requirement_and_candidate_are_market_neutral():
+    requirement = SettlementRequirement(
+        resource_kind="bare-metal-node",
+        units=1,
+        attributes={"architecture": "amd64"},
     )
-    assert request.pool_id == "hetzner-eu"
-
-
-def test_request_accepts_resource_id_alone():
-    request = PhysicalSettlementRequest(
-        allocation_id="alloc-1", agreement_id="agree-1", market="vms",
-        resource_id="kvm1",
+    candidate = SettlementCandidate(
+        resource_id="node-7",
+        pool_id="pool-a",
+        resource_kind="bare-metal-node",
+        available_units=1,
+        provider="redfish",
+        attributes={"architecture": "amd64"},
     )
-    assert request.resource_id == "kvm1"
+    assert candidate.resource_kind == requirement.resource_kind
 
 
-def test_pool_id_and_resource_id_are_mutually_exclusive():
-    with pytest.raises(ValidationError, match="mutually exclusive"):
-        PhysicalSettlementRequest(
-            allocation_id="alloc-1", agreement_id="agree-1", market="vms",
-            pool_id="hetzner-eu", resource_id="kvm1",
-        )
-
-
-def test_settlement_resource_defaults_empty_attributes():
+def test_capacity_settlement_assignment_wraps_selected_resource():
     resource = SettlementResource(
-        settlement_resource_id="kvm1",
-        pool_id="default",
-        resource_kind="compute.gpu",
-        provider="ansible",
+        settlement_resource_id="node-7",
+        pool_id="pool-a",
+        resource_kind="bare-metal-node",
+        provider="redfish",
     )
-    assert resource.attributes == {}
+    assignment = CapacitySettlementAssignment(
+        allocation_id="alloc-1",
+        agreement_id="agree-1",
+        resource=resource,
+    )
+    assert assignment.resource == resource

--- a/provisioning/compute/tests/unit/test_physical_settlement.py
+++ b/provisioning/compute/tests/unit/test_physical_settlement.py
@@ -1,0 +1,51 @@
+"""Unit tests for PhysicalSettlementRequest/SettlementResource shapes."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from compute_provisioning import PhysicalSettlementRequest, SettlementResource
+
+
+def test_minimal_request_defaults_to_any_eligible_pool():
+    request = PhysicalSettlementRequest(
+        allocation_id="alloc-1", agreement_id="agree-1", market="vms",
+    )
+    assert request.pool_id is None
+    assert request.resource_id is None
+    assert request.terms == {}
+
+
+def test_request_accepts_pool_id_alone():
+    request = PhysicalSettlementRequest(
+        allocation_id="alloc-1", agreement_id="agree-1", market="vms",
+        pool_id="hetzner-eu",
+    )
+    assert request.pool_id == "hetzner-eu"
+
+
+def test_request_accepts_resource_id_alone():
+    request = PhysicalSettlementRequest(
+        allocation_id="alloc-1", agreement_id="agree-1", market="vms",
+        resource_id="kvm1",
+    )
+    assert request.resource_id == "kvm1"
+
+
+def test_pool_id_and_resource_id_are_mutually_exclusive():
+    with pytest.raises(ValidationError, match="mutually exclusive"):
+        PhysicalSettlementRequest(
+            allocation_id="alloc-1", agreement_id="agree-1", market="vms",
+            pool_id="hetzner-eu", resource_id="kvm1",
+        )
+
+
+def test_settlement_resource_defaults_empty_attributes():
+    resource = SettlementResource(
+        settlement_resource_id="kvm1",
+        pool_id="default",
+        resource_kind="compute.gpu",
+        provider="ansible",
+    )
+    assert resource.attributes == {}


### PR DESCRIPTION
## POOLS-2: Capacity Settlement Scheduler

### Summary

Introduces an explicit, idempotent scheduling boundary between an accepted
capacity reservation and provider-specific physical settlement. Previously,
physical placement was either caller-supplied (`vm_target`) or a static
config fallback (`default_vm_host`) — this closes that gap with a real
scheduler, while relocating `ResourcePoolService` out of the VM domain so
it (and the scheduler) can be executor-neutral.

Full design rationale: `openspec/changes/pools-2-physical-settlement-scheduler/`
(`proposal.md`, `design.md`). Deferred fairness work split out to
`openspec/changes/pools-6-multidimensional-fair-scheduling/`.

### What changed

**New package — `kit/resource-pools`**
`ResourcePoolService`, the `ResourcePool` ORM model, and the pool wire
contracts moved out of `domains/vms/provisioning/service` into their own
kit package (`arkhai-kit-resource-pools`), matching how `CapacityLedgerService`
already lives in `kit/site`. No VM/Ansible-specific logic was in the
service to begin with — only a default-handler import fallback, which is
now a required constructor argument instead.

**Corrected pool-disable behavior**
The `default` pool can now be disabled (excluded from scheduling) without
ceasing to exist or ceasing to be the fallback for hosts/create-requests
that omit a pool ID. Previously, disabling `default` was unconditionally
rejected — a behavior with no real justification once pools can be
scheduled around.

**Capacity reservation watchdog**
`CapacityLedgerService.expire_due_holds()` (new public method) plus
`CapacityReservationWatchdog`, mirroring the existing `LeaseWatchdog`
pattern, so an uncommitted hold on an otherwise-idle site is reclaimed
without depending on another request touching the ledger.

**`PhysicalSettlementScheduler`**
New executor-neutral scheduler (`domains/vms/provisioning/service`) that:
- validates the referenced capacity reservation (exists, active, not
  expired, agreement/market/terms match) before scheduling anything;
- is idempotent by `allocation_id` — a retry returns the existing
  assignment; a retry with a *conflicting* explicit `resource_id` fails
  rather than silently returning the old one;
- builds eligible candidates from pool membership and available capacity
  without depending on the VM `Host` ORM;
- delegates the actual pick to a pluggable `SettlementSchedulingPolicy`
  (new protocol in `arkhai-compute-provisioning`), currently a
  deterministic round-robin over sorted eligible pools then sorted
  eligible resources;
- applies full eligibility checks to explicit `resource_id` requests too —
  an explicit resource in a disabled pool is still rejected.

**Pool disablement is a draining operation, not a blocked operation**
Disabling a pool immediately excludes it from new scheduling but does not
require terminating or invalidating existing assignments/workloads on it.
(An earlier draft added an active-binding guard that blocked disabling a
pool with a live assignment; that was deliberately removed in favor of
this simpler model — see `design.md`'s "Alternatives considered.")

**DRF split out to POOLS-6**
The original design's "bottleneck-normalized least-loaded" pool selection
was a mischaracterization of Dominant Resource Fairness (pool-load
balancing, not fairness among competing consumers) and doesn't cleanly
map onto the site ledger's actual data model. Rather than force it into
this change, it's deferred to `pools-6-multidimensional-fair-scheduling`
as an open design problem, with the current round-robin policy proving
the policy boundary is swappable without touching caller contracts.

### Non-goals (this change)

- Wiring the scheduler into a caller-facing settlement endpoint (`pools-3`).
- `FulfillmentProvider` execution / durable `SettlementRecord` persistence
  (`pools-3`).
- Storefront-side capacity-boundary changes (`pools-4`).
- Fair/multidimensional scheduling policy (`pools-6`).
- Buyer-selected pool constraints (only "any eligible pool" or "this exact
  resource" are supported).

### Known intermediate-state limitations

Documented explicitly in the `site-capacity` delta rather than left
implicit:
- Capacity Settlement Assignments and round-robin cursors are
  **process-local** (in-memory) — idempotency holds within one running
  service instance, not across a restart or across multiple instances.
  Durable persistence is `pools-3` scope.
- The concrete resource capacity claim still happens at initial
  reservation (pre-scheduling); the scheduler credits the reservation's
  own held units back during eligibility evaluation as an interim
  approximation. Moving the claim into the assignment transaction itself
  is follow-on work.

### Follow-up (tracked in `pools-2`'s `tasks.md` / not blocking this PR)

- Persist Capacity Settlement Assignments and round-robin cursors
  transactionally; move the concrete capacity claim into that transaction.
- Enforce exactly-one-pool resource membership at the database layer.
- Wire the scheduler into a real settlement caller path.
- Multi-process concurrency / restart integration tests for durable
  idempotency.
- `docs/development/ARCHITECTURE.md` still needs a pass for the new
  vocabulary (Capacity Settlement Assignment, Provisioned Resource /
  Active Workload) — not yet done.