### PR TITLE
VmLease table and model deprecation

### DIFF
--- a/domains/vms/provisioning/service/src/db/migrations.py
+++ b/domains/vms/provisioning/service/src/db/migrations.py
@@ -177,7 +177,45 @@ def _migrate_hosts_public_host(engine: Engine) -> None:
 
 
 def _migrate_vm_leases_table(engine: Engine) -> None:
-    Base.metadata.tables["vm_leases"].create(bind=engine, checkfirst=True)
+    """Historical step, kept for correct replay against any DB still
+    catching up from scratch. vm_leases was dropped for good by
+    ``_migrate_drop_vm_leases_table`` below — this only recreates a table
+    that migration then removes. Defined via raw SQL rather than
+    ``Base.metadata.tables["vm_leases"]`` because the VmLease ORM model
+    (which this table backed) was removed once the table itself was
+    confirmed dead code; migration history must stay replayable without
+    depending on a model that no longer exists.
+    """
+    if engine.dialect.name == "postgresql":
+        id_default = "(gen_random_uuid()::text)"
+    else:
+        id_default = "(lower(hex(randomblob(16))))"
+    with engine.begin() as connection:
+        connection.execute(text(
+            f"""
+            CREATE TABLE IF NOT EXISTS vm_leases (
+                id VARCHAR PRIMARY KEY DEFAULT {id_default},
+                resource_id VARCHAR NOT NULL,
+                escrow_uid VARCHAR NOT NULL UNIQUE,
+                vm_host VARCHAR NOT NULL,
+                vm_target VARCHAR NOT NULL,
+                lease_start_utc TIMESTAMP,
+                lease_end_utc TIMESTAMP NOT NULL,
+                status VARCHAR NOT NULL DEFAULT 'pending',
+                create_job_id VARCHAR,
+                vm_remove_job_id VARCHAR,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+            )
+            """
+        ))
+    for index_name, sql in (
+        ("ix_vm_leases_resource_id", "CREATE INDEX IF NOT EXISTS ix_vm_leases_resource_id ON vm_leases (resource_id)"),
+        ("ix_vm_leases_escrow_uid", "CREATE INDEX IF NOT EXISTS ix_vm_leases_escrow_uid ON vm_leases (escrow_uid)"),
+        ("ix_vm_leases_lease_end_utc", "CREATE INDEX IF NOT EXISTS ix_vm_leases_lease_end_utc ON vm_leases (lease_end_utc)"),
+        ("ix_vm_leases_status", "CREATE INDEX IF NOT EXISTS ix_vm_leases_status ON vm_leases (status)"),
+    ):
+        _create_index_if_missing(engine, index_name, sql)
 
 
 def _migrate_vm_leases_allocation_id(engine: Engine) -> None:
@@ -189,6 +227,22 @@ def _migrate_vm_leases_allocation_id(engine: Engine) -> None:
             "CREATE INDEX IF NOT EXISTS ix_vm_leases_allocation_id "
             "ON vm_leases (allocation_id)",
         )
+
+
+def _migrate_drop_vm_leases_table(engine: Engine) -> None:
+    """Drop vm_leases for good.
+
+    Confirmed dead: no code anywhere in this repository ever constructs a
+    VmLease row (the ORM model backing this table has been removed —
+    db/models.py). The live lease watchdog operates entirely through
+    SiteAllocation (market_site.db) instead. This is a genuine DROP, not a
+    disable/soft-delete — there is no data to preserve (the table has
+    always been empty in practice) and no application-level FK references
+    it (VmLease.resource_id was always an unvalidated TEXT column, per its
+    own former docstring).
+    """
+    with engine.begin() as connection:
+        connection.execute(text("DROP TABLE IF EXISTS vm_leases"))
 
 
 def _migrate_site_allocations_executor_fields(engine: Engine) -> None:
@@ -306,5 +360,9 @@ _MIGRATIONS: tuple[Migration, ...] = (
     Migration(
         "20260713_002_resource_pools_and_hosts_pool_id",
         _migrate_resource_pools_and_hosts_pool_id,
+    ),
+    Migration(
+        "20260718_001_drop_vm_leases_table",
+        _migrate_drop_vm_leases_table,
     ),
 )

--- a/domains/vms/provisioning/service/src/db/models.py
+++ b/domains/vms/provisioning/service/src/db/models.py
@@ -22,27 +22,6 @@ class CredentialRole(str, enum.Enum):
     tenant = "tenant"
 
 
-class LeaseStatus(str, enum.Enum):
-    """Lifecycle states for a VM lease tracked in the vm_leases table.
-
-    pending   — lease_start_utc is in the future; VM may not yet be running.
-    active    — lease is running; lease_end_utc is in the future.
-    releasing — lease_end_utc has passed; watchdog submitted a vm_remove job to
-                confirm VM cleanup and is waiting for it to complete before
-                releasing the storefront resource.
-    released       — vm_remove succeeded and capacity is available again.
-    release_failed — vm_remove failed/timed out; capacity remains held.
-    unmanaged      — lifecycle oversight released; admin cleanup is required.
-    """
-
-    pending        = "pending"
-    active         = "active"
-    releasing      = "releasing"
-    released       = "released"
-    release_failed = "release_failed"
-    unmanaged      = "unmanaged"
-
-
 class AnsibleJob(Base):
     __tablename__ = "ansible_jobs"
     __table_args__ = (
@@ -196,71 +175,3 @@ from market_site.db import (  # noqa: F401
     SiteAllocation,
     SiteResource,
 )
-
-
-class VmLease(Base):
-    """Tracks active VM leases so the LeaseWatchdog can release storefront
-    resources when leases expire — replacing the storefront's polling pattern.
-
-    resource_id:
-        The storefront-assigned resource identifier (e.g. 'compute-kvm1-001').
-        Stored as unvalidated TEXT; the provisioning service has no resources
-        table, so no FK constraint is possible. Application-level FK enforced
-        by the storefront (caller).
-
-    escrow_uid:
-        On-chain escrow UID from the deal. Unique per lease — one deal produces
-        exactly one lease. Used for recovery queries and idempotency.
-
-    vm_host / vm_target:
-        KVM host alias and libvirt domain name. Used when submitting vm_remove jobs.
-
-    lease_start_utc / lease_end_utc:
-        Lease window boundaries in UTC. lease_start_utc is nullable (None means
-        "starts immediately on creation"). The watchdog acts when
-        lease_end_utc < now AND status IN (active, pending).
-
-    status:
-        LeaseStatus enum value. Transitions:
-          pending  → active    (when lease_start_utc passes or is None at creation)
-          active   → releasing (when lease_end_utc passes, watchdog submits vm_remove job)
-          releasing→ released       (vm_remove job succeeds)
-          releasing→ release_failed (vm_remove fails or times out)
-          active   → unmanaged      (operator releases lifecycle oversight)
-
-    create_job_id:
-        Provisioning job_id of the VM creation job. Allows tracing from lease
-        back to the original job that produced the VM.
-
-    vm_remove_job_id:
-        Provisioning job_id for the most recent vm_remove Ansible job submitted by
-        the watchdog. Nullable — only set during the 'releasing' phase. Allows
-        operators to query ``GET /api/v1/jobs/{vm_remove_job_id}`` for details.
-    """
-
-    __tablename__ = "vm_leases"
-
-    id = Column(
-        String, primary_key=True, default=lambda: str(uuid.uuid4())
-    )
-    resource_id = Column(String, nullable=False, index=True)
-    allocation_id = Column(String, nullable=True, index=True)
-    escrow_uid = Column(String, nullable=False, unique=True, index=True)
-    vm_host = Column(String, nullable=False)
-    vm_target = Column(String, nullable=False)
-    lease_start_utc = Column(DateTime(timezone=True), nullable=True)
-    lease_end_utc = Column(DateTime(timezone=True), nullable=False, index=True)
-    status = Column(
-        String, nullable=False, default=LeaseStatus.pending.value, index=True
-    )
-    create_job_id = Column(String, nullable=True)
-    vm_remove_job_id = Column(String, nullable=True)
-    created_at = Column(
-        DateTime(timezone=True), server_default=func.now(), nullable=False
-    )
-    updated_at = Column(
-        DateTime(timezone=True),
-        server_default=func.now(),
-        onupdate=func.now(),
-        nullable=False,
-    )

--- a/domains/vms/provisioning/service/src/tests/unit/services/test_ledger_lease_lifecycle.py
+++ b/domains/vms/provisioning/service/src/tests/unit/services/test_ledger_lease_lifecycle.py
@@ -1,10 +1,11 @@
 """Watchdog over ledger allocations: local release + deal event, no PATCH.
 
-The legacy vm_leases leg keeps its own tests
-(test_lease_lifecycle_service.py); these cover the merged-row leg added
-for remote-capacity mode — release happens in the ledger's local
-transaction, the owning storefront gets a point-to-point
-capacity-released event, and the resource PATCH callback never fires.
+These cover the SiteAllocation-backed lease lifecycle: release happens in
+the ledger's local transaction, the owning storefront gets a
+point-to-point capacity-released event, and the resource PATCH callback
+never fires. (The legacy vm_leases table/model this superseded — and its
+own now-removed test file — were confirmed dead and cleaned up
+separately; see db/models.py and db/migrations.py.)
 """
 
 from __future__ import annotations

--- a/domains/vms/provisioning/service/src/tests/unit/test_database.py
+++ b/domains/vms/provisioning/service/src/tests/unit/test_database.py
@@ -87,9 +87,6 @@ def test_run_migrations_applies_versioned_migrations_to_old_sqlite_schema():
         column["name"] for column in inspector.get_columns("ansible_jobs")
     }
     host_columns = {column["name"] for column in inspector.get_columns("hosts")}
-    lease_columns = {
-        column["name"] for column in inspector.get_columns("vm_leases")
-    }
     allocation_columns = {
         column["name"] for column in inspector.get_columns("site_allocations")
     }
@@ -104,8 +101,12 @@ def test_run_migrations_applies_versioned_migrations_to_old_sqlite_schema():
         "idempotency_key",
     }.issubset(ansible_columns)
     assert "public_host" in host_columns
-    assert "vm_leases" in inspector.get_table_names()
-    assert "allocation_id" in lease_columns
+    # vm_leases is created by an early migration and dropped by the final
+    # one (20260718_001_drop_vm_leases_table) — dead table, superseded by
+    # site_allocations. Both migration steps stay in history (append-only)
+    # so replay against any pre-existing DB state is correct, but the
+    # end state after a full run has no vm_leases table.
+    assert "vm_leases" not in inspector.get_table_names()
     assert {
         "executor_kind",
         "executor_target",
@@ -159,6 +160,7 @@ def test_run_migrations_applies_versioned_migrations_to_old_sqlite_schema():
         "20260707_001_site_allocations_executor_fields",
         "20260713_001_ansible_jobs_contract_fields",
         "20260713_002_resource_pools_and_hosts_pool_id",
+        "20260718_001_drop_vm_leases_table",
     }
 
 
@@ -174,9 +176,6 @@ def test_run_migrations_is_idempotent():
         column["name"] for column in inspector.get_columns("ansible_jobs")
     ]
     host_columns = [column["name"] for column in inspector.get_columns("hosts")]
-    lease_columns = [
-        column["name"] for column in inspector.get_columns("vm_leases")
-    ]
     allocation_columns = [
         column["name"] for column in inspector.get_columns("site_allocations")
     ]
@@ -190,7 +189,7 @@ def test_run_migrations_is_idempotent():
     assert ansible_columns.count("idempotency_key") == 1
     assert host_columns.count("public_host") == 1
     assert host_columns.count("pool_id") == 1
-    assert lease_columns.count("allocation_id") == 1
+    assert "vm_leases" not in inspector.get_table_names()
     assert allocation_columns.count("executor_kind") == 1
     assert allocation_columns.count("executor_target") == 1
     assert allocation_columns.count("release_job_id") == 1
@@ -205,7 +204,7 @@ def test_run_migrations_is_idempotent():
         migration_count = connection.execute(
             text("SELECT COUNT(*) FROM schema_migrations")
         ).scalar_one()
-    assert migration_count == 7
+    assert migration_count == 8
 
 
 # ---------------------------------------------------------------------------
@@ -231,7 +230,7 @@ class TestCheckSchemaVersion:
         with engine.begin() as connection:
             connection.execute(text(
                 "DELETE FROM schema_migrations WHERE id = "
-                "'20260713_002_resource_pools_and_hosts_pool_id'"
+                "'20260718_001_drop_vm_leases_table'"
             ))
         with pytest.raises(SchemaDriftError):
             check_schema_version(engine)

--- a/openspec/changes/market-platform-compute-30-extract-service/proposal.md
+++ b/openspec/changes/market-platform-compute-30-extract-service/proposal.md
@@ -44,21 +44,27 @@ It never reached its activation condition, and this change already claimed
 ownership of resolving its package-boundary question, so its scope is
 folded in here rather than tracked in two places. Concretely:
 
-- **Open decision, carried forward unresolved:** whether
-  `PhysicalSettlementScheduler` (`domains/vms/provisioning/service`,
-  VM-service-local), `FulfillmentProvider`/`ProviderRegistry`
-  (`kit/resource-pools`), and the `SettlementRecord`/settlement-resource
-  shapes they operate on should consolidate into `compute_provisioning`
-  once this extraction lands, or stay split the way they are today.
+- **Resolved by `pools-7-storefront-fulfillment-cutover`'s design review
+  (2026-07-17), ahead of this change's own extraction work:**
+  `PhysicalSettlementScheduler` and `DeterministicRoundRobinPolicy` move
+  from VM-service-local code into `compute_provisioning` — not into
+  `kit/resource-pools`, which would close a circular dependency
+  (`compute_provisioning` already depends on `kit/resource-pools`; the
+  scheduler needs real runtime imports from `compute_provisioning`'s
+  settlement types, unlike `FulfillmentProvider`'s string-quoted forward
+  references). `FulfillmentProvider`/`ProviderRegistry`/error taxonomy
+  remain in `kit/resource-pools`, per `pools-3`'s original placement.
   `pools-2`'s scheduling/request contracts (`PhysicalSettlementRequest`,
   `SettlementResource`, `SettlementCandidate`, `SettlementRequirement`,
-  `SettlementSchedulingPolicy`) already live in `compute_provisioning`;
-  `pools-3`'s `FulfillmentProvider`/`ProviderRegistry`/error taxonomy live
-  in `kit/resource-pools` instead — a deliberate override of POOLS-5's gate
-  made during `pools-3` (see that change's `design.md`, "Domain-neutral
-  contracts vs. domain-specific payloads"). This proposal's task list (§1)
-  should reconcile that split as part of "Verify Prerequisites and Current
-  Ownership," not treat it as pre-decided.
+  `SettlementSchedulingPolicy`) already lived in `compute_provisioning`
+  before this. See `pools-7`'s `design.md`, "`PhysicalSettlementScheduler`
+  and `DeterministicRoundRobinPolicy` move to `compute_provisioning`."
+  This is the same kind of narrow, deliberate override of waiting for this
+  change's activation that `pools-3` already made once for
+  `FulfillmentProvider`/`ProviderRegistry` — resolving where a class lives
+  is not this change's service-extraction scope, and this proposal's task
+  list (§1) should verify the moved location during "Verify Prerequisites
+  and Current Ownership" rather than treat it as still open.
 - **Concrete, verified, gate-independent finding:** `provisioning/compute/
   src/compute_provisioning/pools.py` and `pool_config_handler.py` are
   byte-identical duplicates of the files in `kit/resource-pools/src/

--- a/openspec/changes/pools-6-multidimensional-fair-scheduling/proposal.md
+++ b/openspec/changes/pools-6-multidimensional-fair-scheduling/proposal.md
@@ -33,6 +33,38 @@ A richer scheduler must still preserve the durable properties established by POO
 - Treating abstract aggregate capacity as proof that one concrete resource can fit a request.
 - Changing Capacity Settlement Assignment or physical-settlement caller contracts solely to accommodate one algorithm.
 
+## Concrete, currently-unenforced gap (found during POOLS-7 design review, 2026-07-17)
+
+While designing `pools-7-storefront-fulfillment-cutover`'s reservation/
+scheduling retrofit, we confirmed this change's abstract problem
+statement has a concrete, currently-live instance, not just a future
+risk: **`Host` (`domains/vms/provisioning/service/src/db/models.py`) has
+no memory, disk, or vCPU capacity field — only `gpu_count`.** Reservation
+admission (`kit/site/ledger.py`) can therefore correctly bin-pack on GPU
+count against real hosts, but nothing in the capacity layer verifies a
+negotiated shape's memory/disk/vCPU actually fits any physical host
+before a Capacity Reservation is admitted. `VmFulfillmentRequirements`
+(`pools-3`) carries these fields, but only at fulfillment time — downstream
+of the point where admission has already committed to a reservation.
+
+Net effect: **a Capacity Reservation can be admitted today for a shape no
+physical machine can serve**, with the mismatch only surfacing later, at
+fulfillment or scheduling time, as an unexplained failure rather than a
+clean admission-time rejection. `pools-7` treats resolving this as a
+prerequisite it consumes from this change, not something it re-derives
+piecemeal (e.g. adding an ad hoc memory column to `Host` without going
+through the dimension-normalization questions below) — see `pools-7`'s
+`design.md`, "Dependency on POOLS-6."
+
+This is offered as a concrete, scoped starting point for design work on
+this change — unlike the rest of this document, which is deliberately
+abstract and names no selected direction. It does not itself answer the
+"Non-Work / Deferred Decisions" questions below (what dimensions are
+first-class, how units normalize, whether pools are weighted, etc.); it
+just establishes that at minimum, VM memory/disk/vCPU must become
+first-class, admission-time-checked dimensions before `pools-7`'s
+reservation-admission path can be considered correct.
+
 ## Status of the requirement delta
 
 The `## ADDED Requirements` in this change's `specs/physical-provisioning/spec.md` use the standard openspec delta header — openspec's delta model has no separate "proposed but not yet decided" state, every change is a proposal until archived. That header does **not** mean this is implementation-ready: the "Non-Work / Deferred Decisions" list below and the open questions in `design.md` must be resolved in a dedicated design session before any of these requirements are implemented or this change is archived. Treat this change directory as a placeholder for problem framing, not a ready-to-build spec.

--- a/openspec/changes/pools-7-storefront-fulfillment-cutover/design.md
+++ b/openspec/changes/pools-7-storefront-fulfillment-cutover/design.md
@@ -538,3 +538,70 @@ to `reserve()` — never enforced by the provisioning service itself
 ledger capability is needed, only a place for the operator to express a
 preference and a storefront willing to read it). Left for planning to
 schedule, not required by POOLS-7's first pass.
+
+## Commit <-> async-dispatch failure window: resolved (design review continued, 2026-07-17)
+
+**Resolved: Option 1 (durable `dispatch_pending` state + startup recovery
+sweep), not Option 2 (separate outbox table).** This was previously left
+open pending verification of a specific assumption: that Option 1 is
+only safe if the underlying provider's job-submission path is idempotent
+on a deterministic key. That assumption did not hold as found, but the
+fix needed to make it hold is small, so Option 1 stands once the fix is
+in.
+
+**Confirmed gap (by inspection, not assumed):** `AnsibleJobService.submit()`
+already has a real, tested idempotency mechanism — it dedupes on
+`(allocation_id, action_kind, idempotency_key)` via a DB uniqueness
+constraint (`uq_ansible_jobs_contract_idempotency`), including correct
+handling of the concurrent-race case (catches the `IntegrityError` from
+a racing duplicate insert and returns the existing job rather than
+erroring). But this path only activates `if contract is not None`.
+`AnsibleFulfillmentProvider.create()` and `.teardown()`
+(`services/ansible_fulfillment_provider.py`) both call
+`self._job_service.submit(params, self._job_queue_provider())` with no
+`contract` argument — so this dedup is bypassed entirely on the
+fulfillment path today. Every call, retry or not, gets a fresh
+`job_id = uuid4()` and inserts a new `AnsibleJob` row. A recovery sweep
+naively retrying `create()` on a `dispatch_pending` `SettlementRecord`
+would therefore genuinely double-dispatch a real `vm_create`/`vm_remove`
+job, not safely no-op.
+
+**Resolved fix:** `AnsibleFulfillmentProvider.create()`/`.teardown()`
+construct an `ExecutorActionEnvelope` contract and pass it to
+`job_service.submit()`, with `idempotency_key=f"{allocation_id}:create"`
+/ `f"{allocation_id}:teardown"` — reusing the existing, already-migrated,
+already-tested-elsewhere mechanism (the storefront's current direct-dispatch
+path already builds equivalent keys) rather than introducing a new one.
+See `specs/physical-provisioning/spec.md`'s new "Deterministic provider
+dispatch idempotency" requirement for the normative statement of this.
+
+With that fix in place, the recovery sweep is:
+
+```python
+# Provisioning service startup, alongside the existing schema-drift check
+for record in db.query(SettlementRecord).filter_by(
+    state=SettlementRecordState.dispatch_pending.value
+):
+    # Safe to retry unconditionally: submit() with a contract either
+    # returns the original job (crashed after the DB write, before or
+    # during the provider call) or genuinely submits it for the first
+    # time (crashed before ever calling the provider). Either way,
+    # exactly one AnsibleJob is ever dispatched for this
+    # allocation_id/action_kind pair.
+    await fulfillment_service.create(record.to_request(), record.to_settlement_resource())
+```
+
+This closes the dispatch half of the failure window (did the provider
+call actually happen). The narrower remaining window — the provider call
+succeeded but the follow-up DB write recording `state="dispatching"` and
+the returned job id fails — is closed by the same sweep: a record stuck
+at `dispatch_pending` whose retried `create()` call finds the deduped
+existing job via the uniqueness constraint and simply needs its
+`provider_metadata`/`state` written correctly, which `FulfillmentService.create()`
+already does on any call, first or retried.
+
+Option 2 (a separate outbox table with a consuming worker) is not
+pursued: it would solve a problem this fix closes more cheaply by
+finishing the wiring of a dedup mechanism that already exists in this
+codebase, without changing `create()`'s synchronous-with-side-effect API
+shape.

--- a/openspec/changes/pools-7-storefront-fulfillment-cutover/design.md
+++ b/openspec/changes/pools-7-storefront-fulfillment-cutover/design.md
@@ -147,15 +147,18 @@ wired.
   `compute_provisioning`); `compute-30`'s own proposal has been updated
   to match.
 - **Operator listing-mode hints via `ResourcePool.policy_tags`** —
-  **RESOLVED, see "Listing-mode hint consumption" below.** The channel
-  question this bullet originally left open (how a storefront learns a
-  pool's `policy_tags` across the service boundary) is answered by
-  `CapacityProjection` (this file's "`SiteResource` is retired" section):
-  the pull-based pool mirror carries `policy_tags` along for free, no new
-  channel needed. The `_eligible_candidates`/`SiteResource.attributes.pool_id`
-  sync gap this bullet also raised is separately resolved by the same
-  section — `site_resource_pools` is now derived from `hosts`/
-  `resource_pools`, not storefront-pushed.
+  **designed, then SPLIT OUT to `pools-8-capacity-projection-and-listing-hints`
+  along with `CapacityProjection`** (see "Scope split: `CapacityProjection`
+  and hints move to `pools-8`" below) — not resolved in this change. The
+  channel question this bullet originally left open (how a storefront
+  learns a pool's `policy_tags` across the service boundary) was answered
+  during this review by `CapacityProjection`: the pull-based pool mirror
+  carries `policy_tags` along for free, no new channel needed — but the
+  design itself now lives in `pools-8`, not here. The
+  `_eligible_candidates`/`SiteResource.attributes.pool_id` sync gap this
+  bullet also raised IS resolved in this change (unaffected by the scope
+  split) — see "`SiteResource` is retired," below: `site_resource_pools`
+  is now derived from `hosts`/`resource_pools`, not storefront-pushed.
 
 ## Accepted provider configuration
 
@@ -209,15 +212,11 @@ Resolved shape:
   up front; the scheduler reassigns among *equally eligible* resources),
   not Option B (reserve against a pool-level aggregate with no concrete
   resource until scheduling) from this change's earlier draft.
-- **`CapacityProjection`** (storefront-side, new) — the storefront's
-  read-only, pull-based mirror of every connected provisioning service's
-  pool/capacity state (`GET /api/v1/pools`, which already exists and is
-  already reachable — the storefront already holds the admin key for
-  each configured site). This is the only place aggregation across hosts
-  happens, and it is explicitly advisory/display-only (pricing, listing
-  publication) — never the thing admission control checks against. Keyed
-  by `(site, pool_id)`, since pool IDs are only unique per provisioning
-  service.
+- **`CapacityProjection`** (storefront-side) — **split out of this
+  change, see "Scope split: CapacityProjection and hints move to
+  `pools-8`" below.** Briefly: the storefront's read-only mirror of every
+  connected provisioning service's pool/capacity state, for
+  pricing/listing display only, never for admission.
 - **Physical Resource** (vocabulary term, unchanged) — already used
   across kit with per-domain implementations; no change needed.
 
@@ -367,9 +366,22 @@ for the same reason).
 ```python
 class SettlementRecordState(str, enum.Enum):
     assigned         = "assigned"          # scheduler picked a resource,
-                                            # no dispatch yet — the ONLY
-                                            # state in which the row may
-                                            # still be re-selected/mutated
+                                            # no dispatch yet. May persist
+                                            # for a real, potentially long
+                                            # window (see "Expected time
+                                            # between scheduling and
+                                            # dispatch" below) — but is NOT
+                                            # mutable: a repeat
+                                            # select_resource call for this
+                                            # allocation_id is an ordinary
+                                            # idempotent-retry-or-conflict
+                                            # check, same shape as
+                                            # FulfillmentService.create's.
+                                            # See "Requirements change under
+                                            # negotiation" below for how a
+                                            # changed shape is actually
+                                            # handled (a NEW allocation_id,
+                                            # never mutation of this one).
     dispatch_pending = "dispatch_pending"  # about to call provider.create();
                                             # written durably BEFORE the
                                             # call, for crash recovery
@@ -380,11 +392,17 @@ class SettlementRecordState(str, enum.Enum):
     active           = "active"            # provider reports succeeded
     failed           = "failed"            # validation rejected, or
                                             # provider reports failed
+    teardown_dispatch_pending = "teardown_dispatch_pending"  # about to
+                                            # call provider.teardown();
+                                            # written durably BEFORE the
+                                            # call — teardown's analogue of
+                                            # dispatch_pending, same
+                                            # recovery-sweep treatment
     tearing_down     = "tearing_down"
     torn_down        = "torn_down"
     teardown_failed  = "teardown_failed"
     abandoned        = "abandoned"         # reservation expired/released/
-                                            # changed while still
+                                            # was superseded while still
                                             # "assigned" — no physical work
                                             # was ever dispatched. Terminal,
                                             # not re-enterable: a rejected
@@ -410,9 +428,11 @@ class SettlementRecord(Base):
     settlement_resource_id = Column(String, nullable=False)
     provider = Column(String, nullable=False)
     requirements = Column(JSON, nullable=False)   # for equivalence checks;
-                                                    # mutable while state=="assigned"
-                                                    # (negotiation may still change
-                                                    # requirements before dispatch)
+                                                    # IMMUTABLE once written —
+                                                    # a changed shape gets a
+                                                    # new allocation_id, see
+                                                    # "Requirements change
+                                                    # under negotiation"
     provider_metadata = Column(JSON, nullable=False, default=dict)
     teardown_provider_metadata = Column(JSON, nullable=True)
     state = Column(String, nullable=False, default=SettlementRecordState.assigned.value)
@@ -420,36 +440,39 @@ class SettlementRecord(Base):
     updated_at = Column(DateTime, ...)
 ```
 
-### Two different idempotency rules depending on `state`
+### `select_resource` idempotency is uniform — no state-dependent mutation branch
 
-`select_resource`'s existing-record handling is NOT a single uniform
-"record exists -> return it" rule. The dividing line is whether `state`
-has left `assigned`:
+An earlier draft of this review gave `state == "assigned"` a special,
+mutable carve-out — repeat calls could overwrite `pool_id`/
+`settlement_resource_id`/`requirements` to accommodate negotiation
+changing the deal's shape before dispatch. **Resolved: this is wrong and
+is removed.** See "Requirements change under negotiation" below —
+allowing in-place mutation of an admitted reservation's shape is
+dangerous (the held capacity may no longer correspond to what's
+recorded, and it undermines the exact auditability property motivating a
+single-row state machine in the first place). The correct handling is a
+new `allocation_id` entirely, never mutation of this one.
 
-- **`state == "assigned"` (including no record at all):** the row is
-  still a mutable scheduling decision. `select_resource` is free to
-  re-run eligibility/selection and overwrite `pool_id`,
-  `settlement_resource_id`, `provider`, and `requirements` — needed for
-  the case where negotiation changes the deal's requirements (or the
-  buyer's requested capacity) after an initial schedule but before
-  dispatch. `assign_settlement_resource` already handles the capacity
-  side of a genuine re-pick atomically (no-op if the resource is
-  unchanged; moves held units correctly if it's a real reassignment) —
-  `select_resource` now also calls it on re-selection, not only on first
-  selection.
-- **`state != "assigned"` (dispatch has started or finished):** the row
-  is the immutable, equivalence-checked record `pools-3` already
-  specified. `select_resource` returns it as-is; an explicit-resource
-  request that disagrees with `settlement_resource_id` fails with
-  `SettlementRequestMismatchError`. No expiry check applies on this path
-  — the `CapacityReservation`'s TTL hold is irrelevant once real physical
-  work exists; only equivalence/conflict rules apply from here.
+With that removed, `select_resource`'s existing-record handling is
+uniform regardless of `state`:
+
+```python
+existing = db.get(SettlementRecord, request.allocation_id, with_for_update=True)
+if existing is not None:
+    if _is_equivalent(existing, request):
+        return existing.to_settlement_resource()   # idempotent retry
+    raise SettlementRequestMismatchError(...)       # conflicting reuse
+
+# No record yet — the only path that can ever write one.
+allocation = self._require_valid_allocation(db, request)   # may raise
+                                                              # CapacityReservationExpiredError
+...
+```
 
 `CapacityReservation` expiry (`CapacityReservationExpiredError`) is
-therefore checked **only** on the "still assigned, may re-schedule"
-path, never on the "already dispatched" fast-return path — an allocation
-whose TTL lapsed after dispatch already succeeded must not have its
-retries start failing.
+therefore checked **only** when no `SettlementRecord` exists yet for this
+`allocation_id` — an allocation whose TTL lapsed after it was already
+scheduled (or dispatched) must not have its retries start failing.
 
 **If an operator requests scheduling against an already-expired
 `CapacityReservation`, `select_resource` MUST reject it.** The storefront
@@ -462,22 +485,25 @@ TTL hint" below for an operator-side lever on that.
 
 ### `abandoned` state and the lease-lifecycle watchdog
 
-A `CapacityReservation` can expire, release, or have its requirements
-change while its `SettlementRecord` is still sitting in `assigned`
-(nothing dispatched yet) — this is expected to be the common case for
-delay between scheduling and dispatch, not the exception; see below. The
-existing watchdog that already sweeps expired/released
+A `CapacityReservation` can expire, release, or be superseded by a fresh
+reservation (see "Requirements change under negotiation" below) while its
+`SettlementRecord` is still sitting in `assigned` (nothing dispatched
+yet) — this is expected to be a common way to reach this state, not the
+exception. The existing watchdog that already sweeps expired/released
 `CapacityReservation` rows (`LeaseLifecycleService.check_leases`) should
 also transition any `assigned`-state `SettlementRecord` for that
 allocation to `abandoned` — reusing the existing sweep rather than adding
-a second, parallel watchdog. No capacity cleanup is needed as part of
-that specific transition: `assign_settlement_resource` only ever moves
-*which* resource the reservation's already-held units point at, and the
-reservation's own release path already frees whatever resource it
-currently points to, independent of whether a `SettlementRecord` was
-ever created. `abandoned` exists purely for audit clarity, so a
-`settlement_records` row never sits at `assigned` forever with no
-explanation of why it stalled.
+a second, parallel watchdog. This is also the mechanism a supersede
+resolves through: releasing the *old* `allocation_id`'s reservation after
+a new one succeeds runs through this same release path, and its
+`SettlementRecord` (if any existed) picks up `abandoned` the same way.
+No capacity cleanup is needed as part of that specific transition:
+`assign_settlement_resource` only ever moves *which* resource the
+reservation's already-held units point at, and the reservation's own
+release path already frees whatever resource it currently points to,
+independent of whether a `SettlementRecord` was ever created. `abandoned`
+exists purely for audit clarity, so a `settlement_records` row never sits
+at `assigned` forever with no explanation of why it stalled.
 
 ### Expected time between scheduling and dispatch
 
@@ -488,27 +514,50 @@ in practice is between **reservation and scheduling**, not between
 scheduling and dispatch — a `CapacityReservation` may sit unscheduled for
 a long time and can expire before it's ever scheduled. A real (if
 uncommon) case for delay between scheduling and dispatch specifically:
-scheduling happening as part of agent lease negotiation itself (e.g. a
-delayed lease start time, or a late-stage negotiation change), most
-plausibly triggered by the buyer's requested capacity/requirements
-changing mid-negotiation after an earlier schedule. The
-still-`assigned`/mutable-until-dispatch design above is what accommodates
-this without treating it as an error case.
+scheduling happening as part of agent lease negotiation itself, most
+plausibly because the storefront calls `select_resource` *before*
+finalizing price — the resource actually selected can be commercially
+material (see "Storefront orchestrates scheduling and dispatch as
+separate calls" below) — so a real window can open between "resource is
+known" and "deal is finalized and dispatch is triggered." The
+still-`assigned`, non-mutable design above accommodates this without
+treating it as an error case: the record simply waits in `assigned`,
+idempotently, until either dispatch or a supersede/release reaches it.
 
-### Pool-level reservation TTL hint (flagged, not designed here)
+### Requirements change under negotiation: supersede, never mutate (design review continued, 2026-07-17)
 
-An operator may want a pool-level limit on how long a
-`CapacityReservation` against their resources can sit unscheduled/held —
-raised during this review as a real, well-motivated use case, not
-designed here. Same shape and posture as the listing-mode hint above:
-an additive `ResourcePool.policy_tags` entry
-(`{"max_reservation_hold_seconds": 900}`), read and voluntarily respected
-by a cooperating storefront when it chooses the `ttl_seconds` it passes
-to `reserve()` — never enforced by the provisioning service itself
-(`reserve()` already accepts a caller-supplied `ttl_seconds`; no new
-ledger capability is needed, only a place for the operator to express a
-preference and a storefront willing to read it). Left for planning to
-schedule, not required by POOLS-7's first pass.
+**Resolved:** if a deal's requirements change after a
+`CapacityReservation`/`SettlementRecord` already exists for it (still
+`assigned`, not yet dispatched), the caller mints a **new**
+`allocation_id`, reserves capacity for the *new* shape under it, and only
+**after that reservation succeeds** releases the *old* `allocation_id`'s
+`CapacityReservation`. Never mutates the existing reservation or
+`SettlementRecord` in place.
+
+Ordering matters and is the crux of the decision: **reserve-new, then
+release-old — never release-old-then-reserve-new.** If a new reservation
+attempt fails (the updated shape genuinely isn't available), the old
+reservation MUST remain untouched and valid — the negotiation continues
+on the original terms, and whatever's negotiating (an agent, most likely)
+takes the failure back into the negotiation ("can't do X, can still do
+Y") rather than the system having destroyed a working reservation while
+chasing one that didn't pan out. This is achievable with existing
+primitives — an ordinary `reserve()` call for the new shape, then an
+ordinary `release()` of the old `allocation_id` — no new ledger mechanism
+needed.
+
+This is also why the `select_resource` idempotency simplification above
+is correct rather than a loss of capability: every "requirements changed"
+case that used to motivate mutating a record in place is now a *new*
+`allocation_id`'s first-time `select_resource` call, which the ordinary
+(no existing record) path already handles.
+
+### Pool-level reservation TTL hint — split out, see `pools-8`
+
+Moved to `pools-8-capacity-projection-and-listing-hints` alongside the
+listing-mode hint, per the scope-split decision below — same
+`policy_tags`-hint shape and posture, not required for POOLS-7's first
+pass.
 
 ## Commit <-> async-dispatch failure window: resolved (design review continued, 2026-07-17)
 
@@ -700,77 +749,175 @@ still-possible generic/unpinned case, special-case pinned claims to route
 directly by known site, or something else, is not decided here — this is
 a question for planning, not resolved by this design review.
 
-## Listing-mode hint consumption: resolved (design review continued, 2026-07-17)
 
-Resolves the channel question the original "Operator listing-mode hints"
-entry above left open. No new channel is needed: `CapacityProjection`
-(this file's "`SiteResource` is retired" section) already pulls pool
-metadata from `GET /api/v1/pools`, so `policy_tags` rides along once the
-sync carries it:
+## Listing-mode hint consumption — split out, see `pools-8`
+
+Moved to `pools-8-capacity-projection-and-listing-hints` in full (schema,
+`resolve_vm_listing_mode`/`resolve_apicredits_listing_mode`,
+extensibility argument, enforcement posture), per the scope-split
+decision below — it depends on `CapacityProjection` carrying
+`policy_tags`, which is no longer this change's scope.
+
+## Scope split: `CapacityProjection` and hints move to `pools-8` (design review continued, 2026-07-17)
+
+**Resolved:** `CapacityProjection`, the listing-mode hint, and the
+pool-level reservation TTL hint move to a new change,
+`pools-8-capacity-projection-and-listing-hints`. Reasoning: this change
+is already large (`site_resource_pools`/`CapacityReservation`/
+`SettlementRecord`/scheduler-and-fulfillment orchestration/idempotent
+dispatch/release-path wiring), and `CapacityProjection` is a materially
+separate subsystem — pull schedules, freshness, multi-site keys,
+publication reactions, its own storage and migrations — not inherently
+part of the fulfillment-cutover mechanics. The two hints depend on
+`CapacityProjection` carrying `policy_tags`, so they move with it.
+
+**This split has a real consequence, not a free one, and it must stay
+visible rather than be quietly absorbed:** this change's "`SiteResource`
+is retired" fix makes `site_resource_pools`/`PhysicalSettlementScheduler`
+correctly source `pool_id` from `hosts`/`resource_pools` — closing the
+provisioning-service side of the original `pool_id`-namespace bug this
+whole review started from. But the storefront's own claim-building
+(`vm_job_spec_service.py`) still sources the `pool_id`/`resource_id` it
+puts into a reservation request from the storefront's local, independently-
+authored inventory today. Until `pools-8` lands and actually replaces
+that local table with `CapacityProjection`, the storefront can still send
+claims naming pool/resource identities that don't correspond to anything
+real — which, after this change's fix, now fails cleanly at admission
+(a real `NoEligibleSettlementResourceError`/similar) instead of silently
+matching the wrong thing. That's strictly better than today's silent
+mismatch risk, but it is not the same as the bug being fully closed
+end-to-end. `pools-7`'s `proposal.md` Dependencies section should state
+this plainly: `pools-7` alone fixes provisioning-side correctness;
+`pools-8` is required for the storefront to reliably send valid claims.
+
+## Storefront orchestrates scheduling and dispatch as separate calls (design review continued, 2026-07-17)
+
+**Resolved: confirms POOLS-3's design was already correct as written —
+no correction needed there.** `pools-3`'s `design.md` diagram names "the
+storefront" as the orchestrator calling `select_resource(...)` then
+`FulfillmentService.create(...)` in sequence. An earlier pass of this
+review flagged apparent tension between that and this change's atomic,
+single-transaction `select_resource` design — there isn't one, once the
+reason for the split is understood: **`select_resource`'s result can be
+commercially material to the negotiation before a deal is finalized**
+(e.g. a larger node's price for the same requested capacity may differ
+from a smaller one, and the buyer/agent may need to know which node was
+selected before price is finalized). Scheduling capacity and finalizing
+a deal are genuinely separate decisions the storefront needs to make at
+separate times, not an implementation detail to hide behind one call.
+
+Resolved shape: two required storefront-facing operations, plus one
+optional convenience operation:
+
+1. **Schedule** — invokes `select_resource`. Returns the selected
+   `SettlementResource` (so it can inform pricing/negotiation). Does not
+   dispatch anything.
+2. **Dispatch** — invokes `FulfillmentService.create` against an
+   already-scheduled allocation. This is where `dispatch_pending` and
+   everything downstream in the state machine begins.
+3. **(Optional) Atomic convenience operation** — calls (1) then (2) in
+   one request, for callers that don't need the pricing-preview behavior
+   and just want to fulfill immediately. Not required; a thin
+   composition of the two required operations, not a third code path.
+
+Each of (1) and (2) remains its own atomic transaction internally (this
+file's earlier transaction-boundary decisions are unaffected) — "the
+storefront calls them separately" describes the *external* API shape,
+not the internal transaction boundary of either call. Exact route/wire
+shapes (the concrete API contract `create_vm_and_wait_with_credentials`
+gets replaced by — request/response bodies, status representation,
+credentials retrieval, teardown request/response) are not decided here;
+left for planning.
+
+## Transaction boundary and repository ownership, stated explicitly (design review continued, 2026-07-17)
+
+Two things that were implicit in this file's code sketches rather than
+stated as requirements, made explicit here:
+
+- **`assign_settlement_resource` (capacity rebind) and `SettlementRecord`
+  creation/transition MUST share one database transaction.** Achievable
+  because `CapacityLedgerService`, `ResourcePoolService`, and (per the
+  `compute_provisioning` migration decision above) `PhysicalSettlementScheduler`
+  all already live in the same provisioning-service process/database — this
+  isn't a cross-service transaction, it's an ordinary single-database one.
+  A sequence that moves capacity, commits, and only then inserts the
+  settlement record as a second commit is NOT acceptable — a crash between
+  those two commits leaves a moved reservation with no durable scheduling
+  identity, silently reintroducing the exact failure window point 2 exists
+  to close.
+- **`SettlementRecord`'s model/repository interface lives in
+  `compute_provisioning`, alongside `PhysicalSettlementScheduler` and the
+  request/resource dataclasses it already owns — not in `kit/resource-pools`
+  alongside `ResourcePool`.** It is physical-settlement lifecycle state,
+  not pool-administration state; it belongs with the scheduler that writes
+  it, for the same reasons the scheduler itself moved there. The concrete
+  SQLAlchemy table is still composed into whichever service's actual
+  database (the VM provisioning service's, today).
+
+## Provider input snapshot: prepare/dispatch split (design review continued, 2026-07-17)
+
+Concretizes a principle this file already stated in passing ("Accepted
+provider configuration," above) without a mechanism. **Resolved:** the
+provider prepares its execution input synchronously, before the
+transaction that marks a record `dispatch_pending` commits; dispatch
+itself happens after commit, against the already-prepared, now-durable
+input — not by re-reading live pool/host configuration during a recovery
+retry.
 
 ```python
-class CachedResourcePool(Base):
-    __tablename__ = "capacity_projection_pools"
-
-    site = Column(String, primary_key=True)
-    pool_id = Column(String, primary_key=True)
-    label = Column(String, nullable=False)
-    provider = Column(String, nullable=False)
-    enabled = Column(Boolean, nullable=False)
-    policy_tags = Column(JSON, nullable=False, default=dict)
-    synced_at = Column(DateTime, nullable=False)
+prepared = provider.prepare_create(request, resource, pool_config)
+# `prepared` is a serializable, normalized representation of exactly what
+# will be submitted — stored on the SettlementRecord (or a related column)
+# as part of the same transaction that sets state=dispatch_pending.
+...
+await provider.dispatch_create(prepared)   # post-commit; safe to retry
+                                             # via the recovery sweep using
+                                             # the SAME stored `prepared`
+                                             # value, never a fresh read
 ```
 
-The reconciler-driven publish path (`domains/vms/listings/reconciler.py`,
-`cli_publish.py`) already has a structural default, confirmed during
-`pools-4`'s design review: a listing derived from a single-resource pool
-is resource-pinned; one derived from a real multi-member pool is
-pool-scoped. This change's scope is narrower than originally framed: let
-an explicit hint override that default, don't replace it.
+This is what makes the recovery sweep (point 2) correct against a pool
+edited or deleted *after* a record was accepted: accepted work is
+insulated from later configuration changes because it dispatches from a
+frozen snapshot, not a live re-read.
 
-```python
-# kit/resource-pools — domain-neutral: the key name only.
-LISTING_MODE_TAG = "listing_mode"
+## Recovery sweep: periodic, not startup-only (design review continued, 2026-07-17)
 
-# domains/vms — VM-domain interpretation + default.
-class VmListingMode(str, Enum):
-    pooled = "pooled"
-    specific_resource = "specific_resource"
+**Resolved:** the `dispatch_pending`/`teardown_dispatch_pending` recovery
+sweep (point 2) runs periodically, not only at process startup. A
+startup-only sweep misses the case where a provider call fails
+transiently (e.g. a network blip to the Ansible controller) while the
+process keeps running — that record would never be retried until the
+next restart. Same query, same idempotent-retry logic as the startup
+sweep; just scheduled periodically instead of once. Multi-replica safety
+(claiming rows so multiple replicas don't double-process the same record
+— `SELECT ... FOR UPDATE SKIP LOCKED` or an equivalent claim/lease
+pattern) is required regardless of whether the sweep is startup-only or
+periodic, and is left for planning to specify concretely.
 
-def resolve_vm_listing_mode(pool: CachedResourcePool, member_count: int) -> VmListingMode:
-    declared = pool.policy_tags.get(LISTING_MODE_TAG)
-    if declared in (VmListingMode.pooled.value, VmListingMode.specific_resource.value):
-        return VmListingMode(declared)
-    return (VmListingMode.specific_resource if member_count == 1
-            else VmListingMode.pooled)   # unchanged pools-4 structural default
-```
+## Legacy allocations during cutover (design review continued, 2026-07-17)
 
-**Extensibility confirmed against `apicredits`**, not just asserted: since
-`apicredits` is explicitly in scope for this session's broader
-`kit`/`CapacityReservation` reshape, the shape only counts as
-domain-neutral if `apicredits` can express something VM doesn't need
-without touching `kit/resource-pools`. It can — same `LISTING_MODE_TAG`
-key, a wholly different enum and default rule, zero kit changes:
+Real gap, not addressed by "no allocation without a `SettlementRecord`"
+alone — that describes the target *steady state*, not what happens to
+allocations already in flight, created under the old direct-dispatch
+path, at the moment this change deploys. **Resolved: two acceptable
+strategies, choice deferred to planning, but whichever is chosen MUST be
+stated explicitly rather than silently assumed:**
 
-```python
-class ApiCreditsListingMode(str, Enum):
-    shared_quota = "shared_quota"     # listing draws from a pooled quota bucket
-    dedicated_key = "dedicated_key"   # listing is pinned to one provider API key
+1. **Fabricate a `SettlementRecord` for each pre-existing allocation
+   during migration** — backfill a row (state reflecting whatever's
+   inferable about the allocation's actual status, e.g. `active` for a
+   running VM) so every allocation uniformly has one going forward, and
+   the release path never needs a "no settlement record" branch at all.
+2. **Explicitly accept a compatibility break** — allocations created
+   before the cutover marker are not migrated; release for them continues
+   through the pre-existing direct-dispatch-aware path (or an equivalent
+   documented fallback) rather than being forced through
+   `PhysicalSettlementScheduler`/`FulfillmentService`. This is acceptable
+   for this codebase's maturity level ("that's OK from time to time," not
+   a production migration with an SLA) but MUST be written down as a
+   deliberate decision in whatever change implements the cutover, not
+   discovered by a future reader as an unstated gap.
 
-def resolve_apicredits_listing_mode(pool: CachedResourcePool) -> ApiCreditsListingMode:
-    declared = pool.policy_tags.get(LISTING_MODE_TAG)
-    if declared in (ApiCreditsListingMode.shared_quota.value, ApiCreditsListingMode.dedicated_key.value):
-        return ApiCreditsListingMode(declared)
-    return ApiCreditsListingMode.shared_quota
-```
-
-`kit/resource-pools` owns one string key; each domain owns its own enum
-and default rule; no cross-domain coupling.
-
-**Enforcement posture unchanged, restated for the record:**
-`PhysicalSettlementScheduler`'s explicit-`resource_id` eligibility path
-(`pools-2`) is unaffected by a pool's `listing_mode` regardless — a
-buyer's explicit resource request is honored even against a pool tagged
-`pooled`. A storefront that never reads the tag, or one running against a
-provisioning service that predates this feature, falls through to the
-unchanged structural default. Purely additive.
+Either way, this needs a concrete plan before implementation — not
+resolved further here.

--- a/openspec/changes/pools-7-storefront-fulfillment-cutover/design.md
+++ b/openspec/changes/pools-7-storefront-fulfillment-cutover/design.md
@@ -1,11 +1,10 @@
 ## Context
 
-Captured during the `pools-3-fulfillment-provider` design-review session
-(2026-07-15), before any implementation of `pools-3` existed. This file is
-reference material for whoever picks this change up — it is not a design
-this change has committed to; it records what was verified true at the
-time so a future session doesn't have to re-derive it, and can verify it's
-still true before proceeding.
+POOLS-7 cuts the storefront and provisioning services over from the current
+direct executor path to durable physical-resource scheduling, fulfillment,
+result delivery, and teardown. This document records the design decisions
+approved during the POOLS-7 discuss phase and is the design basis for the
+implementation plan.
 
 ## Current storefront fulfillment path (verified, not assumed)
 
@@ -130,35 +129,6 @@ record must retain the original selected resource, provider, and sufficient
 provider metadata for later asynchronous teardown. Final teardown states and
 record retention are designed here when the real lease-release call path is
 wired.
-
-## Remaining open questions for whoever picks this up
-
-- **RESOLVED, see "`fill_first`/`most_available`: resolved" below.**
-  ~~Does `AggregateCapacityClient`'s `fill_first`/`most_available`
-  placement logic get deleted outright...~~ — kept, bug-fixed, not
-  bundled with the listing-mode hint. That same section also surfaced a
-  new, still-open question: whether the site-fallback behavior itself is
-  now vestigial for pool/resource-pinned claims post-POOLS-4.
-- **RESOLVED, see "Scope decision: retrofit, not compute-30 extraction"
-  below.** ~~Whether `market-platform-compute-30-extract-service`'s
-  absorbed package-boundary decision... should be forced by this
-  change...~~ — forced, for `PhysicalSettlementScheduler`/
-  `DeterministicRoundRobinPolicy` specifically (moved to
-  `compute_provisioning`); `compute-30`'s own proposal has been updated
-  to match.
-- **Operator listing-mode hints via `ResourcePool.policy_tags`** —
-  **designed, then SPLIT OUT to `pools-8-capacity-projection-and-listing-hints`
-  along with `CapacityProjection`** (see "Scope split: `CapacityProjection`
-  and hints move to `pools-8`" below) — not resolved in this change. The
-  channel question this bullet originally left open (how a storefront
-  learns a pool's `policy_tags` across the service boundary) was answered
-  during this review by `CapacityProjection`: the pull-based pool mirror
-  carries `policy_tags` along for free, no new channel needed — but the
-  design itself now lives in `pools-8`, not here. The
-  `_eligible_candidates`/`SiteResource.attributes.pool_id` sync gap this
-  bullet also raised IS resolved in this change (unaffected by the scope
-  split) — see "`SiteResource` is retired," below: `site_resource_pools`
-  is now derived from `hosts`/`resource_pools`, not storefront-pushed.
 
 ## Accepted provider configuration
 
@@ -770,7 +740,13 @@ and third layers pick among fundamentally different things (sites vs.
 hosts within one already-chosen site) and are correctly already
 separated by process boundary, not just by convention.
 
-### Open question surfaced by writing this table down: is the second layer's fallback still meaningful post-POOLS-4?
+### Site fallback after POOLS-4
+
+Site fallback remains meaningful only before a capacity reservation exists.
+Once a storefront has selected a site and that site has created the capacity
+reservation, scheduling and fulfillment MUST remain with that provisioning
+authority. A site receiving an unknown capacity reservation, pool, or resource
+identifier returns an error and MUST NOT reinterpret or forward it.
 
 Not resolved here — flagged for planning. Before POOLS-4, a claim could
 be a generic attribute shape (`region`, `gpu_model`, `gpu_count`) with no
@@ -840,69 +816,43 @@ end-to-end. `pools-7`'s `proposal.md` Dependencies section should state
 this plainly: `pools-7` alone fixes provisioning-side correctness;
 `pools-8` is required for the storefront to reliably send valid claims.
 
-## Storefront orchestrates scheduling and dispatch as separate calls (design review continued, 2026-07-17)
+## Storefront orchestrates scheduling and fulfillment as separate calls
 
-**Resolved: confirms POOLS-3's design was already correct as written —
-no correction needed there.** `pools-3`'s `design.md` diagram names "the
-storefront" as the orchestrator calling `select_resource(...)` then
-`FulfillmentService.create(...)` in sequence. An earlier pass of this
-review flagged apparent tension between that and this change's atomic,
-single-transaction `select_resource` design — there isn't one, once the
-reason for the split is understood: **`select_resource`'s result can be
-commercially material to the negotiation before a deal is finalized**
-(e.g. a larger node's price for the same requested capacity may differ
-from a smaller one, and the buyer/agent may need to know which node was
-selected before price is finalized). Scheduling capacity and finalizing
-a deal are genuinely separate decisions the storefront needs to make at
-separate times, not an implementation detail to hide behind one call.
+The storefront owns progress through negotiation, site/pool selection,
+capacity reservation, resource scheduling, and the decision to begin
+fulfillment. The provisioning service does not receive agreement or negotiation
+identity.
 
-Resolved shape: two required storefront-facing operations, plus one
-optional convenience operation:
+Two required operations remain separate because the selected physical resource
+may be commercially material before fulfillment begins:
 
-1. **Schedule** — invokes `select_resource`. Returns the selected
-   `SettlementResource` (so it can inform pricing/negotiation). Does not
-   dispatch anything.
-2. **Dispatch** — invokes `FulfillmentService.create` against an
-   already-scheduled allocation. This is where `dispatch_pending` and
-   everything downstream in the state machine begins.
-3. **(Optional) Atomic convenience operation** — calls (1) then (2) in
-   one request, for callers that don't need the pricing-preview behavior
-   and just want to fulfill immediately. Not required; a thin
-   composition of the two required operations, not a third code path.
+1. **`schedule_resource(capacity_reservation_id, requirements)`** — selects
+   and durably assigns a settlement resource without executing a provider.
+2. **`begin_fulfillment(capacity_reservation_id, request)`** — accepts the
+   already-scheduled reservation and returns a durable `fulfillment_id`.
 
-Each of (1) and (2) remains its own atomic transaction internally (this
-file's earlier transaction-boundary decisions are unaffected) — "the
-storefront calls them separately" describes the *external* API shape,
-not the internal transaction boundary of either call. Exact route/wire
-shapes (the concrete API contract `create_vm_and_wait_with_credentials`
-gets replaced by — request/response bodies, status representation,
-credentials retrieval, teardown request/response) are not decided here;
-left for planning.
+A thin convenience operation may compose them for callers that do not need the
+selection preview, but it MUST use the same two application paths. After
+acceptance, fulfillment status and whole-fulfillment teardown are addressed by
+`fulfillment_id`; provisioned outputs receive neutral
+`provisioned_resource_id` values rather than exposing VM-specific identity as
+the generic contract.
 
-## Transaction boundary and repository ownership, stated explicitly (design review continued, 2026-07-17)
+## Transaction boundary and shared package ownership
 
-Two things that were implicit in this file's code sketches rather than
-stated as requirements, made explicit here:
+`assign_settlement_resource` (capacity rebind) and settlement-record
+creation/transition MUST share one database transaction. A sequence that moves
+capacity, commits, and then inserts the settlement record is not acceptable.
+The same atomic rule applies when abandonment releases or supersedes reserved
+capacity.
 
-- **`assign_settlement_resource` (capacity rebind) and `SettlementRecord`
-  creation/transition MUST share one database transaction.** Achievable
-  because `CapacityLedgerService`, `ResourcePoolService`, and (per the
-  `compute_provisioning` migration decision above) `PhysicalSettlementScheduler`
-  all already live in the same provisioning-service process/database — this
-  isn't a cross-service transaction, it's an ordinary single-database one.
-  A sequence that moves capacity, commits, and only then inserts the
-  settlement record as a second commit is NOT acceptable — a crash between
-  those two commits leaves a moved reservation with no durable scheduling
-  identity, silently reintroducing the exact failure window point 2 exists
-  to close.
-- **`SettlementRecord`'s model/repository interface lives in
-  `compute_provisioning`, alongside `PhysicalSettlementScheduler` and the
-  request/resource dataclasses it already owns — not in `kit/resource-pools`
-  alongside `ResourcePool`.** It is physical-settlement lifecycle state,
-  not pool-administration state; it belongs with the scheduler that writes
-  it, for the same reasons the scheduler itself moved there. The concrete
-  SQLAlchemy table is still composed into whichever service's actual
-  database (the VM provisioning service's, today).
+The shared lifecycle and concrete reusable SQLAlchemy implementation live in a
+new `kit/physical-settlement` package, not `kit/resource-pools` and not the
+base `compute_provisioning` package. The kit owns domain-neutral scheduling,
+fulfillment persistence, repository, recovery-claim, provisioned-resource, and
+result-outbox infrastructure. The VM provisioning service composes the shared
+metadata into its database, owns the Alembic migration, and supplies VM/Ansible
+adapters and worker composition.
 
 ## Provider input snapshot: prepare/dispatch split (design review continued, 2026-07-17)
 
@@ -945,29 +895,192 @@ sweep; just scheduled periodically instead of once. Multi-replica safety
 pattern) is required regardless of whether the sweep is startup-only or
 periodic, and is left for planning to specify concretely.
 
-## Legacy allocations during cutover (design review continued, 2026-07-17)
+## Active allocation backfill during cutover
 
-Real gap, not addressed by "no allocation without a `SettlementRecord`"
-alone — that describes the target *steady state*, not what happens to
-allocations already in flight, created under the old direct-dispatch
-path, at the moment this change deploys. **Resolved: two acceptable
-strategies, choice deferred to planning, but whichever is chosen MUST be
-stated explicitly rather than silently assumed:**
+The migration uses a uniform backfill rather than a long-lived legacy release
+branch or an operator-managed cutover marker. Existing hosts are first placed
+in the default resource pool. Every active or releasing VM capacity reservation
+then receives a settlement/fulfillment record with the selected resource,
+Ansible provider, and versioned teardown input inferred from the durable fields
+the current release path already uses (`vm_host`, `vm_target` or
+`executor_target`, and executor identity).
 
-1. **Fabricate a `SettlementRecord` for each pre-existing allocation
-   during migration** — backfill a row (state reflecting whatever's
-   inferable about the allocation's actual status, e.g. `active` for a
-   running VM) so every allocation uniformly has one going forward, and
-   the release path never needs a "no settlement record" branch at all.
-2. **Explicitly accept a compatibility break** — allocations created
-   before the cutover marker are not migrated; release for them continues
-   through the pre-existing direct-dispatch-aware path (or an equivalent
-   documented fallback) rather than being forced through
-   `PhysicalSettlementScheduler`/`FulfillmentService`. This is acceptable
-   for this codebase's maturity level ("that's OK from time to time," not
-   a production migration with an SLA) but MUST be written down as a
-   deliberate decision in whatever change implements the cutover, not
-   discovered by a future reader as an unstated gap.
+Historical create input may be absent for already-running VMs. The migration
+fails visibly when an active reservation cannot be mapped unambiguously and
+need not fabricate records for terminal expired VMs without a retention use
+case.
 
-Either way, this needs a concrete plan before implementation — not
-resolved further here.
+## Final planning decisions (design review completed 2026-07-20)
+
+This section is authoritative where it conflicts with earlier chronological
+review notes in this document.
+
+### Cross-domain identities and terminology
+
+The provisioning boundary is capacity-reservation-centric and MUST NOT carry
+storefront commercial identities such as negotiation, buyer, deal, or
+agreement identifiers.
+
+- `allocation_id` is renamed broadly to `capacity_reservation_id`.
+- `capacity_reservation_id` identifies the admitted capacity and is the
+  idempotency boundary for scheduling and `begin_fulfillment`.
+- `begin_fulfillment` returns a durable `fulfillment_id` identifying the
+  post-acceptance provisioning lifecycle aggregate.
+- A fulfillment may produce zero or more `ProvisionedResource` records, each
+  with a globally unique `provisioned_resource_id` and an optional
+  domain-specific `domain_resource_ref` such as a VM ID or pod UID.
+- `settlement_resource_id` identifies the selected underlying physical supply
+  resource. It is not the provisioned VM/pod identity.
+- Whole-fulfillment status and teardown use `fulfillment_id`. The schema MUST
+  support multiple provisioned resources. Per-resource teardown is a future
+  extension unless implementation discovers a current caller that requires it.
+- Public APIs use fulfillment-specific verbs such as `schedule_resource`,
+  `begin_fulfillment`, `get_fulfillment_status`,
+  `get_fulfillment_result`, and `begin_fulfillment_teardown`. “Dispatch” is
+  retained only as an internal provider-command term.
+
+A capacity reservation is owned by exactly one provisioning authority. Once a
+reservation exists there is no cross-site fallback: an unknown reservation,
+pool, or resource identifier is rejected rather than reinterpreted or
+forwarded. Pool, resource, reservation, fulfillment, and provisioned-resource
+identifiers MUST be globally unique opaque identifiers. Planning may select
+UUIDv7 after reviewing repository conventions; ownership remains explicit via
+`site_id` rather than encoded into identifier strings. Requirements MUST also
+review whether any site-plus-pool composite identity is needed for routing or
+integrity.
+
+### Shared package boundary
+
+Create a new `kit/physical-settlement` package. This is intentionally separate
+from both `kit/resource-pools` and the base `compute_provisioning` package.
+The kit owns domain-neutral settlement and fulfillment lifecycle types,
+scheduler/policy code, versioned prepared-operation contracts, SQLAlchemy
+mappings and generic repositories, transition validation, recovery-claim
+infrastructure, provisioned-resource records, and durable result-delivery
+outbox models. VM-specific Ansible adapters, API routes, worker composition,
+and migrations remain in the VM provisioning service.
+
+The concrete SQLAlchemy implementation belongs in the shared kit when it is
+genuinely reusable across domains; services compose the shared metadata and
+apply migrations in their own databases.
+
+### Scheduling and fulfillment boundary
+
+The storefront owns progress through negotiation, site/pool selection,
+capacity reservation, physical-resource scheduling, and the decision to begin
+fulfillment. The provisioning service only needs the local
+`capacity_reservation_id` and scheduling requirements, which MUST NOT exceed
+the admitted reservation.
+
+Scheduling and fulfillment remain separate calls because the selected physical
+resource may be commercially material before fulfillment begins. Scheduling
+atomically rebinds capacity, where fairness requires it, and creates the
+immutable assigned settlement record. A changed requirement supersedes the
+reservation; it never mutates an accepted assignment under the same
+`capacity_reservation_id`.
+
+Once `begin_fulfillment` is durably accepted, the provisioning service owns all
+forward progress: provider-command submission, recovery, provider-status
+convergence, provisioned-resource persistence, settlement-result delivery,
+teardown, and final physical-resource reclamation. The storefront is not
+responsible for polling a provider job to advance this lifecycle.
+
+### Settlement and fulfillment persistence
+
+There is one durable settlement/fulfillment aggregate per capacity reservation.
+Equivalent retries return the existing aggregate; conflicting reuse fails
+before provider submission. State transition validation is implemented through
+a compact table-driven service mechanism rather than stored procedures or a
+method for every edge.
+
+`assign_settlement_resource`, settlement creation/transition, and any
+reservation capacity movement MUST share one database transaction. Likewise,
+transitioning an unfulfilled assigned settlement to `abandoned` and releasing
+or superseding its capacity reservation MUST be atomic. Lease lifecycle code
+performs the transition directly where possible; watchdog processing is a
+reconciliation backstop.
+
+Prepared provider create and teardown payloads are normalized, serializable,
+and versioned. Any generic dictionary persisted durably or sent cross-domain
+MUST carry a schema version and kind discriminator. Provider input is frozen
+before committing a pending provider-command state and is never reconstructed
+from mutable live pool configuration during retry.
+
+### Active-allocation migration and backfill
+
+POOLS-7 performs a comprehensive breaking migration suitable for independently
+operated sites without lease-expiry coordination instructions.
+
+1. Existing hosts are migrated into a default resource pool and corresponding
+   resource/pool membership records.
+2. Every active or releasing VM capacity reservation is backfilled with a
+   durable settlement/fulfillment record.
+3. The migration derives selected resource, provider identity, and versioned
+   teardown input from the same durable fields the current release path uses
+   (`vm_host`, `vm_target`/`executor_target`, and executor identity).
+4. Historical create input may be absent for already-active backfilled
+   fulfillments; this does not prevent status representation or teardown.
+5. Rows are marked as backfilled for auditability.
+6. The migration fails loudly when an active reservation cannot be mapped
+   unambiguously; it does not create a silently incomplete teardown record.
+7. Historical terminal/expired allocations need not be fabricated unless a
+   separate retention requirement exists.
+
+After successful migration, no long-lived legacy release branch or operator
+cutover marker is required.
+
+### Provider recovery and lifecycle convergence
+
+Pending provider commands are claimed in short transactions using a
+multi-replica-safe claim/lease pattern. Database locks are released before any
+long-running external provider call. Recovery uses bounded batches,
+exponential backoff with jitter, claim expiry after worker death, and
+idempotent deterministic provider command identities.
+
+The watchdog framework has logically separate handlers for create-command
+submission/recovery, provider-status convergence, result delivery, teardown
+submission/recovery, and abandonment reconciliation. Records in both pending
+and in-progress states converge without storefront polling.
+
+### Durable pushed SettlementResult delivery
+
+The provisioning service pushes a versioned `SettlementResult` to the
+storefront; inter-service polling is not the primary result-delivery contract.
+A terminal or otherwise reportable fulfillment transition and its delivery
+obligation are committed atomically through a durable outbox.
+
+Delivery is at-least-once with exactly-once logical application:
+
+- each result has a stable globally unique `result_id`;
+- the storefront authenticates the source, deduplicates by `result_id`,
+  persists the result, commits, and only then acknowledges;
+- lost acknowledgements cause harmless retries;
+- retries use exponential backoff with jitter and a capped interval but do not
+  permanently abandon an undelivered result while the fulfillment is active;
+- operator metrics, alerts, audit history, and a manual replay mechanism are
+  required.
+
+Raw credentials MUST NOT be stored in settlement rows, generic JSON columns,
+or outbox payloads. The delivery worker obtains or refreshes credentials just
+in time, keeps them in memory for the authenticated encrypted request, and
+then discards them. If recovery rotates credentials, a monotonic
+`credential_generation` prevents an older retry from replacing a newer
+credential set at the storefront. Fulfillment state and result-delivery state
+are separate: successful provisioning remains successful while delivery is
+retrying.
+
+### Breaking cleanup scope
+
+This work item is approved for broad schema cleanup. Planning and implementation
+MUST include coherent renames and removal of superseded paths rather than
+preserving ambiguous compatibility names indefinitely, including:
+
+- `SiteAllocation` to `CapacityReservation`;
+- `allocation_id` to `capacity_reservation_id`;
+- retirement/replacement of `SiteResource` where the final host, pool,
+  membership, and reservable-capacity model requires it;
+- globally unique identifiers and explicit site ownership;
+- removal of direct storefront executor submission and polling;
+- replacement of the old release path after backfilled settlement teardown is
+  operational;
+- corresponding API/client/schema/fixture/test/architecture changes.

--- a/openspec/changes/pools-7-storefront-fulfillment-cutover/design.md
+++ b/openspec/changes/pools-7-storefront-fulfillment-cutover/design.md
@@ -133,58 +133,29 @@ wired.
 
 ## Remaining open questions for whoever picks this up
 
-- Does `AggregateCapacityClient`'s `fill_first`/`most_available` placement
-  logic get deleted outright once `PhysicalSettlementScheduler` owns
-  placement, or does it downgrade to a pool-level preference hint passed
-  into `SettlementRequirement.attributes`? Not analyzed this session.
-- Whether `market-platform-compute-30-extract-service`'s absorbed
-  package-boundary decision (stay VM-service-local vs. move to
-  `compute_provisioning`; formerly tracked by the now-closed
-  `pools-5-shared-provisioning-package`) should be forced by this change
-  rather than waited on — if the storefront is going to depend on these contracts
-  cross-service, that's itself an argument for moving them out of a
-  VM-domain-local package. Worth revisiting at activation time rather than
-  deciding here.
-- **Operator listing-mode hints via `ResourcePool.policy_tags`** (raised
-  during `pools-4`'s design review, 2026-07-16 — verified, not assumed):
-
-  - `PhysicalSettlementScheduler._eligible_candidates`
-    (`domains/vms/provisioning/service/src/services/physical_settlement_scheduler.py`)
-    already filters `SiteResource.attributes["pool_id"]` against
-    `ResourcePoolService.list_pools()` — i.e. it already assumes a
-    `SiteResource`'s `pool_id` attribute reflects a *real* operator-managed
-    Resource Pool. But no code was found that syncs `ResourcePoolService`
-    pool membership into `SiteResource.attributes`. The only caller of
-    `CapacityLedgerService.register_resource` today is the storefront's own
-    `sync_site_resources()` (`market_storefront/services/capacity_client.py`),
-    pushing its locally-managed CSV/listing attributes — which, per
-    `pools-4`'s design review, are not guaranteed to carry a `pool_id` that
-    corresponds to any `ResourcePoolService` pool at all. This gap hasn't
-    bitten anything yet only because `select_resource` has no production
-    caller (per `pools-2`'s own remaining-work note) — it will matter the
-    moment this change wires one in.
-  - Given that, the natural home for an operator's listing-mode preference
-    is `ResourcePool.policy_tags` (`kit/resource-pools` — already a
-    free-form, filterable `dict[str, Any]`, already exposed through the
-    pool admin API's list/detail/export). A storefront that's colocated
-    with (or trusts) a provisioning service could read a tag like
-    `{"listing_mode": "specific_resource"}` off a pool and decide whether
-    to publish that pool's listings as resource-pinned or pool-scoped.
-  - This is explicitly a **hint**, not a constraint provisioning enforces:
-    `pools-2`'s spec already commits to honoring an explicit `resource_id`
-    request regardless of a pool's preferred mode (see this file's sibling
-    Non-Goals entry). A third-party storefront that never reads the hint at
-    all falls back to today's structural default (pool membership: a
-    listing derived from a real multi-member pool is never resource-pinned;
-    a listing derived from a single-resource pool carries that resource's
-    `resource_id`).
-  - Not designed here: the actual channel a storefront uses to learn a
-    pool's `policy_tags` across the service boundary (poll the pool admin
-    API? carried through CSV import? only relevant when storefront and
-    provisioning share an operator?), and whether/how `_eligible_candidates`'s
-    existing (undocumented) assumption that `SiteResource.attributes.pool_id`
-    already matches a real `ResourcePoolService` pool ID should itself become
-    an explicit, enforced sync rather than an implicit expectation.
+- **RESOLVED, see "`fill_first`/`most_available`: resolved" below.**
+  ~~Does `AggregateCapacityClient`'s `fill_first`/`most_available`
+  placement logic get deleted outright...~~ — kept, bug-fixed, not
+  bundled with the listing-mode hint. That same section also surfaced a
+  new, still-open question: whether the site-fallback behavior itself is
+  now vestigial for pool/resource-pinned claims post-POOLS-4.
+- **RESOLVED, see "Scope decision: retrofit, not compute-30 extraction"
+  below.** ~~Whether `market-platform-compute-30-extract-service`'s
+  absorbed package-boundary decision... should be forced by this
+  change...~~ — forced, for `PhysicalSettlementScheduler`/
+  `DeterministicRoundRobinPolicy` specifically (moved to
+  `compute_provisioning`); `compute-30`'s own proposal has been updated
+  to match.
+- **Operator listing-mode hints via `ResourcePool.policy_tags`** —
+  **RESOLVED, see "Listing-mode hint consumption" below.** The channel
+  question this bullet originally left open (how a storefront learns a
+  pool's `policy_tags` across the service boundary) is answered by
+  `CapacityProjection` (this file's "`SiteResource` is retired" section):
+  the pull-based pool mirror carries `policy_tags` along for free, no new
+  channel needed. The `_eligible_candidates`/`SiteResource.attributes.pool_id`
+  sync gap this bullet also raised is separately resolved by the same
+  section — `site_resource_pools` is now derived from `hosts`/
+  `resource_pools`, not storefront-pushed.
 
 ## Accepted provider configuration
 
@@ -728,3 +699,78 @@ order." Whether to keep the ranked-fallback code path for a
 still-possible generic/unpinned case, special-case pinned claims to route
 directly by known site, or something else, is not decided here — this is
 a question for planning, not resolved by this design review.
+
+## Listing-mode hint consumption: resolved (design review continued, 2026-07-17)
+
+Resolves the channel question the original "Operator listing-mode hints"
+entry above left open. No new channel is needed: `CapacityProjection`
+(this file's "`SiteResource` is retired" section) already pulls pool
+metadata from `GET /api/v1/pools`, so `policy_tags` rides along once the
+sync carries it:
+
+```python
+class CachedResourcePool(Base):
+    __tablename__ = "capacity_projection_pools"
+
+    site = Column(String, primary_key=True)
+    pool_id = Column(String, primary_key=True)
+    label = Column(String, nullable=False)
+    provider = Column(String, nullable=False)
+    enabled = Column(Boolean, nullable=False)
+    policy_tags = Column(JSON, nullable=False, default=dict)
+    synced_at = Column(DateTime, nullable=False)
+```
+
+The reconciler-driven publish path (`domains/vms/listings/reconciler.py`,
+`cli_publish.py`) already has a structural default, confirmed during
+`pools-4`'s design review: a listing derived from a single-resource pool
+is resource-pinned; one derived from a real multi-member pool is
+pool-scoped. This change's scope is narrower than originally framed: let
+an explicit hint override that default, don't replace it.
+
+```python
+# kit/resource-pools — domain-neutral: the key name only.
+LISTING_MODE_TAG = "listing_mode"
+
+# domains/vms — VM-domain interpretation + default.
+class VmListingMode(str, Enum):
+    pooled = "pooled"
+    specific_resource = "specific_resource"
+
+def resolve_vm_listing_mode(pool: CachedResourcePool, member_count: int) -> VmListingMode:
+    declared = pool.policy_tags.get(LISTING_MODE_TAG)
+    if declared in (VmListingMode.pooled.value, VmListingMode.specific_resource.value):
+        return VmListingMode(declared)
+    return (VmListingMode.specific_resource if member_count == 1
+            else VmListingMode.pooled)   # unchanged pools-4 structural default
+```
+
+**Extensibility confirmed against `apicredits`**, not just asserted: since
+`apicredits` is explicitly in scope for this session's broader
+`kit`/`CapacityReservation` reshape, the shape only counts as
+domain-neutral if `apicredits` can express something VM doesn't need
+without touching `kit/resource-pools`. It can — same `LISTING_MODE_TAG`
+key, a wholly different enum and default rule, zero kit changes:
+
+```python
+class ApiCreditsListingMode(str, Enum):
+    shared_quota = "shared_quota"     # listing draws from a pooled quota bucket
+    dedicated_key = "dedicated_key"   # listing is pinned to one provider API key
+
+def resolve_apicredits_listing_mode(pool: CachedResourcePool) -> ApiCreditsListingMode:
+    declared = pool.policy_tags.get(LISTING_MODE_TAG)
+    if declared in (ApiCreditsListingMode.shared_quota.value, ApiCreditsListingMode.dedicated_key.value):
+        return ApiCreditsListingMode(declared)
+    return ApiCreditsListingMode.shared_quota
+```
+
+`kit/resource-pools` owns one string key; each domain owns its own enum
+and default rule; no cross-domain coupling.
+
+**Enforcement posture unchanged, restated for the record:**
+`PhysicalSettlementScheduler`'s explicit-`resource_id` eligibility path
+(`pools-2`) is unaffected by a pool's `listing_mode` regardless — a
+buyer's explicit resource request is honored even against a pool tagged
+`pooled`. A storefront that never reads the tag, or one running against a
+provisioning service that predates this feature, falls through to the
+unchanged structural default. Purely additive.

--- a/openspec/changes/pools-7-storefront-fulfillment-cutover/design.md
+++ b/openspec/changes/pools-7-storefront-fulfillment-cutover/design.md
@@ -189,3 +189,185 @@ wired.
 ## Accepted provider configuration
 
 Durable fulfillment persistence must snapshot the accepted provider inputs needed for recovery and teardown so later pool edits cannot reinterpret already accepted work. Database uniqueness and dispatch recovery remain the cross-process idempotency boundary; POOLS-3's in-memory service intentionally provides only sequential retry behavior.
+
+## Scope decision: retrofit, not compute-30 extraction (design review, 2026-07-17)
+
+This session scoped POOLS-7 to retrofitting the existing VM domain
+storefront and provisioning service onto the POOLS 1-4 machinery, not to
+`market-platform-compute-30-extract-service`'s service extraction. kit
+packages (`kit/site`, `kit/resource-pools`) and the `apicredits` domain
+may be modified where genuinely cross-domain — this is permitted, not
+required, and several of the decisions below exercise that permission.
+The remainder of this section records what that design review settled.
+
+### `SiteResource` is retired; replaced by two distinct, differently-scoped entities
+
+Tracing why `PhysicalSettlementScheduler` and the storefront's local CSV
+inventory could disagree about `pool_id` (see "Operator listing-mode
+hints" above) surfaced a bigger problem than a missing sync: the
+storefront was maintaining its own shadow copy of physical inventory
+(`resources` table, hand-curated CSV) instead of treating the
+provisioning service's `hosts`/`resource_pools` tables as authoritative.
+Fixing the sync gap without fixing the ownership inversion would just
+move where the drift originates.
+
+Resolved shape:
+
+- **`site_resource_pools`** (renamed from `SiteResource`, `kit/site`,
+  hosted by the provisioning service) — stays **host-granular**, one row
+  per physical resource, exactly as `SiteResource` is today. It is no
+  longer independently authored by the storefront's CSV push; it is
+  derived from the provisioning service's own `hosts` + `resource_pools`
+  tables (POOLS-1), which are the actual single source of truth for host
+  inventory and pool membership. `pool_id` becomes a real, enforced
+  attribute rather than a storefront-authored guess that happens to
+  collide with an operator pool ID.
+- **`CapacityReservation`** (renamed from `SiteAllocation`) — the
+  hold/lease-tail row. Its primary claim target changes from an
+  always-concrete `resource_id` to `pool_id`; `settlement_resource_id`
+  becomes a nullable field populated once, by `assign_settlement_resource`,
+  when `PhysicalSettlementScheduler` makes its placement decision — not
+  rebound from one resource to another the way an earlier draft of this
+  review proposed. See "Host-granular matching is a feasibility
+  guarantee, not an aggregation choice" below for why this is now Option
+  A (reserve against one concrete resource up front; the scheduler
+  reassigns among *equally eligible* resources) rather than Option B
+  (reserve against a pool-level aggregate with no concrete resource until
+  scheduling) from this change's earlier draft.
+- **`CapacityProjection`** (storefront-side, new) — the storefront's
+  read-only, pull-based mirror of every connected provisioning service's
+  pool/capacity state (`GET /api/v1/pools`, which already exists and is
+  already reachable — the storefront already holds the admin key for
+  each configured site). This is the only place aggregation across hosts
+  happens, and it is explicitly advisory/display-only (pricing, listing
+  publication) — never the thing admission control checks against. Keyed
+  by `(site, pool_id)`, since pool IDs are only unique per provisioning
+  service.
+- **Physical Resource** (vocabulary term, unchanged) — already used
+  across kit with per-domain implementations; no change needed.
+
+This decision explicitly extends beyond the VM domain: `apicredits`
+today calls `CapacityLedgerService` directly with no pool concept at all
+("token quota resources carry no host"). The intent is for `apicredits`
+to also adopt a capacity-reservation-against-a-pooled-view shape, not
+just the VM domain — `kit/site`'s reshape must stay generic enough to
+carry a non-physical, non-host-shaped notion of "pool" (a quota bucket)
+as well as VM's host-shaped one.
+
+### Host-granular matching is a feasibility guarantee, not an aggregation choice (design review, 2026-07-17)
+
+An earlier draft of this review proposed collapsing `site_resource_pools`
+into one row per pool (aggregate `total_units`). **This is wrong and MUST
+NOT be implemented**: today's row-per-host matching
+(`_resource_matches`/`_find_candidate` in `kit/site/ledger.py`) is what
+guarantees a reservation for N units only succeeds when *some single
+host* actually has N units free — the arithmetic never sums across rows.
+Replacing that with one pool-level aggregate row would let a reservation
+succeed against a pool's total free capacity even when no single host in
+that pool can serve the shape (e.g. 500 units free scattered one-per-host
+across 500 machines, and a request for 4 units on one host). This is the
+`pools-6` risk *"pool-level aggregation can hide that dimensions live on
+different physical resources"* realized at **reservation** time instead
+of scheduling time — worse, because it means accepting a deal the system
+cannot structurally fulfill.
+
+**Resolved:** `site_resource_pools` rows stay host-granular.
+`CapacityReservation` binds to one concrete, feasibility-verified host at
+reservation time (today's mechanism, just correctly sourced from
+`hosts`/`resource_pools` instead of storefront CSV). This is "Option A"
+from this change's earlier draft, not "Option B" (deferring all resource
+selection to scheduling) — Option B is deferred to `pools-6` alongside
+multidimensional capacity, not attempted here. `assign_settlement_resource`
+remains a real, atomic capacity-transfer mechanism, but its role is
+narrowed: a **fairness reassignment among already-equally-eligible
+hosts**, not a relaxation of feasibility that reservation-time admission
+already established.
+
+### Reservation-time admission and scheduling-time eligibility MUST share one predicate
+
+`kit/site/ledger.py`'s `_resource_matches` (reservation admission) and
+`PhysicalSettlementScheduler._eligible_candidates` (scheduling
+eligibility) are two independent implementations of "does this shape fit
+this resource" today. This is the same class of bug as the `pool_id`
+mismatch this review started from: two things that must agree, with
+nothing forcing them to. Resolved direction: extract a single
+`resource_satisfies_requirement(resource, requirement) -> bool` predicate
+that both call sites use — reservation calls it to gate admission ("does
+at least one host qualify"), scheduling calls it to build the eligible
+set for policy selection. Exact home for this predicate (alongside
+`PhysicalSettlementScheduler` in `compute_provisioning`, or in
+`kit/site` where the resource rows themselves live) is not decided;
+resolve during planning.
+
+### `PhysicalSettlementScheduler` and `DeterministicRoundRobinPolicy` move to `compute_provisioning`, not `kit/resource-pools`
+
+Both are already effectively domain-neutral (`DeterministicRoundRobinPolicy`
+verified to contain zero VM-specific logic — it only sorts `pool_id`/
+`resource_id` strings). Moving them out of VM-service-local code was
+considered for `kit/resource-pools` (where `FulfillmentProvider`/
+`ProviderRegistry` already live, per `pools-3`), but that destination is
+**not viable**: `PhysicalSettlementScheduler` needs real runtime imports
+from `compute_provisioning` (`SettlementCandidate`, `SettlementRequirement`,
+`SettlementResource`, `PhysicalSettlementRequest` — constructed, not just
+type-hinted, unlike `FulfillmentProvider`'s string-quoted forward
+references), and `compute_provisioning` already depends on
+`kit/resource-pools` (`provisioning/compute/pyproject.toml`). Adding the
+reverse edge would close a cycle.
+
+`compute_provisioning` has no such problem — it already depends on both
+`kit/site` and `kit/resource-pools`, and the settlement types the
+scheduler operates on already live there (`pools-2`). **Resolved:**
+`PhysicalSettlementScheduler` and `DeterministicRoundRobinPolicy` move
+into `compute_provisioning`.
+
+This incidentally resolves part of the open, unresolved question
+`market-platform-compute-30-extract-service` inherited from the closed
+`pools-5-shared-provisioning-package` ("should `PhysicalSettlementScheduler`
+... consolidate into `compute_provisioning`") — without POOLS-7 taking on
+compute-30's actual service-extraction scope. This is the same kind of
+narrow, deliberate override `pools-3` already made once for
+`FulfillmentProvider`/`ProviderRegistry`; see that change's `design.md`,
+"Domain-neutral contracts vs. domain-specific payloads." `compute-30`'s
+proposal has been updated to reflect this as resolved rather than open.
+
+Two pre-existing domain leaks were found while confirming this move is
+safe, and should be fixed as part of it rather than carried into a
+supposedly domain-neutral shared package:
+
+- `kit/site/ledger.py`'s `_UNIT_CLAIM_KEYS = ("units", "gpu_count")` is a
+  module-level constant hardcoding a VM-specific alias into otherwise
+  domain-neutral ledger code. Should become a `CapacityLedgerService.__init__`
+  parameter (default `("units",)`), with the VM composition root supplying
+  `("units", "gpu_count")` explicitly — same pattern already used for
+  `required_attributes`.
+- `PhysicalSettlementScheduler._requirement`'s fallback
+  (`resource_kind = ... or "compute.gpu"`) silently defaults to a
+  VM-flavored value. Once shared across domains this default is wrong for
+  `apicredits`. Should become a required field with no fallback, or an
+  injected per-domain default at the composition root.
+
+## Dependency on POOLS-6: multidimensional capacity is a prerequisite, not parallel work
+
+Design review (2026-07-17) surfaced a correctness gap that blocks
+`site_resource_pools`/`CapacityReservation` from being trustworthy even
+with the host-granularity fix above: **`Host` (`domains/vms/provisioning/
+service/src/db/models.py`) has no memory, disk, or vCPU capacity field —
+only `gpu_count`.** Reservation admission can therefore verify GPU-count
+bin-packing correctly but cannot verify that a negotiated shape
+(vCPU/memory/disk, carried today only in `VmFulfillmentRequirements` at
+*fulfillment* time, downstream of admission) actually fits any real
+host. A reservation can be admitted for a shape no physical machine can
+serve.
+
+This is a real instance of `pools-6`'s deliberately-abstract problem
+statement, not a new problem — see `pools-6-multidimensional-fair-scheduling/
+proposal.md`'s "Concrete, currently-unenforced gap" addition. POOLS-7's
+reservation-admission work depends on `pools-6` resolving multidimensional
+capacity tracking; it is not POOLS-7's scope to solve, and POOLS-7 MUST
+NOT quietly re-derive a partial answer (e.g. adding only a memory field to
+`Host` without going through `pools-6`'s design questions on dimension
+normalization, units, and fairness) in order to unblock itself. Sequencing:
+`pools-6` resolves multidimensional capacity vectors first; POOLS-7's
+reservation-admission and scheduling-eligibility work (including the
+shared `resource_satisfies_requirement` predicate above) consumes that
+result rather than working around its absence.

--- a/openspec/changes/pools-7-storefront-fulfillment-cutover/design.md
+++ b/openspec/changes/pools-7-storefront-fulfillment-cutover/design.md
@@ -524,27 +524,77 @@ still-`assigned`, non-mutable design above accommodates this without
 treating it as an error case: the record simply waits in `assigned`,
 idempotently, until either dispatch or a supersede/release reaches it.
 
-### Requirements change under negotiation: supersede, never mutate (design review continued, 2026-07-17)
+### Requirements change under negotiation: supersede, never mutate (design review continued, 2026-07-17; ordering corrected 2026-07-17)
 
 **Resolved:** if a deal's requirements change after a
 `CapacityReservation`/`SettlementRecord` already exists for it (still
 `assigned`, not yet dispatched), the caller mints a **new**
-`allocation_id`, reserves capacity for the *new* shape under it, and only
-**after that reservation succeeds** releases the *old* `allocation_id`'s
-`CapacityReservation`. Never mutates the existing reservation or
+`allocation_id`, reserves capacity for the *new* shape under it, and the
+*old* `allocation_id`'s `CapacityReservation` is released as part of the
+same atomic operation. Never mutates the existing reservation or
 `SettlementRecord` in place.
 
-Ordering matters and is the crux of the decision: **reserve-new, then
-release-old — never release-old-then-reserve-new.** If a new reservation
-attempt fails (the updated shape genuinely isn't available), the old
-reservation MUST remain untouched and valid — the negotiation continues
-on the original terms, and whatever's negotiating (an agent, most likely)
-takes the failure back into the negotiation ("can't do X, can still do
-Y") rather than the system having destroyed a working reservation while
-chasing one that didn't pan out. This is achievable with existing
-primitives — an ordinary `reserve()` call for the new shape, then an
-ordinary `release()` of the old `allocation_id` — no new ledger mechanism
-needed.
+**The mechanism is one atomic ledger transaction, not two independently-
+committed calls in a chosen order.** An earlier version of this decision
+proposed "reserve-new, then release-old" as two ordinary, separate
+`reserve()`/`release()` calls specifically to guarantee the old
+reservation survives if the new one fails. That ordering has a real
+false-negative bug: evaluating the new shape's availability *before*
+releasing the old reservation means the check runs against a view where
+the old hold is still artificially consuming capacity — a resource that
+would satisfy the new request the moment the old hold clears can
+incorrectly report as unavailable, because that capacity is invisible
+until release actually happens. Reversing the order (release-then-reserve)
+would fix the visibility problem but reintroduces the original risk: a
+failed re-reservation would leave the negotiation with nothing, since the
+old reservation is already gone.
+
+Both properties — the new shape's availability evaluated *as if* the old
+hold were already released, and the old reservation left completely
+untouched if the new shape can't be satisfied — are only simultaneously
+achievable via one transaction that releases-then-reserves internally,
+committing only on success and rolling back in full on failure:
+
+```python
+def resize_reservation(
+    self, db, *, old_allocation_id: str, new_claim: dict, ttl_seconds: int,
+) -> str:
+    """Atomically supersede a CapacityReservation with a new shape."""
+    with db.begin():
+        old = self._require_active_reservation(db, old_allocation_id, for_update=True)
+        self._release_locked(db, old)          # frees old's held units,
+                                                  # visible only inside
+                                                  # this open transaction
+        resource, available = self._find_candidate(db, new_claim)  # now
+                                                  # correctly sees the
+                                                  # capacity old was
+                                                  # holding
+        if resource is None:
+            raise CapacityUnavailableError(...)  # transaction rolls back
+                                                    # in full — old's
+                                                    # release is undone,
+                                                    # nothing commits, old
+                                                    # remains exactly as
+                                                    # it was
+        new_allocation_id = self._reserve_locked(db, resource, new_claim, ttl_seconds)
+        if old_settlement_record_exists(db, old_allocation_id):
+            # mark it abandoned synchronously, in this same transaction —
+            # don't wait for the lease-lifecycle watchdog's next sweep
+            self._mark_settlement_abandoned(db, old_allocation_id)
+        return new_allocation_id   # committed atomically with everything above
+```
+
+Row locking (`for_update=True` on the old reservation, plus whatever
+locking `_find_candidate`'s candidate resources already use) prevents a
+concurrent transaction from grabbing the momentarily-freed capacity while
+this transaction is still open. This generalizes the atomic-rebind
+pattern `assign_settlement_resource` already uses (release source,
+check/claim destination, atomically) to a case that pattern doesn't
+already cover: there, source and destination are always *different*
+physical resources (or a true no-op when identical), so the old hold
+never blocks the new claim's availability check. Here, source and
+destination can legitimately be the *same* resource or same pool — which
+is exactly when the false-negative risk shows up.
 
 This is also why the `select_resource` idempotency simplification above
 is correct rather than a loss of capability: every "requirements changed"

--- a/openspec/changes/pools-7-storefront-fulfillment-cutover/design.md
+++ b/openspec/changes/pools-7-storefront-fulfillment-cutover/design.md
@@ -223,17 +223,21 @@ Resolved shape:
   attribute rather than a storefront-authored guess that happens to
   collide with an operator pool ID.
 - **`CapacityReservation`** (renamed from `SiteAllocation`) — the
-  hold/lease-tail row. Its primary claim target changes from an
-  always-concrete `resource_id` to `pool_id`; `settlement_resource_id`
-  becomes a nullable field populated once, by `assign_settlement_resource`,
-  when `PhysicalSettlementScheduler` makes its placement decision — not
-  rebound from one resource to another the way an earlier draft of this
-  review proposed. See "Host-granular matching is a feasibility
-  guarantee, not an aggregation choice" below for why this is now Option
-  A (reserve against one concrete resource up front; the scheduler
-  reassigns among *equally eligible* resources) rather than Option B
-  (reserve against a pool-level aggregate with no concrete resource until
-  scheduling) from this change's earlier draft.
+  hold/lease-tail row. `resource_id` still binds **immediately**, at
+  `reserve()` time, to one concrete, feasibility-verified host — exactly
+  as `SiteAllocation` does today (see "Host-granular matching is a
+  feasibility guarantee" below for why this must not change to a
+  pool-only claim). `pool_id` is carried alongside it, denormalized from
+  that resource, so pool-scoped queries don't need a join.
+  `settlement_resource_id` is a separate, nullable field: NULL until
+  `PhysicalSettlementScheduler` runs, then set by
+  `assign_settlement_resource` — in the common case equal to `resource_id`
+  (the scheduler confirms the host `reserve()` already picked), differing
+  only when round-robin fairness reassigns to a different, equally
+  eligible host. This is Option A (reserve against one concrete resource
+  up front; the scheduler reassigns among *equally eligible* resources),
+  not Option B (reserve against a pool-level aggregate with no concrete
+  resource until scheduling) from this change's earlier draft.
 - **`CapacityProjection`** (storefront-side, new) — the storefront's
   read-only, pull-based mirror of every connected provisioning service's
   pool/capacity state (`GET /api/v1/pools`, which already exists and is
@@ -371,3 +375,166 @@ normalization, units, and fairness) in order to unblock itself. Sequencing:
 reservation-admission and scheduling-eligibility work (including the
 shared `resource_satisfies_requirement` predicate above) consumes that
 result rather than working around its absence.
+
+## `SettlementRecord` shape (design review continued, 2026-07-17)
+
+**Resolved: one row, one state machine** — not a separate
+scheduler-owned assignment table plus a distinct fulfillment record.
+Reasoning: `select_resource` and `FulfillmentService.create` are, per
+`pools-3`'s own diagram, meant to be called in sequence by one
+orchestrator as part of one fulfillment step, not separated by
+meaningful business time in the common case (see "Expected time between
+scheduling and dispatch" below for the one real exception). A single row
+answers "does this allocation have a settlement, and what state is it
+in" with one lookup, keeps both services' idempotency checks on the same
+primary key, and gives an admin one row to read per allocation instead of
+reconciling two tables — the same auditability property already valued
+in this codebase's lease-lifecycle design (`SiteAllocation`/
+`CapacityReservation` merging the hold and the lease tail into one row
+for the same reason).
+
+```python
+class SettlementRecordState(str, enum.Enum):
+    assigned         = "assigned"          # scheduler picked a resource,
+                                            # no dispatch yet — the ONLY
+                                            # state in which the row may
+                                            # still be re-selected/mutated
+    dispatch_pending = "dispatch_pending"  # about to call provider.create();
+                                            # written durably BEFORE the
+                                            # call, for crash recovery
+                                            # (see point 2, commit <->
+                                            # async-dispatch failure window)
+    dispatching      = "dispatching"       # provider accepted the job;
+                                            # tracking metadata recorded
+    active           = "active"            # provider reports succeeded
+    failed           = "failed"            # validation rejected, or
+                                            # provider reports failed
+    tearing_down     = "tearing_down"
+    torn_down        = "torn_down"
+    teardown_failed  = "teardown_failed"
+    abandoned        = "abandoned"         # reservation expired/released/
+                                            # changed while still
+                                            # "assigned" — no physical work
+                                            # was ever dispatched. Terminal,
+                                            # not re-enterable: a rejected
+                                            # (expired) CapacityReservation
+                                            # blocks select_resource from
+                                            # ever reaching this record
+                                            # again, so select_resource
+                                            # itself never needs to special-
+                                            # case "abandoned" vs. "no
+                                            # record" — the reservation
+                                            # check upstream already
+                                            # distinguishes them.
+
+
+class SettlementRecord(Base):
+    __tablename__ = "settlement_records"
+
+    allocation_id = Column(String, ForeignKey("capacity_reservations.allocation_id"),
+                            primary_key=True)
+    agreement_id = Column(String, nullable=False)
+    market = Column(String, nullable=False)
+    pool_id = Column(String, nullable=False)
+    settlement_resource_id = Column(String, nullable=False)
+    provider = Column(String, nullable=False)
+    requirements = Column(JSON, nullable=False)   # for equivalence checks;
+                                                    # mutable while state=="assigned"
+                                                    # (negotiation may still change
+                                                    # requirements before dispatch)
+    provider_metadata = Column(JSON, nullable=False, default=dict)
+    teardown_provider_metadata = Column(JSON, nullable=True)
+    state = Column(String, nullable=False, default=SettlementRecordState.assigned.value)
+    created_at = Column(DateTime, ...)
+    updated_at = Column(DateTime, ...)
+```
+
+### Two different idempotency rules depending on `state`
+
+`select_resource`'s existing-record handling is NOT a single uniform
+"record exists -> return it" rule. The dividing line is whether `state`
+has left `assigned`:
+
+- **`state == "assigned"` (including no record at all):** the row is
+  still a mutable scheduling decision. `select_resource` is free to
+  re-run eligibility/selection and overwrite `pool_id`,
+  `settlement_resource_id`, `provider`, and `requirements` — needed for
+  the case where negotiation changes the deal's requirements (or the
+  buyer's requested capacity) after an initial schedule but before
+  dispatch. `assign_settlement_resource` already handles the capacity
+  side of a genuine re-pick atomically (no-op if the resource is
+  unchanged; moves held units correctly if it's a real reassignment) —
+  `select_resource` now also calls it on re-selection, not only on first
+  selection.
+- **`state != "assigned"` (dispatch has started or finished):** the row
+  is the immutable, equivalence-checked record `pools-3` already
+  specified. `select_resource` returns it as-is; an explicit-resource
+  request that disagrees with `settlement_resource_id` fails with
+  `SettlementRequestMismatchError`. No expiry check applies on this path
+  — the `CapacityReservation`'s TTL hold is irrelevant once real physical
+  work exists; only equivalence/conflict rules apply from here.
+
+`CapacityReservation` expiry (`CapacityReservationExpiredError`) is
+therefore checked **only** on the "still assigned, may re-schedule"
+path, never on the "already dispatched" fast-return path — an allocation
+whose TTL lapsed after dispatch already succeeded must not have its
+retries start failing.
+
+**If an operator requests scheduling against an already-expired
+`CapacityReservation`, `select_resource` MUST reject it.** The storefront
+handles that failure by requesting a fresh `CapacityReservation` (which
+may itself fail if the physical picture changed in the interim) — this
+is an existing, already-designed failure path in `pools-2`'s error
+taxonomy, not new work. It is deliberately the storefront's
+responsibility how long a hold it asks for; see "Pool-level reservation
+TTL hint" below for an operator-side lever on that.
+
+### `abandoned` state and the lease-lifecycle watchdog
+
+A `CapacityReservation` can expire, release, or have its requirements
+change while its `SettlementRecord` is still sitting in `assigned`
+(nothing dispatched yet) — this is expected to be the common case for
+delay between scheduling and dispatch, not the exception; see below. The
+existing watchdog that already sweeps expired/released
+`CapacityReservation` rows (`LeaseLifecycleService.check_leases`) should
+also transition any `assigned`-state `SettlementRecord` for that
+allocation to `abandoned` — reusing the existing sweep rather than adding
+a second, parallel watchdog. No capacity cleanup is needed as part of
+that specific transition: `assign_settlement_resource` only ever moves
+*which* resource the reservation's already-held units point at, and the
+reservation's own release path already frees whatever resource it
+currently points to, independent of whether a `SettlementRecord` was
+ever created. `abandoned` exists purely for audit clarity, so a
+`settlement_records` row never sits at `assigned` forever with no
+explanation of why it stalled.
+
+### Expected time between scheduling and dispatch
+
+Normally short — scheduling shouldn't happen until fulfillment is about
+to occur, at which point there is little reason for delay between
+`select_resource` and `FulfillmentService.create`. The gap that matters
+in practice is between **reservation and scheduling**, not between
+scheduling and dispatch — a `CapacityReservation` may sit unscheduled for
+a long time and can expire before it's ever scheduled. A real (if
+uncommon) case for delay between scheduling and dispatch specifically:
+scheduling happening as part of agent lease negotiation itself (e.g. a
+delayed lease start time, or a late-stage negotiation change), most
+plausibly triggered by the buyer's requested capacity/requirements
+changing mid-negotiation after an earlier schedule. The
+still-`assigned`/mutable-until-dispatch design above is what accommodates
+this without treating it as an error case.
+
+### Pool-level reservation TTL hint (flagged, not designed here)
+
+An operator may want a pool-level limit on how long a
+`CapacityReservation` against their resources can sit unscheduled/held —
+raised during this review as a real, well-motivated use case, not
+designed here. Same shape and posture as the listing-mode hint above:
+an additive `ResourcePool.policy_tags` entry
+(`{"max_reservation_hold_seconds": 900}`), read and voluntarily respected
+by a cooperating storefront when it chooses the `ttl_seconds` it passes
+to `reserve()` — never enforced by the provisioning service itself
+(`reserve()` already accepts a caller-supplied `ttl_seconds`; no new
+ledger capability is needed, only a place for the operator to express a
+preference and a storefront willing to read it). Left for planning to
+schedule, not required by POOLS-7's first pass.

--- a/openspec/changes/pools-7-storefront-fulfillment-cutover/design.md
+++ b/openspec/changes/pools-7-storefront-fulfillment-cutover/design.md
@@ -605,3 +605,126 @@ pursued: it would solve a problem this fix closes more cheaply by
 finishing the wiring of a dedup mechanism that already exists in this
 codebase, without changing `create()`'s synchronous-with-side-effect API
 shape.
+
+## `fill_first`/`most_available`: resolved (design review continued, 2026-07-17)
+
+### `CapacityProjection` MUST NOT replace the live per-request snapshot these policies read
+
+`fill_first`/`most_available` run inside `AggregateCapacityClient.probe()`/
+`.reserve()`, choosing which site to try first for one specific,
+in-flight request, via a live `_snapshots()` call at request time.
+`CapacityProjection` (this file's earlier "`SiteResource` is retired"
+section) is explicitly advisory/display-only, refreshed on its own pull
+cadence, and can be stale by design — it exists for pricing/listing
+publication, never for admission. **These MUST stay two separate
+mechanisms**: `CapacityProjection` for display, live per-request
+`_snapshots()` for routing. A stale `CapacityProjection` entry routing a
+real reservation attempt toward an empty site would turn a display cache
+into a load-bearing routing input, defeating the reason it's allowed to
+be stale in the first place.
+
+### Bug fix: `most_available` ignores `claim`
+
+Confirmed: `most_available` accepts `claim` but never uses it —
+`_site_available_units` sums every row's `available_units` regardless of
+pool/resource/attribute match, so a site with capacity in an unrelated
+pool can look "most available" for a request it cannot serve. Fix:
+
+```python
+# core/storefront/aggregation.py
+
+def _resource_matches_claim(row: Mapping[str, Any], claim: Mapping[str, Any] | None) -> bool:
+    """Best-effort client-side ranking hint only — NOT an enforcement
+    point. Deliberately does not import kit/site (the aggregator is a
+    storefront-process concept and must not depend on
+    provisioning-service-internal packages); operates on the plain-dict
+    snapshot() payload that crosses the HTTP boundary."""
+    if not claim:
+        return True
+    attrs = row.get("attributes") or {}
+    for key, expected in claim.items():
+        if key in ("units", "gpu_count"):
+            continue
+        if attrs.get(key, row.get(key)) != expected:
+            return False
+    return True
+
+def _site_available_units(snapshot, claim):
+    return sum(max(int(r.get("available_units") or 0), 0)
+               for r in snapshot if _resource_matches_claim(r, claim))
+```
+
+**Deliberately NOT sharing code with `kit/site`'s `_resource_matches` or
+`PhysicalSettlementScheduler`'s `resource_satisfies_requirement`**, unlike
+the earlier `pool_id`-mismatch and matching-logic-duplication fixes in
+this document. Those two are enforcement/eligibility gates where drift is
+a correctness bug (an admitted-but-unfulfillable reservation). This one
+is a best-effort ranking hint that only affects *try order* —
+`probe()`/`reserve()` on the chosen site remain the real, authoritative
+check, and `AggregateCapacityClient.reserve()` already falls through to
+the next site on refusal. A wrong ranking here costs one extra
+round-trip, not an incorrect admission. Duplicating the shape of the
+check across the HTTP process boundary is an acceptable, deliberate
+trade-off in this one case — do not "fix" this later by forcing a shared
+predicate across that boundary.
+
+### No bundling with the `policy_tags` listing-mode hint
+
+Considered and rejected: `ResourcePool.policy_tags` is a property of one
+pool within one site; `fill_first`/`most_available` choose among *sites*
+(different provisioning services). A pool-level preference does not
+translate into a site-ranking signal without aggregating every pool's
+hint across every site into one score — a materially different, later
+feature, not a natural extension of this fix. The listing-mode hint stays
+scoped to how the storefront *publishes* listings, never to placement
+ranking.
+
+### Layered ownership model (expanded per design review request)
+
+Three genuinely distinct decisions, at three different times, owned by
+two different processes, must not be conflated:
+
+| Decision | Owned by | When | Mechanism |
+|---|---|---|---|
+| Which pool/resource a listing represents | Storefront | **Publish time** | Listing-mode hint (point 4) + `CapacityProjection`, baked into the listing's `offer_resource.pool_id`/`resource_id` at creation (POOLS-4) |
+| Which site to route a reserve/probe call to | Storefront (`AggregateCapacityClient`) | **Reserve/negotiate time** | `fill_first`/`most_available`, live `_snapshots()` |
+| Which concrete host within that pool fulfills the reservation | Provisioning service (`PhysicalSettlementScheduler`) | **Schedule time** | Deterministic round-robin (or later, a `pools-6` policy) |
+
+`aggregation.py`'s own docstring already states the reasoning for the
+second layer staying storefront-owned rather than moving into
+`compute_provisioning`/kit alongside the third: *"pooling/placement is a
+commercial judgment per seller... it lives in the storefront process, not
+in a site and not in a shared service."* Nothing in this session's
+`compute_provisioning`/kit consolidation work changes that — the second
+and third layers pick among fundamentally different things (sites vs.
+hosts within one already-chosen site) and are correctly already
+separated by process boundary, not just by convention.
+
+### Open question surfaced by writing this table down: is the second layer's fallback still meaningful post-POOLS-4?
+
+Not resolved here — flagged for planning. Before POOLS-4, a claim could
+be a generic attribute shape (`region`, `gpu_model`, `gpu_count`) with no
+`pool_id`/`resource_id`, so the same claim could legitimately match
+equivalent fungible capacity at more than one site, and trying sites in
+ranked order with fallback-on-refusal made sense. POOLS-4 now requires
+every listing's claim to carry `pool_id` and/or `resource_id`
+("unscoped claims are invalid"), and `pool_id`/`resource_id` are only
+unique **within one site** (this file's `CapacityProjection` section).
+Once a specific listing is published, its pool/resource identity — and
+therefore its owning site — is already fixed at publish time (the first
+row of the table above). Trying that *same, now-pinned* claim against a
+second site's `reserve()` will almost always find no matching pool/
+resource there at all (a coincidental name collision aside), rather than
+legitimately finding equivalent capacity elsewhere the way it could
+pre-POOLS-4.
+
+This suggests `AggregateCapacityClient`'s try-in-order-with-fallback
+behavior may now be effectively vestigial for pool/resource-pinned VM
+listings — the real routing decision for a specific deal may just be
+"look up the one site this listing's pool/resource is known to live at"
+(deterministic, since every row crossing the HTTP boundary is already
+site-tagged — `_tagged(site, payload)`), not "try each site in ranked
+order." Whether to keep the ranked-fallback code path for a
+still-possible generic/unpinned case, special-case pinned claims to route
+directly by known site, or something else, is not decided here — this is
+a question for planning, not resolved by this design review.

--- a/openspec/changes/pools-7-storefront-fulfillment-cutover/proposal.md
+++ b/openspec/changes/pools-7-storefront-fulfillment-cutover/proposal.md
@@ -20,12 +20,11 @@ not assumed) is entirely separate:
 
 So there are two parallel, non-interacting systems today: the one the
 storefront actually uses, and the one `pools-2`/`pools-3` are building.
-This change is where that gets reconciled — but not yet, and not without
-more information than exists in this session. It's recorded now as a
-placeholder so a future session has the full context without re-deriving
-it.
+POOLS-7 reconciles these paths by cutting the storefront over to durable
+physical-resource scheduling and fulfillment managed by the provisioning
+service.
 
-## What This Change Will Eventually Cover
+## What This Change Covers
 
 - Change the storefront's ordinary reservation path from host-shaped
   (`vm_host` required attribute) to pool-shaped, consuming
@@ -33,7 +32,7 @@ it.
 - Replace `create_vm_and_wait_with_credentials`'s direct
   `ExecutorActionEnvelope` dispatch with two provisioning-side calls the
   storefront invokes as separate operations — schedule
-  (`PhysicalSettlementScheduler.select_resource`) and dispatch
+  (`PhysicalSettlementScheduler.select_resource`) and begin fulfillment
   (`FulfillmentService.create`) — plus an optional convenience operation
   that composes both for callers that don't need the pricing-preview
   behavior. **`FulfillmentService` does not call the scheduler and never
@@ -56,7 +55,7 @@ it.
   scheduler while there was no caller to design against
   (`pools-3`'s `design.md`, Risks).
 - Add durable database-backed fulfillment idempotency keyed by
-  `allocation_id`. Equivalent retries return the existing fulfillment;
+  `capacity_reservation_id`. Equivalent retries return the existing fulfillment;
   conflicting reuse fails before dispatch. Database uniqueness and
   transactions, not process-local locks, are the correctness mechanism.
   Explicitly handle recovery across the commit/queue-dispatch failure window.
@@ -71,19 +70,16 @@ it.
 
 ## Status
 
-This change is active — a full design review (2026-07-15 through
-2026-07-17) resolved the scope and package-boundary questions this
-section originally deferred. It is not yet planned (no `tasks.md`); the
-next step is planning, not a further design-review pass, unless planning
-surfaces a genuine new ambiguity.
+This change is active and design-complete. The design review completed on
+2026-07-20, and `tasks.md` is the implementation plan for the cutover.
 
 **Resolved scope, superseding the original activation gate below:**
 this change retrofits the existing VM domain storefront and provisioning
 service onto the POOLS 1-4 machinery. It does not perform
 `market-platform-compute-30-extract-service`'s service extraction —
-where `PhysicalSettlementScheduler`/`DeterministicRoundRobinPolicy` live
-was decided directly by this change's design review (moved to
-`compute_provisioning`; see `design.md`) rather than waited on. `kit/site`
+the shared physical-settlement lifecycle, persistence, scheduler, and recovery
+contracts live was decided directly by this change's design review (a new
+`kit/physical-settlement` package; see `design.md`) rather than waited on. `kit/site`
 and `kit/resource-pools` may be modified where genuinely cross-domain,
 and the `apicredits` domain is explicitly in scope for the same
 capacity-reservation-against-a-pooled-view reshape, not just VM — both
@@ -93,10 +89,7 @@ permitted, not required, exercised where this review found real need.
 
 - `pools-2-physical-settlement-scheduler` — implemented prerequisite.
 - `pools-3-fulfillment-provider` — implemented prerequisite.
-- `pools-4-storefront-capacity-boundary` — prerequisite; verify landed
-  status at planning time (see original activation condition below —
-  this dependency itself is unchanged, only the compute-30 half of the
-  original gate is resolved).
+- `pools-4-storefront-capacity-boundary` — implemented prerequisite.
 - `pools-6-multidimensional-fair-scheduling` — **blocking prerequisite**,
   found during this review, not part of the original gate: `Host` has no
   memory/disk/vCPU capacity field, so reservation admission cannot verify
@@ -112,26 +105,7 @@ permitted, not required, exercised where this review found real need.
 - `market-platform-compute-30-extract-service` — related follow-on, not
   an activation prerequisite or blocker.
 
-**Original activation condition (superseded above, kept for history):**
-
-This stayed taskless until:
-
-- (a) `pools-4-storefront-capacity-boundary` has landed — the storefront
-  needs to already be asking for pool-shaped capacity before it can
-  meaningfully call a resource scheduler instead of picking its own
-  `vm_host`, and
-- (b) either `market-platform-compute-30-extract-service` has completed
-  its cutover and settled where `PhysicalSettlementScheduler`/
-  `FulfillmentProvider`/`ProviderRegistry` physically live
-  (`compute_provisioning` vs. staying VM-service-local — see that change's
-  "Absorbed from POOLS-5" section, formerly tracked by the now-closed
-  `pools-5-shared-provisioning-package`), or a second domain forces that
-  decision sooner — whichever comes first.
-
-(b) was resolved directly rather than waited on, per "Resolved scope"
-above.
-
-## Non-Goals (once activated)
+## Non-Goals
 
 - Anything `pools-4` already covers (claim-shape change itself).
 - Kubernetes/cloud/other non-Ansible providers — inherits `pools-3`'s
@@ -152,7 +126,7 @@ above.
 
 ## Capabilities
 
-### Modified Capabilities (once activated)
+### Modified Capabilities
 
 - `site-capacity`: storefront capacity reservation and fulfillment call
   shape changes to consume the scheduler/provider path.
@@ -165,7 +139,7 @@ above.
 
 - Requires `pools-2-physical-settlement-scheduler` (implemented) and
   `pools-3-fulfillment-provider` (implemented).
-- Requires `pools-4-storefront-capacity-boundary` to land first.
+- Requires `pools-4-storefront-capacity-boundary` (implemented).
 - **Requires `pools-6-multidimensional-fair-scheduling`** — blocking
   prerequisite for reservation-admission work; see "Status" above.
 - Related, not blocking: `pools-8-capacity-projection-and-listing-hints`
@@ -179,10 +153,8 @@ above.
 ## Impact
 
 Touches `kit/site` (`site_resource_pools`/`CapacityReservation` reshape),
-`compute_provisioning` (scheduler/policy relocation, `SettlementRecord`),
+`kit/physical-settlement` (scheduler/policy relocation, settlement persistence, recovery, and result-delivery contracts),
 the VM provisioning service (models, migrations, services, release
 lifecycle), and the VM storefront's reservation/orchestration path.
 Blocked on `pools-6` for reservation-admission correctness; not fully
-complete end-to-end without `pools-8`. Detailed file-level impact is a
-planning-step output, not assessed further here — this section will be
-revised once `tasks.md` exists.
+complete end-to-end without `pools-8`. The dependency-ordered implementation work is defined in `tasks.md`.

--- a/openspec/changes/pools-7-storefront-fulfillment-cutover/proposal.md
+++ b/openspec/changes/pools-7-storefront-fulfillment-cutover/proposal.md
@@ -31,11 +31,17 @@ it.
   (`vm_host` required attribute) to pool-shaped, consuming
   `pools-4-storefront-capacity-boundary`'s reservation claim shape.
 - Replace `create_vm_and_wait_with_credentials`'s direct
-  `ExecutorActionEnvelope` dispatch with a provisioning-side
-  `FulfillmentService` call. That service coordinates
-  `PhysicalSettlementScheduler.select_resource`, provider resolution,
-  asynchronous create dispatch, and normalized status observation (see
-  `pools-3`'s asynchronous-provider decision — `create()` is dispatch-only by design).
+  `ExecutorActionEnvelope` dispatch with two provisioning-side calls the
+  storefront invokes as separate operations — schedule
+  (`PhysicalSettlementScheduler.select_resource`) and dispatch
+  (`FulfillmentService.create`) — plus an optional convenience operation
+  that composes both for callers that don't need the pricing-preview
+  behavior. **`FulfillmentService` does not call the scheduler and never
+  will** (`pools-3`'s explicit, unchanged boundary decision); the
+  storefront calls them in sequence because `select_resource`'s result
+  can be commercially material before a deal is finalized (see
+  `design.md`, "Storefront orchestrates scheduling and dispatch as
+  separate calls").
 - Resolve `pools-3`'s deferred release-path wiring: give
   `VmReleaseExecutor` (or its replacement) a way to resolve
   `SettlementRecord` → `ProviderRegistry.require(provider).teardown(...)`
@@ -63,9 +69,52 @@ it.
   policy is meant to own. Likely removed or reduced to pool-level
   preference once the storefront stops picking concrete resources itself.
 
-## Activation Condition
+## Status
 
-This stays taskless until:
+This change is active — a full design review (2026-07-15 through
+2026-07-17) resolved the scope and package-boundary questions this
+section originally deferred. It is not yet planned (no `tasks.md`); the
+next step is planning, not a further design-review pass, unless planning
+surfaces a genuine new ambiguity.
+
+**Resolved scope, superseding the original activation gate below:**
+this change retrofits the existing VM domain storefront and provisioning
+service onto the POOLS 1-4 machinery. It does not perform
+`market-platform-compute-30-extract-service`'s service extraction —
+where `PhysicalSettlementScheduler`/`DeterministicRoundRobinPolicy` live
+was decided directly by this change's design review (moved to
+`compute_provisioning`; see `design.md`) rather than waited on. `kit/site`
+and `kit/resource-pools` may be modified where genuinely cross-domain,
+and the `apicredits` domain is explicitly in scope for the same
+capacity-reservation-against-a-pooled-view reshape, not just VM — both
+permitted, not required, exercised where this review found real need.
+
+**Dependencies, current as of this review:**
+
+- `pools-2-physical-settlement-scheduler` — implemented prerequisite.
+- `pools-3-fulfillment-provider` — implemented prerequisite.
+- `pools-4-storefront-capacity-boundary` — prerequisite; verify landed
+  status at planning time (see original activation condition below —
+  this dependency itself is unchanged, only the compute-30 half of the
+  original gate is resolved).
+- `pools-6-multidimensional-fair-scheduling` — **blocking prerequisite**,
+  found during this review, not part of the original gate: `Host` has no
+  memory/disk/vCPU capacity field, so reservation admission cannot verify
+  a negotiated shape fits any real machine. See `design.md`, "Dependency
+  on POOLS-6." This change's reservation-admission work must not begin
+  implementation until `pools-6` resolves multidimensional capacity
+  tracking.
+- `pools-8-capacity-projection-and-listing-hints` — related, not
+  blocking, but consequential: this change alone fixes
+  provisioning-service-side `pool_id` correctness; the storefront's own
+  claim-building isn't fixed until `pools-8` also lands. See `design.md`,
+  "Scope split: `CapacityProjection` and hints move to `pools-8`."
+- `market-platform-compute-30-extract-service` — related follow-on, not
+  an activation prerequisite or blocker.
+
+**Original activation condition (superseded above, kept for history):**
+
+This stayed taskless until:
 
 - (a) `pools-4-storefront-capacity-boundary` has landed — the storefront
   needs to already be asking for pool-shaped capacity before it can
@@ -79,11 +128,8 @@ This stays taskless until:
   `pools-5-shared-provisioning-package`), or a second domain forces that
   decision sooner — whichever comes first.
 
-Starting this cutover before (b) risks wiring the storefront against
-integration points that move once the package boundary resolves. A fresh
-design-review pass should precede implementation once activated, not a
-straight implementation of this document — same posture `compute-30` takes
-for its absorbed package-boundary decision.
+(b) was resolved directly rather than waited on, per "Resolved scope"
+above.
 
 ## Non-Goals (once activated)
 
@@ -93,21 +139,16 @@ for its absorbed package-boundary decision.
 - Removing `SettlementRecord`/`settlement_claims` independence —
   `pools-3` resolved that boundary; this change should not reopen it
   without new evidence of an actual need to correlate them.
-- **Operator-declared listing-mode hints are out of scope for this change's
-  first pass, but MUST be on its design-review agenda before implementation
-  starts.** Raised during `pools-4`'s design review (2026-07-16): a
-  datacenter operator's `ResourcePool.policy_tags` (`kit/resource-pools`)
-  is the natural place to declare whether their pool prefers pool-scoped
-  or specific-resource listing behavior — pool-level because it's the
-  operator's equipment and their call, and additive to a field the
-  resource-pool-management spec already designed for operator-declared
-  metadata. This must stay a **non-binding hint the storefront may read**,
-  never a fulfillment-lifecycle constraint enforced by provisioning —
-  `pools-2`'s "Explicit selection preserves eligibility" requirement
-  already commits to honoring an explicit `resource_id` request rather
-  than rejecting it for disagreeing with a pool's preferred scheduling
-  mode, and that should not change. See `design.md`'s "Remaining open
-  questions" for the concrete gap this surfaced.
+- **Operator-declared listing-mode hints, and `CapacityProjection`
+  (the storefront's pool/capacity mirror they depend on), are fully out
+  of scope — moved to `pools-8-capacity-projection-and-listing-hints`.**
+  Originally this change's proposal required listing-mode hints be on
+  this change's design-review agenda before implementation; that review
+  happened, and its conclusion was to split this work out entirely
+  rather than design it here, given its size and separability from the
+  fulfillment-cutover mechanics. See `design.md`, "Scope split:
+  `CapacityProjection` and hints move to `pools-8`" for the consequence
+  this split has for this change's own `pool_id`-correctness fix.
 
 ## Capabilities
 
@@ -123,15 +164,25 @@ for its absorbed package-boundary decision.
 ## Dependencies and Related Changes
 
 - Requires `pools-2-physical-settlement-scheduler` (implemented) and
-  `pools-3-fulfillment-provider`.
+  `pools-3-fulfillment-provider` (implemented).
 - Requires `pools-4-storefront-capacity-boundary` to land first.
-- Interacts with `market-platform-compute-30-extract-service`'s absorbed
+- **Requires `pools-6-multidimensional-fair-scheduling`** — blocking
+  prerequisite for reservation-admission work; see "Status" above.
+- Related, not blocking: `pools-8-capacity-projection-and-listing-hints`
+  — required for this change's `pool_id`-correctness fix to be complete
+  end-to-end on the storefront side; see "Status" above.
+- Interacted with `market-platform-compute-30-extract-service`'s absorbed
   package-boundary decision (formerly tracked by the now-closed
-  `pools-5-shared-provisioning-package`) — see Activation Condition.
+  `pools-5-shared-provisioning-package`) — resolved directly by this
+  change's design review rather than waited on; see "Status" above.
 
 ## Impact
 
-Not assessed — scope depends on how `pools-4` and `compute-30`'s absorbed
-package-boundary question resolve. A future design-review session should
-reassess before this leaves taskless status, not implement this document
-as written.
+Touches `kit/site` (`site_resource_pools`/`CapacityReservation` reshape),
+`compute_provisioning` (scheduler/policy relocation, `SettlementRecord`),
+the VM provisioning service (models, migrations, services, release
+lifecycle), and the VM storefront's reservation/orchestration path.
+Blocked on `pools-6` for reservation-admission correctness; not fully
+complete end-to-end without `pools-8`. Detailed file-level impact is a
+planning-step output, not assessed further here — this section will be
+revised once `tasks.md` exists.

--- a/openspec/changes/pools-7-storefront-fulfillment-cutover/specs/physical-provisioning/spec.md
+++ b/openspec/changes/pools-7-storefront-fulfillment-cutover/specs/physical-provisioning/spec.md
@@ -27,18 +27,18 @@ second, duplicate Ansible job for the same physical operation.
 
 #### Scenario: Recovery sweep retries a pending dispatch
 
-- **WHEN** a `SettlementRecord` is found in `dispatch_pending` state at
-  service startup and `FulfillmentService.create` is retried for that
-  allocation
+- **WHEN** a `SettlementRecord` is found in `dispatch_pending` state by
+  the periodic recovery sweep and `FulfillmentService.create` is retried
+  for that allocation
 - **THEN** at most one Ansible create job is ever dispatched for that
   allocation, and the retry observes the originally-submitted job rather
   than a new one
 
 #### Scenario: Recovery sweep retries a pending teardown dispatch
 
-- **WHEN** a `SettlementRecord` is found in a teardown-dispatch-pending
-  state at service startup and `FulfillmentService.teardown` is retried
-  for that allocation
+- **WHEN** a `SettlementRecord` is found in `teardown_dispatch_pending`
+  state by the periodic recovery sweep and `FulfillmentService.teardown`
+  is retried for that allocation
 - **THEN** at most one Ansible teardown job is ever dispatched for that
   allocation, and the retry observes the originally-submitted job rather
   than a new one

--- a/openspec/changes/pools-7-storefront-fulfillment-cutover/specs/physical-provisioning/spec.md
+++ b/openspec/changes/pools-7-storefront-fulfillment-cutover/specs/physical-provisioning/spec.md
@@ -1,52 +1,194 @@
 ## ADDED Requirements
 
-### Requirement: Deterministic provider dispatch idempotency
+### Requirement: Durable capacity-reservation settlement identity
 
-The Ansible fulfillment provider MUST submit create and teardown jobs
-through the job service's contract-based deduplication path, with a
-deterministic idempotency key derived from `allocation_id` and action
-kind (`create` or `teardown`). A repeated dispatch for the same
-allocation and action MUST return the originally-submitted job rather
-than submitting a duplicate.
+The provisioning service MUST maintain exactly one durable fulfillment
+aggregate for each accepted `capacity_reservation_id`. `begin_fulfillment`
+MUST be idempotent by `capacity_reservation_id`: equivalent retries return the
+same `fulfillment_id`, while conflicting reuse fails before provider command
+submission.
 
-This is distinct from and does not replace `pools-3`'s "Idempotent
-fulfillment identity" requirement, which governs whether
-`FulfillmentService.create`/`teardown` accept or reject a retried
-*request* (equivalent vs. conflicting, at the `allocation_id` boundary).
-This requirement governs whether an *accepted* request's dispatch to the
-underlying job runner is itself safe to retry — the layer below
-`FulfillmentService`, exercised specifically by the durable
-`dispatch_pending` recovery sweep this change introduces (see
-`design.md`, "`SettlementRecord` shape" and "commit ↔ async-dispatch
-failure window"). Prior to this change, `AnsibleFulfillmentProvider`
-called the job service without a contract, bypassing its existing
-`(allocation_id, action_kind, idempotency_key)` uniqueness constraint
-entirely — confirmed by inspection, not assumed — so a recovery-driven
-retry of a `dispatch_pending` `SettlementRecord` would have submitted a
-second, duplicate Ansible job for the same physical operation.
+#### Scenario: Equivalent fulfillment retry
+- **WHEN** `begin_fulfillment` is repeated with an equivalent request for an
+  already accepted capacity reservation
+- **THEN** the existing `fulfillment_id` and state are returned and no second
+  fulfillment aggregate is created
 
-#### Scenario: Recovery sweep retries a pending dispatch
+#### Scenario: Conflicting fulfillment retry
+- **WHEN** the same capacity reservation is reused with conflicting selected
+  resource, provider, requirements, or fulfillment identity
+- **THEN** the request fails before any provider command is submitted
 
-- **WHEN** a `SettlementRecord` is found in `dispatch_pending` state by
-  the periodic recovery sweep and `FulfillmentService.create` is retried
-  for that allocation
-- **THEN** at most one Ansible create job is ever dispatched for that
-  allocation, and the retry observes the originally-submitted job rather
-  than a new one
+### Requirement: Separate scheduling and fulfillment acceptance
 
-#### Scenario: Recovery sweep retries a pending teardown dispatch
+The provisioning service MUST expose scheduling and beginning fulfillment as
+separate operations. Scheduling MUST accept a local `capacity_reservation_id`
+and requirements that do not exceed the reservation, and MUST return the
+selected settlement resource without beginning provider execution.
+`begin_fulfillment` MUST resolve the durable scheduled assignment by
+`capacity_reservation_id` and MUST NOT accept an arbitrary caller-selected
+resource as authoritative.
 
-- **WHEN** a `SettlementRecord` is found in `teardown_dispatch_pending`
-  state by the periodic recovery sweep and `FulfillmentService.teardown`
-  is retried for that allocation
-- **THEN** at most one Ansible teardown job is ever dispatched for that
-  allocation, and the retry observes the originally-submitted job rather
-  than a new one
+#### Scenario: Resource selected before fulfillment
+- **WHEN** the storefront schedules an active capacity reservation
+- **THEN** the selected settlement resource is persisted and returned without
+  submitting a provider command
 
-#### Scenario: Concurrent duplicate dispatch races
+#### Scenario: Unknown owning authority
+- **WHEN** a site receives an unknown reservation, pool, or resource identifier
+- **THEN** it rejects the request and does not forward, reinterpret, or fall
+  back to another site
 
-- **WHEN** two callers submit create (or two callers submit teardown)
-  for the same allocation concurrently
-- **THEN** the job service's uniqueness constraint resolves the race so
-  both callers observe the same job identity and only one job is ever
-  enqueued
+### Requirement: Atomic scheduling persistence
+
+Capacity reassignment, where required for fair scheduling, and durable
+settlement-record creation or transition MUST commit in one database
+transaction. A changed requirement MUST supersede the capacity reservation
+rather than mutate an accepted assignment under the same identifier.
+
+#### Scenario: Crash during assignment transaction
+- **WHEN** scheduling fails before the transaction commits
+- **THEN** neither the capacity movement nor the settlement assignment is
+  visible
+
+#### Scenario: Reservation requirements change
+- **WHEN** requirements change after an assignment is accepted
+- **THEN** the original reservation is superseded and a new reservation is
+  scheduled rather than mutating the existing assignment
+
+### Requirement: Fulfillment and provisioned-resource identities
+
+`begin_fulfillment` MUST return a durable `fulfillment_id`. A fulfillment MUST
+support zero or more provisioned-resource outputs, each with a globally unique
+`provisioned_resource_id` and an optional domain-specific reference. Whole
+fulfillment status and teardown MUST use `fulfillment_id`; cross-domain
+contracts MUST NOT use VM-specific identifiers as the generic teardown
+identity.
+
+#### Scenario: Multi-resource fulfillment representation
+- **WHEN** one fulfillment creates multiple independently identifiable outputs
+- **THEN** all outputs are represented under the same `fulfillment_id` with
+  distinct `provisioned_resource_id` values
+
+### Requirement: Versioned prepared provider operations
+
+Before committing a pending provider-command state, the provider MUST prepare
+and validate a normalized serializable payload containing a schema version and
+kind discriminator. Recovery MUST dispatch from the stored payload and MUST
+NOT reconstruct accepted input from mutable live pool or host configuration.
+
+#### Scenario: Pool configuration changes after acceptance
+- **WHEN** provider configuration changes after fulfillment acceptance but
+  before a recovery retry
+- **THEN** the retry uses the original stored prepared payload
+
+### Requirement: Deterministic provider command idempotency
+
+Create and teardown provider commands MUST use the job service's
+contract-based deduplication path with deterministic identifiers derived from
+`capacity_reservation_id` or `fulfillment_id`, action kind, and command schema
+version. Repeated or concurrent submission of the same logical action MUST
+observe one underlying job.
+
+#### Scenario: Recovery retries create submission
+- **WHEN** a pending create command is retried after an uncertain submission
+- **THEN** at most one underlying create job is enqueued and the existing job
+  identity is observed
+
+#### Scenario: Recovery retries teardown submission
+- **WHEN** a pending teardown command is retried after an uncertain submission
+- **THEN** at most one underlying teardown job is enqueued and the existing job
+  identity is observed
+
+### Requirement: Provisioning-owned lifecycle convergence
+
+After `begin_fulfillment` is durably accepted, the provisioning service MUST
+own provider submission, retry, provider-status convergence, output
+persistence, settlement-result delivery, teardown, and final physical-resource
+reclamation. Progress MUST NOT depend on storefront polling.
+
+Pending and in-progress work MUST be recovered periodically with a
+multi-replica-safe claim/lease mechanism. Database locks MUST be released
+before external provider calls.
+
+#### Scenario: Process restarts after acceptance
+- **WHEN** the provisioning process restarts with a pending or in-progress
+  fulfillment
+- **THEN** periodic recovery resumes and converges the lifecycle without a new
+  storefront command
+
+#### Scenario: Worker dies after claiming work
+- **WHEN** a worker dies after committing a claim but before completing the
+  external call
+- **THEN** the claim expires and another worker can safely retry the operation
+
+### Requirement: Durable pushed SettlementResult
+
+The provisioning service MUST push a versioned `SettlementResult` to the
+storefront through a durable outbox. The fulfillment transition and delivery
+obligation MUST commit atomically. Delivery MUST be at-least-once and the
+storefront MUST apply it idempotently by stable `result_id`, persisting before
+acknowledgement.
+
+Retries MUST use exponential backoff with jitter and a capped interval and
+MUST NOT permanently abandon an undelivered result while the fulfillment
+remains active. Operator metrics, alerts, audit history, and manual replay MUST
+be available.
+
+#### Scenario: Crash before result send
+- **WHEN** the provisioning process commits fulfillment success and crashes
+  before sending the result
+- **THEN** the durable outbox causes the result to be delivered after recovery
+
+#### Scenario: Acknowledgement is lost
+- **WHEN** the storefront persists a result but its acknowledgement is lost
+- **THEN** the provisioning service retries and the storefront treats the same
+  `result_id` as an idempotent duplicate
+
+### Requirement: Credentials are transient delivery material
+
+Raw credentials MUST NOT be persisted in settlement records, generic JSON
+columns, or result outbox payloads. The delivery worker MUST obtain or refresh
+credentials just in time, transmit them only over an authenticated encrypted
+channel, and discard them afterward. Where refreshing rotates credentials, a
+monotonic `credential_generation` MUST prevent stale retries from replacing a
+newer generation.
+
+#### Scenario: Storefront unavailable during credential delivery
+- **WHEN** successful fulfillment credentials cannot be delivered because the
+  storefront is unavailable
+- **THEN** fulfillment remains successful, result delivery remains retryable,
+  and credentials can be obtained or refreshed for a later attempt
+
+### Requirement: Atomic abandonment and release
+
+Transitioning an unfulfilled assigned settlement to `abandoned` and releasing
+or superseding its capacity reservation MUST occur in one database
+transaction. Lease lifecycle code SHOULD perform this transition directly;
+periodic watchdog processing MUST reconcile missed transitions.
+
+#### Scenario: Reservation expires before fulfillment begins
+- **WHEN** an assigned reservation expires before `begin_fulfillment`
+- **THEN** the assignment becomes abandoned and its held capacity is released
+  atomically
+
+### Requirement: Active fulfillment migration
+
+The migration MUST place existing hosts into a default resource pool and MUST
+backfill settlement/fulfillment records for every active or releasing VM
+capacity reservation. It MUST infer the selected resource, provider, and
+versioned teardown input from durable fields used by the existing release
+path. Historical create input MAY be absent for already-active fulfillments.
+The migration MUST fail when an active reservation cannot be mapped
+unambiguously.
+
+#### Scenario: Existing active VM
+- **WHEN** the migration encounters an active VM with resolvable host, target,
+  and executor metadata
+- **THEN** it creates a backfilled fulfillment record capable of durable
+  teardown without a legacy release branch
+
+#### Scenario: Ambiguous active VM mapping
+- **WHEN** an active VM cannot be mapped unambiguously to a resource and
+  teardown input
+- **THEN** migration fails visibly rather than creating a partial record

--- a/openspec/changes/pools-7-storefront-fulfillment-cutover/specs/physical-provisioning/spec.md
+++ b/openspec/changes/pools-7-storefront-fulfillment-cutover/specs/physical-provisioning/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: Deterministic provider dispatch idempotency
+
+The Ansible fulfillment provider MUST submit create and teardown jobs
+through the job service's contract-based deduplication path, with a
+deterministic idempotency key derived from `allocation_id` and action
+kind (`create` or `teardown`). A repeated dispatch for the same
+allocation and action MUST return the originally-submitted job rather
+than submitting a duplicate.
+
+This is distinct from and does not replace `pools-3`'s "Idempotent
+fulfillment identity" requirement, which governs whether
+`FulfillmentService.create`/`teardown` accept or reject a retried
+*request* (equivalent vs. conflicting, at the `allocation_id` boundary).
+This requirement governs whether an *accepted* request's dispatch to the
+underlying job runner is itself safe to retry — the layer below
+`FulfillmentService`, exercised specifically by the durable
+`dispatch_pending` recovery sweep this change introduces (see
+`design.md`, "`SettlementRecord` shape" and "commit ↔ async-dispatch
+failure window"). Prior to this change, `AnsibleFulfillmentProvider`
+called the job service without a contract, bypassing its existing
+`(allocation_id, action_kind, idempotency_key)` uniqueness constraint
+entirely — confirmed by inspection, not assumed — so a recovery-driven
+retry of a `dispatch_pending` `SettlementRecord` would have submitted a
+second, duplicate Ansible job for the same physical operation.
+
+#### Scenario: Recovery sweep retries a pending dispatch
+
+- **WHEN** a `SettlementRecord` is found in `dispatch_pending` state at
+  service startup and `FulfillmentService.create` is retried for that
+  allocation
+- **THEN** at most one Ansible create job is ever dispatched for that
+  allocation, and the retry observes the originally-submitted job rather
+  than a new one
+
+#### Scenario: Recovery sweep retries a pending teardown dispatch
+
+- **WHEN** a `SettlementRecord` is found in a teardown-dispatch-pending
+  state at service startup and `FulfillmentService.teardown` is retried
+  for that allocation
+- **THEN** at most one Ansible teardown job is ever dispatched for that
+  allocation, and the retry observes the originally-submitted job rather
+  than a new one
+
+#### Scenario: Concurrent duplicate dispatch races
+
+- **WHEN** two callers submit create (or two callers submit teardown)
+  for the same allocation concurrently
+- **THEN** the job service's uniqueness constraint resolves the race so
+  both callers observe the same job identity and only one job is ever
+  enqueued

--- a/openspec/changes/pools-7-storefront-fulfillment-cutover/specs/site-capacity/spec.md
+++ b/openspec/changes/pools-7-storefront-fulfillment-cutover/specs/site-capacity/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Unambiguous capacity reservation identity
+
+Cross-domain contracts and schemas MUST use `capacity_reservation_id` instead
+of the ambiguous `allocation_id`. Capacity reservations, pools, physical
+resources, fulfillments, and provisioned resources MUST use globally unique
+opaque identifiers, while ownership remains explicit through `site_id` or an
+equivalent authority field rather than being inferred by parsing identifiers.
+
+Planning MUST review whether site-plus-pool composite identity is additionally
+required for routing or integrity.
+
+#### Scenario: Reservation routed to owning site
+- **WHEN** the storefront invokes scheduling or fulfillment for a capacity
+  reservation
+- **THEN** it sends the request only to the provisioning authority that owns
+  that reservation
+
+### Requirement: Scheduling requirements remain within reserved capacity
+
+Scheduling requirements MAY be smaller than the admitted reservation but MUST
+NOT exceed it in any governed dimension. Reservation admission and scheduling
+eligibility MUST use the same shared feasibility predicate.
+
+#### Scenario: Smaller scheduled shape
+- **WHEN** a reservation contains more capacity than the requested scheduling
+  shape
+- **THEN** scheduling may select an eligible resource without increasing the
+  reservation
+
+#### Scenario: Scheduling exceeds reservation
+- **WHEN** any requested scheduling dimension exceeds the capacity reservation
+- **THEN** scheduling is rejected before resource assignment
+
+### Requirement: Broad capacity schema cleanup
+
+POOLS-7 MUST perform the approved breaking rename and schema cleanup,
+including `SiteAllocation` to `CapacityReservation`, `allocation_id` to
+`capacity_reservation_id`, explicit site ownership, globally unique
+identifiers, and the final separation of host identity, pool membership,
+reservable capacity, and settlement-resource assignment.
+
+#### Scenario: Existing host migration
+- **WHEN** the schema migration runs
+- **THEN** every existing host is represented in the default resource pool
+  before active fulfillment records are backfilled

--- a/openspec/changes/pools-7-storefront-fulfillment-cutover/tasks.md
+++ b/openspec/changes/pools-7-storefront-fulfillment-cutover/tasks.md
@@ -1,0 +1,113 @@
+## 1. Finalize shared contracts and package skeleton
+
+- [ ] 1.1 Create `kit/physical-settlement` using repository-standard Python kit packaging, Makefile, tests, typing marker, and distribution/reinit conventions.
+- [ ] 1.2 Define globally unique opaque ID value types for `capacity_reservation_id`, `fulfillment_id`, `provisioned_resource_id`, `settlement_resource_id`, and `result_id`; evaluate UUIDv7 against repository conventions and document the selected format.
+- [ ] 1.3 Decide and document whether routing/integrity requires an explicit site-plus-pool composite reference in addition to globally unique `pool_id` and explicit `site_id`.
+- [ ] 1.4 Move domain-neutral physical-settlement request/resource types, `PhysicalSettlementScheduler`, and `DeterministicRoundRobinPolicy` into the new kit without introducing VM/storefront dependencies.
+- [ ] 1.5 Remove provisioning commercial identity from shared contracts: delete `agreement_id` and rename `allocation_id` to `capacity_reservation_id` across new interfaces.
+- [ ] 1.6 Add versioned payload envelopes for prepared provider create/teardown inputs, provider metadata, and `SettlementResult`; prohibit unversioned cross-domain generic dictionaries.
+- [ ] 1.7 Add package-boundary/import tests proving dependency direction and carrier purity.
+
+## 2. Reshape site capacity and identifiers
+
+- [ ] 2.1 Rename `SiteAllocation` and related APIs/models/columns to `CapacityReservation` / `capacity_reservation_id` across `kit/site`, provisioning services, clients, fixtures, and tests.
+- [ ] 2.2 Implement the approved breaking separation of host identity, resource-pool membership, reservable capacity, and nullable settlement-resource assignment; retire `SiteResource` and obsolete fields where the final model replaces them.
+- [ ] 2.3 Add explicit `site_id` ownership and database uniqueness/foreign-key constraints for pools, resources, reservations, fulfillments, and provisioned resources.
+- [ ] 2.4 Extract one shared feasibility predicate used by reservation-time admission and scheduling-time eligibility.
+- [ ] 2.5 Make ledger unit-claim aliases configurable rather than VM-specific, and remove the scheduler's default VM-flavored `resource_kind` fallback.
+- [ ] 2.6 Reject scheduling requirements that exceed the capacity reservation in any governed dimension while permitting smaller shapes.
+- [ ] 2.7 Add migration and unit tests for uniqueness, site ownership, host-granular feasibility, and the shared predicate.
+
+## 3. Add shared settlement persistence
+
+- [ ] 3.1 Define shared SQLAlchemy mappings for the fulfillment/settlement aggregate, provisioned-resource outputs, versioned prepared operations, recovery claims, and result-delivery outbox.
+- [ ] 3.2 Implement generic SQLAlchemy repositories using caller-supplied sessions so site-capacity and settlement changes can share one transaction.
+- [ ] 3.3 Define fulfillment, provider-command, teardown, abandonment, and result-delivery states plus a compact table-driven transition validator.
+- [ ] 3.4 Persist canonical request identity/fingerprints and enforce one fulfillment aggregate per `capacity_reservation_id`.
+- [ ] 3.5 Implement equivalent retry return and conflicting retry rejection before provider submission.
+- [ ] 3.6 Model one fulfillment to many `ProvisionedResource` rows with aggregate status; leave per-resource teardown unexposed unless a current caller requires it.
+- [ ] 3.7 Add repository, concurrency, state-transition, and canonicalization tests.
+
+## 4. Implement atomic scheduling
+
+- [ ] 4.1 Replace process-local scheduler assignment and round-robin state with database-backed selection and deterministic persisted fairness state where required.
+- [ ] 4.2 Implement `schedule_resource(capacity_reservation_id, requirements)` against the local owning site only.
+- [ ] 4.3 In one transaction, lock/validate the active reservation, select an eligible resource, perform any fair capacity rebind, and create or return the immutable assigned settlement record.
+- [ ] 4.4 Reject unknown reservation/pool/resource identifiers rather than forwarding, reinterpreting, or trying another site.
+- [ ] 4.5 Make changed requirements supersede the reservation instead of mutating an accepted assignment.
+- [ ] 4.6 Atomically abandon assigned-but-unfulfilled settlements and release/supersede their capacity during lease lifecycle events; add watchdog reconciliation.
+- [ ] 4.7 Add race, retry, rollback, expiry, supersession, and multi-replica scheduling tests.
+
+## 5. Migrate existing hosts and active leases
+
+- [ ] 5.1 Create the default resource pool and migrate all existing hosts and pool-membership/resource-capacity records before fulfillment backfill.
+- [ ] 5.2 Backfill a settlement/fulfillment aggregate for every active or releasing VM capacity reservation.
+- [ ] 5.3 Derive selected resource, Ansible provider identity, domain resource reference, and versioned teardown input from existing `vm_host`, `vm_target`/`executor_target`, executor identity, and lease data.
+- [ ] 5.4 Mark migrated aggregates as backfilled and allow historical create input to be absent for already-active VMs.
+- [ ] 5.5 Fail migration visibly when an active reservation cannot be mapped unambiguously; do not create partial teardown records.
+- [ ] 5.6 Skip terminal/expired historical allocations unless another retention requirement applies.
+- [ ] 5.7 Add migration tests covering active, releasing, expired, ambiguous, duplicate, and rollback cases.
+
+## 6. Implement fulfillment acceptance and provider preparation
+
+- [ ] 6.1 Add `begin_fulfillment(capacity_reservation_id, fulfillment_request)` returning `fulfillment_id`; load the persisted scheduled resource rather than trusting a caller-supplied resource.
+- [ ] 6.2 Preserve `FulfillmentService`'s boundary: it receives an already-selected `SettlementResource` and does not call the scheduler.
+- [ ] 6.3 Split provider behavior into synchronous `prepare_create`/`prepare_teardown` and post-commit `dispatch_create`/`dispatch_teardown` operations.
+- [ ] 6.4 Validate and persist versioned prepared input in the same transaction that accepts a pending provider command.
+- [ ] 6.5 Submit Ansible create/teardown through `ExecutorActionEnvelope` or the equivalent contract-deduplication path using deterministic action/version keys.
+- [ ] 6.6 Persist provider job identity and normalized provider metadata without exposing VM-specific job state as the cross-domain lifecycle contract.
+- [ ] 6.7 Add tests for equivalent/conflicting retries, pool-config mutation after acceptance, duplicate submission races, and create/teardown command deduplication.
+
+## 7. Add provisioning-owned recovery and lifecycle convergence
+
+- [ ] 7.1 Implement a periodic multi-replica-safe watchdog framework with bounded database claims/leases, claim expiry, attempt counters, exponential backoff with jitter, and no locks held during external calls.
+- [ ] 7.2 Add separate handlers for create submission recovery, create status convergence, teardown submission recovery, teardown status convergence, and abandonment reconciliation.
+- [ ] 7.3 Persist normalized fulfillment and teardown terminal states plus provisioned-resource outputs independently of storefront availability.
+- [ ] 7.4 Ensure pending and in-progress records recover after process restart, transient provider failure, and worker death.
+- [ ] 7.5 Add metrics and structured operator diagnostics for stuck claims, retry age, provider failures, and non-terminal lifecycle age.
+- [ ] 7.6 Add crash-window, restart, multi-replica, backoff, and eventual-convergence tests.
+
+## 8. Implement durable pushed SettlementResult delivery
+
+- [ ] 8.1 Define the versioned `SettlementResult` contract containing `result_id`, `fulfillment_id`, `capacity_reservation_id`, aggregate state, provisioned-resource outputs, failure details, and credential-generation metadata without persisted raw credentials.
+- [ ] 8.2 Insert the result-delivery outbox row atomically with each reportable fulfillment transition.
+- [ ] 8.3 Add an authenticated storefront result-receiver endpoint/client contract that deduplicates by `result_id`, persists before acknowledgement, and rejects incorrectly routed site/reservation results.
+- [ ] 8.4 Implement a delivery worker handler that claims due rows, obtains or refreshes credentials just in time, sends them only in memory over the authenticated encrypted channel, and records acknowledgement or retry state.
+- [ ] 8.5 Implement capped exponential backoff with jitter and indefinite retry while the fulfillment remains active; do not dead-letter buyer credential delivery after a fixed attempt count.
+- [ ] 8.6 Add monotonic `credential_generation` handling so stale retries cannot replace newer credentials.
+- [ ] 8.7 Keep fulfillment state separate from result-delivery state and expose metrics, alerts, audit history, oldest-undelivered age, and a manual replay operation.
+- [ ] 8.8 Add tests for crash-before-send, crash-after-send, lost acknowledgement, duplicate delivery, storefront outage, credential refresh/rotation, stale generation, restart, and manual replay.
+
+## 9. Cut over storefront orchestration
+
+- [ ] 9.1 Replace host-shaped ordinary storefront reservation assumptions with the implemented POOLS-4 capacity-reservation claim and owning-site routing.
+- [ ] 9.2 Replace direct `ExecutorActionEnvelope` submission and provider-job polling with `schedule_resource` followed by `begin_fulfillment` when the commercial workflow is ready.
+- [ ] 9.3 Persist `capacity_reservation_id`, selected settlement resource, and returned `fulfillment_id` in storefront workflow state so negotiation and fulfillment resume after restart.
+- [ ] 9.4 Consume pushed `SettlementResult` idempotently and deliver/retain buyer-facing credential state according to the storefront's security model.
+- [ ] 9.5 Map VM-domain job/provider states to the shared fulfillment lifecycle invariant without leaking raw VM job status cross-domain.
+- [ ] 9.6 Remove `create_vm_and_wait_with_credentials` and ordinary storefront polling/direct executor dispatch after all callers are migrated; tombstone deleted paths where repository workflow requires it.
+- [ ] 9.7 Add storefront restart, duplicate result, site-routing, negotiation-resume, and end-to-end credential-delivery tests.
+
+## 10. Cut over teardown and physical-resource reclamation
+
+- [ ] 10.1 Add `begin_fulfillment_teardown(fulfillment_id)` as the whole-fulfillment teardown contract; keep `provisioned_resource_id` in the schema for a future per-resource teardown extension.
+- [ ] 10.2 Resolve the backfilled or native fulfillment aggregate, prepare versioned teardown input, and persist teardown-pending state before provider submission.
+- [ ] 10.3 Drive teardown submission, retry, status convergence, final resource reclamation, and capacity release entirely from provisioning-owned watchdog handlers.
+- [ ] 10.4 Do not return physical capacity to scheduling until teardown succeeds or an explicit operator recovery action resolves the resource.
+- [ ] 10.5 Replace the old `VmReleaseExecutor` direct path once backfilled and new fulfillments use settlement teardown; remove the legacy fallback rather than retaining a cutover marker.
+- [ ] 10.6 Add idempotent repeated teardown, partial failure, restart, lost submission acknowledgement, backfilled VM, and final capacity-release tests.
+
+## 11. Remove obsolete schema and compatibility paths
+
+- [ ] 11.1 Remove superseded `allocation_id`, `SiteAllocation`, direct-host storefront placement, process-local settlement maps/locks, and obsolete executor/provider fields after migrations and callers are complete.
+- [ ] 11.2 Reassess and remove/reduce storefront `fill_first`/`most_available` physical-placement behavior now that physical scheduling belongs to the provisioning service; retain only pre-reservation site/pool policy that remains meaningful.
+- [ ] 11.3 Update container composition, package dependencies, wheel/reinit targets, Docker images, and deployment configuration for `kit/physical-settlement` and its watchdog/result-delivery workers.
+- [ ] 11.4 Ensure logs, traces, exception payloads, and request logging redact credentials and prepared secret material.
+- [ ] 11.5 Run repository-wide import, typing, migration, unit, integration, and end-to-end suites and fix all renamed-contract consumers.
+
+## 12. Documentation and specification closure
+
+- [ ] 12.1 Update `ARCHITECTURE.md` service map, terminology table, ID definitions, lifecycle ownership, transaction boundaries, recovery workers, pushed-result protocol, and teardown flow.
+- [ ] 12.2 Update baseline `site-capacity` and `physical-provisioning` specs to incorporate completed POOLS-2/3/4/6/7 behavior when the change is archived.
+- [ ] 12.3 Update VM provisioning/storefront README and operator documentation for migrations, watchdog health, result-delivery alerts, manual replay, and recovery procedures without lease-expiry sequencing instructions.
+- [ ] 12.4 Verify the implementation against every POOLS-7 scenario and archive the OpenSpec change after validation.

--- a/openspec/changes/pools-8-capacity-projection-and-listing-hints/.openspec.yaml
+++ b/openspec/changes/pools-8-capacity-projection-and-listing-hints/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-17

--- a/openspec/changes/pools-8-capacity-projection-and-listing-hints/design.md
+++ b/openspec/changes/pools-8-capacity-projection-and-listing-hints/design.md
@@ -1,0 +1,129 @@
+## Context
+
+This content was originally designed as part of `pools-7-storefront-
+fulfillment-cutover`'s design review (2026-07-17) and split out here —
+see that change's `proposal.md`/`design.md` "Scope split" sections for
+why. Nothing below reflects new analysis beyond what that review already
+settled; it's relocated, not reconsidered.
+
+## `CapacityProjection` schema
+
+```python
+class CachedResourcePool(Base):
+    __tablename__ = "capacity_projection_pools"
+
+    site = Column(String, primary_key=True)
+    pool_id = Column(String, primary_key=True)
+    label = Column(String, nullable=False)
+    provider = Column(String, nullable=False)
+    enabled = Column(Boolean, nullable=False)
+    policy_tags = Column(JSON, nullable=False, default=dict)
+    synced_at = Column(DateTime, nullable=False)
+```
+
+Pull-based sync job (analogous to, but the reverse direction of, the
+storefront's existing `sync_site_resources()` push):
+
+```python
+async def sync_resource_pools(sites: dict[str, RemotePoolsClient]) -> int:
+    """Pull-based mirror of every configured site's pool admin API —
+    replaces the storefront's local resources table as the source of
+    pool/resource identities used in reservation claims and listing
+    publication."""
+    ...
+```
+
+Must NOT be read by anything in the admission/reservation path
+(`AggregateCapacityClient.reserve()`/`probe()`, `PhysicalSettlementScheduler`)
+— those continue to use live, per-request data, unchanged. This cache is
+for pricing/listing-publication decisions only. See `pools-7`'s
+`design.md`, "`CapacityProjection` MUST NOT replace the live per-request
+snapshot these policies read," for the reasoning — that constraint is
+unaffected by this split; it just now lives in the change that actually
+builds `CapacityProjection`.
+
+## Listing-mode hint consumption
+
+```python
+# kit/resource-pools — domain-neutral: the key name only.
+LISTING_MODE_TAG = "listing_mode"
+
+# domains/vms — VM-domain interpretation + default.
+class VmListingMode(str, Enum):
+    pooled = "pooled"
+    specific_resource = "specific_resource"
+
+def resolve_vm_listing_mode(pool: CachedResourcePool, member_count: int) -> VmListingMode:
+    declared = pool.policy_tags.get(LISTING_MODE_TAG)
+    if declared in (VmListingMode.pooled.value, VmListingMode.specific_resource.value):
+        return VmListingMode(declared)
+    return (VmListingMode.specific_resource if member_count == 1
+            else VmListingMode.pooled)   # unchanged pools-4 structural default
+```
+
+The reconciler-driven publish path (`domains/vms/listings/reconciler.py`,
+`cli_publish.py`) already has the structural default above, confirmed
+during `pools-4`'s design review. This change's job is narrower than it
+might first appear: let an explicit hint override that default, don't
+replace it. The reconciler calls `resolve_vm_listing_mode` once per pool
+it's about to publish listings for, in the same place the structural
+default already lives.
+
+**Extensibility confirmed against `apicredits`, not just asserted:**
+since `apicredits` is explicitly in scope for `pools-7`'s broader
+`kit`/`CapacityReservation` reshape, the shape only counts as
+domain-neutral if `apicredits` can express something VM doesn't need
+without touching `kit/resource-pools`. It can:
+
+```python
+class ApiCreditsListingMode(str, Enum):
+    shared_quota = "shared_quota"     # listing draws from a pooled quota bucket
+    dedicated_key = "dedicated_key"   # listing is pinned to one provider API key
+
+def resolve_apicredits_listing_mode(pool: CachedResourcePool) -> ApiCreditsListingMode:
+    declared = pool.policy_tags.get(LISTING_MODE_TAG)
+    if declared in (ApiCreditsListingMode.shared_quota.value, ApiCreditsListingMode.dedicated_key.value):
+        return ApiCreditsListingMode(declared)
+    return ApiCreditsListingMode.shared_quota
+```
+
+`kit/resource-pools` owns one string key; each domain owns its own enum
+and default rule; no cross-domain coupling.
+
+**Enforcement posture:** explicitly a hint, never provisioning-enforced.
+`PhysicalSettlementScheduler`'s explicit-`resource_id` eligibility path
+(`pools-2`) is unaffected by a pool's `listing_mode` regardless — a
+buyer's explicit resource request is honored even against a pool tagged
+`pooled`. A storefront that never reads the tag, or one running against a
+provisioning service that predates this feature, falls through to the
+unchanged structural default. Purely additive.
+
+## Pool-level reservation TTL hint
+
+An operator may want a pool-level limit on how long a
+`CapacityReservation` against their resources can sit unscheduled/held.
+Same shape and posture as the listing-mode hint: an additive
+`ResourcePool.policy_tags` entry (`{"max_reservation_hold_seconds": 900}`),
+read and voluntarily respected by a cooperating storefront when it
+chooses the `ttl_seconds` it passes to `reserve()` — never enforced by
+the provisioning service itself (`reserve()` already accepts a
+caller-supplied `ttl_seconds`; no new ledger capability needed, only a
+place for the operator to express a preference and a storefront willing
+to read it).
+
+## Open question inherited from `pools-7`
+
+`pools-7`'s design review also surfaced, but did not resolve, whether
+`AggregateCapacityClient`'s ranked site-fallback (`fill_first`/
+`most_available`) is still meaningful once every claim is pool/resource-
+pinned (post-`pools-4`) and pool/resource IDs are only unique per site —
+a pinned claim's owning site is arguably already known at publish time,
+making ranked multi-site fallback for that claim mostly vestigial. This
+touches `CapacityProjection` in that a resolution would likely mean
+site-tagging every cached pool/resource identity explicitly
+(`site_id + pool_id + optional resource_id`) so claims can route
+directly rather than being tried in ranked order. Not resolved here;
+see `pools-7`'s `design.md`, "Open question surfaced by writing this
+table down," for the full analysis. Whoever picks this change up should
+check whether `pools-7` (or a further follow-on) has resolved it before
+finalizing `CapacityProjection`'s key shape.

--- a/openspec/changes/pools-8-capacity-projection-and-listing-hints/proposal.md
+++ b/openspec/changes/pools-8-capacity-projection-and-listing-hints/proposal.md
@@ -1,0 +1,95 @@
+## Why
+
+Split out of `pools-7-storefront-fulfillment-cutover`'s design review
+(2026-07-17), not independently discovered. `pools-7` designed a
+storefront-side read-only mirror of every connected provisioning
+service's pool/capacity state (`CapacityProjection`), plus two operator
+hints that ride on top of it (`ResourcePool.policy_tags`'
+`listing_mode` and a reservation-hold TTL preference). All three are a
+materially separate subsystem from `pools-7`'s fulfillment-cutover
+mechanics — pull schedules, freshness, multi-site keys, publication
+reactions, their own storage and migrations — not inherently part of
+scheduling/dispatch/persistence. `pools-7` was already large; this was
+split out to keep both changes reviewable, migratable, and separately
+rollback-able, per outside design-review feedback (2026-07-17) that
+`pools-7` had accumulated too much unrelated scope, which on reflection
+was correct for this piece specifically.
+
+**This split has a real consequence that must stay visible, not be
+quietly absorbed:** `pools-7`'s `site_resource_pools`/
+`PhysicalSettlementScheduler` fix makes the *provisioning service* side
+of the `pool_id`-namespace-collision bug (`pools-7`'s `design.md`,
+"`SiteResource` is retired") correct — pool identity is sourced from
+`hosts`/`resource_pools`, not guessed. But the *storefront's* own
+claim-building (`vm_job_spec_service.py`) still sources the `pool_id`/
+`resource_id` it sends from the storefront's local, independently
+authored inventory table until this change replaces it with
+`CapacityProjection`. `pools-7` alone fixes provisioning-side
+correctness (bad claims now fail cleanly at admission instead of
+silently matching the wrong thing); this change is required for the
+storefront to reliably send *valid* claims in the first place.
+
+## What This Change Covers
+
+- **`CapacityProjection`**: a storefront-side, pull-based, read-only
+  mirror of every connected provisioning service's pool/capacity state,
+  replacing the storefront's local, independently-authored resource
+  inventory table (`resources`, hand-curated CSV import) as the source
+  of pool/resource identities used when building reservation claims and
+  publishing listings. Sourced from `GET /api/v1/pools` — already
+  exists, already reachable (the storefront already holds each
+  configured site's admin key). Keyed by `(site, pool_id)`, since pool
+  IDs are only unique per provisioning service. Explicitly
+  advisory/display-only for pricing and listing publication — never the
+  thing reservation admission checks against; the live, per-request
+  `AggregateCapacityClient` snapshot remains the routing/admission input,
+  unchanged.
+- **Operator-declared listing-mode hint**: `ResourcePool.policy_tags`
+  (`kit/resource-pools`) gains a `listing_mode` entry a pool operator can
+  set to declare whether their pool prefers pool-scoped or
+  specific-resource listing behavior. Non-binding — a storefront that
+  never reads it falls back to the existing structural default (single-
+  resource pool -> resource-pinned; real multi-member pool -> pool-
+  scoped), and `pools-2`'s "Explicit selection preserves eligibility"
+  requirement is unaffected either way (an explicit `resource_id`
+  request is honored regardless of a pool's declared mode).
+- **Pool-level reservation TTL hint**: a `policy_tags` entry
+  (`max_reservation_hold_seconds`) an operator can set to express a
+  preference for how long their resources should sit reserved-but-
+  unscheduled. Same non-binding posture — read and voluntarily respected
+  by a cooperating storefront choosing the `ttl_seconds` it passes to
+  `reserve()`; never provisioning-enforced.
+- **Extensibility for `apicredits`**: the `listing_mode` tag key is
+  domain-neutral (`kit/resource-pools` owns the key name only); each
+  domain owns its own enum of valid values and default rule. Verified,
+  not just asserted, against a concrete `apicredits` sketch during
+  `pools-7`'s design review — see `design.md`.
+
+## Non-Goals
+
+- Reservation-admission correctness, scheduling, `SettlementRecord`
+  persistence, provider dispatch idempotency, and release-path wiring —
+  all `pools-7`.
+- Any change to how `PhysicalSettlementScheduler` or `CapacityLedgerService`
+  make admission/eligibility decisions. `CapacityProjection` is never
+  consulted for that; see "Why" above.
+
+## Dependencies and Related Changes
+
+- Depends on `pools-4-storefront-capacity-boundary` (pool-shaped claims)
+  and benefits from, but does not strictly require, `pools-7` landing
+  first — the two can proceed in parallel, but `pools-7`'s `pool_id`-
+  correctness fix is not complete end-to-end until this change also
+  lands (see "Why" above).
+- Depends on `kit/resource-pools`' `GET /api/v1/pools` admin API
+  (already exists) for the pull source.
+
+## Impact
+
+Touches the VM storefront (new `CapacityProjection` cache tables and
+sync job, reconciler/listing-publication changes to consume
+`listing_mode`, replacement of the local `resources` table as claim-
+building's source of truth) and `kit/resource-pools` (`policy_tags`
+convention for the two new hint keys — additive, no schema change, it's
+already a free-form dict). Detailed file-level impact is a planning-step
+output; this change has not yet been planned (no `tasks.md`).


### PR DESCRIPTION
PR: Remove dead vm_leases table and VmLease model
Summary
Removes the VmLease ORM model and its LeaseStatus enum from the provisioning service — confirmed dead code, superseded by SiteAllocation.
Why
VmLease/vm_leases predates the site-authority ledger being colocated in the provisioning service. Its docstring described a LeaseWatchdog responsibility that SiteAllocation (kit/site) has actually owned for a while — the live LeaseWatchdog → LeaseLifecycleService path runs entirely through SiteAllocation/SiteAuthorityPort and never touches VmLease. Verified before removing anything:

No VmLease(...) construction anywhere in the repo.
The dedicated legacy test file referenced in a neighboring test's docstring (test_lease_lifecycle_service.py) had already been deleted — the comment was stale.
Only remaining touch points were schema-level (migrations that create it, and drift-check assertions on its columns).

Changes

db/models.py: removed VmLease and LeaseStatus.
db/migrations.py: added 20260718_001_drop_vm_leases_table, a new additive migration that drops the table. Migration history stays append-only — the old create/alter steps remain, now followed by a drop. The historical create step no longer depends on Base.metadata.tables["vm_leases"] (that ORM class is gone) and is now self-contained raw SQL so replay against any pre-existing DB state stays correct.
tests/unit/test_database.py: updated schema assertions (table no longer exists post-migration), expected migration id set/count, and fixed the schema-drift test, which was deleting the second-to-latest migration id to simulate staleness — that stopped actually testing drift once a newer migration existed behind it.
tests/unit/services/test_ledger_lease_lifecycle.py: fixed a stale docstring reference to the already-deleted legacy test file.

Data impact
DROP TABLE IF EXISTS vm_leases. No data migration needed — the table has never had application-level writes.