### PR TITLE
Pools 6 mvp 

### DIFF
--- a/core/storefront/src/core_storefront/capacity.py
+++ b/core/storefront/src/core_storefront/capacity.py
@@ -48,7 +48,7 @@ class CapacityDelta:
     versions from different sites are unrelated sequences.
     """
 
-    kind: str  # "reserved" | "committed" | "released" | "lease_truncated"
+    kind: str  # "reserved" | "committed" | "released" | "lease_truncated" | "capacity_changed"
     version: int
     resource_id: str | None = None
     pool_id: str | None = None

--- a/core/storefront/src/core_storefront/capacity_remote.py
+++ b/core/storefront/src/core_storefront/capacity_remote.py
@@ -218,6 +218,7 @@ class RemoteCapacityClient:
         total_units: int,
         resource_subtype: str | None = None,
         attributes: Mapping[str, Any] | None = None,
+        capacity: Mapping[str, Any] | None = None,
         enabled: bool = True,
     ) -> dict[str, Any]:
         async with self._http() as http:
@@ -227,6 +228,7 @@ class RemoteCapacityClient:
                     "total_units": int(total_units),
                     "resource_subtype": resource_subtype,
                     "attributes": dict(attributes or {}),
+                    "capacity": dict(capacity) if capacity else None,
                     "enabled": enabled,
                 },
                 headers=self._headers(),

--- a/domains/vms/provisioning/service/src/db/migrations.py
+++ b/domains/vms/provisioning/service/src/db/migrations.py
@@ -229,6 +229,21 @@ def _migrate_vm_leases_allocation_id(engine: Engine) -> None:
         )
 
 
+def _migrate_multidimensional_capacity(engine: Engine) -> None:
+    """Add POOLS-6 pass-1 multidimensional capacity columns.
+
+    Additive-only: ``site_resources.total_units`` and
+    ``site_allocations.units`` are left in place as service-maintained
+    mirrors of ``capacity["gpu_count"]``/``dimensions["gpu_count"]`` so
+    existing readers keep working unchanged. Pre-migration rows have
+    ``capacity``/``dimensions`` = NULL; the ledger falls back to
+    ``{"gpu_count": total_units}``/``{"gpu_count": units}`` for those rows.
+    """
+    _add_column_if_missing(engine, "site_resources", "capacity", "JSON")
+    _add_column_if_missing(engine, "site_allocations", "dimensions", "JSON")
+    _add_column_if_missing(engine, "capacity_events", "dimensions", "JSON")
+
+
 def _migrate_drop_vm_leases_table(engine: Engine) -> None:
     """Drop vm_leases for good.
 
@@ -364,5 +379,9 @@ _MIGRATIONS: tuple[Migration, ...] = (
     Migration(
         "20260718_001_drop_vm_leases_table",
         _migrate_drop_vm_leases_table,
+    ),
+    Migration(
+        "20260720_001_multidimensional_capacity",
+        _migrate_multidimensional_capacity,
     ),
 )

--- a/domains/vms/provisioning/service/src/services/physical_settlement_scheduler.py
+++ b/domains/vms/provisioning/service/src/services/physical_settlement_scheduler.py
@@ -139,16 +139,18 @@ class PhysicalSettlementScheduler:
         )
         attributes = dict(request.requirements.get("attributes") or {})
         # dimensions is authoritative when the reservation carries one.
-        # Otherwise fall back to the allocation's legacy  single-quantity "units",
-        # translated to the primary dimension, so reservations made before this
-        # change keep scheduling unchanged.
+        #  Otherwise fall back to the allocation's own dimensions which
+        # ledger.get_allocation() always populates.
+        # Even for a pre-migration allocation that only ever had "units"
+        # (CapacityLedgerService._allocation_dimensions applies that
+        # fallback once, centrally, before this dict ever reaches the
+        # scheduler). Do NOT re-derive a "units" fallback here: it would
+        # be dead code today and, worse, a second copy of a rule that
+        # must only live in one place (found in code review, 2026-07-20;
+        # see test_scheduler_schedules_full-capacity_legacy_allocation).
         dimensions = dict(
-            request.requirements.get("dimensions")
-            or allocation.get("dimensions")
-            or {}
+            request.requirements.get("dimensions") or allocation["dimensions"]
         )
-        if not dimensions:
-            dimensions = {"gpu_count": max(int(allocation.get("units") or 1), 1)}
         return SettlementRequirement(
             resource_kind=resource_kind,
             dimensions=dimensions,
@@ -161,7 +163,9 @@ class PhysicalSettlementScheduler:
         allocation: dict[str, Any],
     ) -> list[SettlementCandidate]:
         pools = {pool.id: pool for pool in self._pool_service.list_pools(enabled_only=True)}
-        allocation_dimensions = dict(allocation.get("dimensions") or {})
+        # Guaranteed non-empty by CapacityLedgerService.get_allocation() --
+        # see the comment in _requirement().
+        allocation_dimensions = dict(allocation["dimensions"])
         candidates: list[SettlementCandidate] = []
         for payload in self._capacity_ledger.list_resources():
             attributes = dict(payload.get("attributes") or {})

--- a/domains/vms/provisioning/service/src/services/physical_settlement_scheduler.py
+++ b/domains/vms/provisioning/service/src/services/physical_settlement_scheduler.py
@@ -138,9 +138,20 @@ class PhysicalSettlementScheduler:
             or "compute.gpu"
         )
         attributes = dict(request.requirements.get("attributes") or {})
+        # dimensions is authoritative when the reservation carries one.
+        # Otherwise fall back to the allocation's legacy  single-quantity "units",
+        # translated to the primary dimension, so reservations made before this
+        # change keep scheduling unchanged.
+        dimensions = dict(
+            request.requirements.get("dimensions")
+            or allocation.get("dimensions")
+            or {}
+        )
+        if not dimensions:
+            dimensions = {"gpu_count": max(int(allocation.get("units") or 1), 1)}
         return SettlementRequirement(
             resource_kind=resource_kind,
-            units=max(int(allocation.get("units") or 1), 1),
+            dimensions=dimensions,
             attributes=attributes,
         )
 
@@ -150,6 +161,7 @@ class PhysicalSettlementScheduler:
         allocation: dict[str, Any],
     ) -> list[SettlementCandidate]:
         pools = {pool.id: pool for pool in self._pool_service.list_pools(enabled_only=True)}
+        allocation_dimensions = dict(allocation.get("dimensions") or {})
         candidates: list[SettlementCandidate] = []
         for payload in self._capacity_ledger.list_resources():
             attributes = dict(payload.get("attributes") or {})
@@ -160,14 +172,20 @@ class PhysicalSettlementScheduler:
                 continue
             if payload.get("resource_type") != requirement.resource_kind:
                 continue
-            available_units = int(payload.get("available_units") or 0)
+            available = dict(payload.get("available") or {})
             # The current ledger reserves against a concrete line item before
-            # POOLS-2 scheduling. Credit this allocation's own held units back
-            # during eligibility evaluation; POOLS-3 persistence will move the
-            # concrete claim into the assignment transaction.
+            # POOLS-2 scheduling. Credit this allocation's own held
+            # dimensions back during eligibility evaluation; POOLS-3
+            # persistence will move the concrete claim into the assignment
+            # transaction.
             if payload.get("resource_id") == allocation.get("resource_id"):
-                available_units += requirement.units
-            if available_units < requirement.units:
+                for key, amount in allocation_dimensions.items():
+                    available[key] = available.get(key, 0) + amount
+            fits = all(
+                available.get(dim, 0) >= amount
+                for dim, amount in requirement.dimensions.items()
+            )
+            if not fits:
                 continue
             if any(attributes.get(key) != value for key, value in requirement.attributes.items()):
                 continue
@@ -177,7 +195,7 @@ class PhysicalSettlementScheduler:
                     resource_id=payload["resource_id"],
                     pool_id=pool_id,
                     resource_kind=payload["resource_type"],
-                    available_units=available_units,
+                    available=available,
                     provider=pool.provider,
                     attributes=attributes,
                 )

--- a/domains/vms/provisioning/service/src/tests/integration/test_capacity_api.py
+++ b/domains/vms/provisioning/service/src/tests/integration/test_capacity_api.py
@@ -141,7 +141,9 @@ async def test_reserve_commit_release_lifecycle(capacity: CapacityApi):
     ]
     assert latest == events[-1]["version"]
     # Anonymity on the wire: events never carry deal context.
-    assert all(set(e) <= {"version", "kind", "resource_id", "occurred_at"}
+    # "dimensions" is anonymous capacity-delta data, not deal context,
+    # so it belongs in the allowed set alongside kind/resource_id/version.
+    assert all(set(e) <= {"version", "kind", "resource_id", "occurred_at", "dimensions"}
                for e in events)
 
 

--- a/domains/vms/provisioning/service/src/tests/unit/services/test_physical_settlement_scheduler.py
+++ b/domains/vms/provisioning/service/src/tests/unit/services/test_physical_settlement_scheduler.py
@@ -250,3 +250,21 @@ def test_scheduler_still_schedules_legacy_gpu_only_requests(services):
     allocation_id = _reserve(ledger)
     resource = scheduler.select_resource(_request(allocation_id))
     assert resource.settlement_resource_id == "r1"
+
+
+def test_scheduler_credit_back_covers_full_capacity_legacy_allocation(services):
+    """A legacy allocation reserving *all* of a resource's capacity must
+    still be schedulable: the eligibility scan credits the allocation's
+    own held quantity back before checking fit, and that credit-back must
+    not silently become a no-op for an allocation whose claim never
+    mentioned "dimensions", but locking the invariant in with a test at
+    the layer that actually depends on it)."""
+    pools, ledger, scheduler = services
+    _pool(pools, "pool-a")
+    _resource(ledger, "r1", "pool-a", units=4)
+    result = ledger.reserve(claim={"gpu_count": 4}, deal_ref={
+        "agreement_id": "agreement-1", "market": "vms",
+    })
+    assert result is not None
+    resource = scheduler.select_resource(_request(result["allocation_id"]))
+    assert resource.settlement_resource_id == "r1"

--- a/domains/vms/provisioning/service/src/tests/unit/services/test_physical_settlement_scheduler.py
+++ b/domains/vms/provisioning/service/src/tests/unit/services/test_physical_settlement_scheduler.py
@@ -174,3 +174,79 @@ def test_disabling_pool_does_not_depend_on_existing_assignment(services):
     scheduler.select_resource(_request(allocation_id))
     disabled = pools.disable_pool("pool-a")
     assert disabled.enabled is False
+
+# ----------------------------------------------------------------------
+# multidimensional eligibility
+# ----------------------------------------------------------------------
+
+def _resource_with_capacity(ledger, resource_id: str, pool_id: str, *, capacity: dict, enabled=True):
+    ledger.register_resource(
+        resource_id=resource_id,
+        resource_type="compute.gpu",
+        total_units=capacity.get("gpu_count", 1),
+        enabled=enabled,
+        attributes={"pool_id": pool_id},
+        capacity=capacity,
+    )
+
+
+def _reserve_with_dimensions(ledger, dimensions: dict, agreement="agreement-1", **deal):
+    ref = {"agreement_id": agreement, "market": "vms", "requirements": {"dimensions": dimensions}, **deal}
+    result = ledger.reserve(claim={"dimensions": dimensions}, deal_ref=ref)
+    assert result is not None
+    return result["allocation_id"]
+
+
+def test_scheduler_excludes_candidate_that_fits_gpu_but_not_memory(services):
+    """Two resources have enough GPU; only one also has enough RAM. The
+    scheduler's own eligibility scan (independent of which resource the
+    ledger's admission happened to reserve against) must still exclude
+    the RAM-short one, not just prove *some* resource exists."""
+    pools, ledger, scheduler = services
+    _pool(pools, "pool-a")
+    _resource_with_capacity(
+        ledger, "roomy", "pool-a",
+        capacity={"gpu_count": 8, "vcpu_count": 32, "ram_gb": 256, "disk_gb": 1000},
+    )
+    _resource_with_capacity(
+        ledger, "ram-short", "pool-a",
+        capacity={"gpu_count": 8, "vcpu_count": 32, "ram_gb": 16, "disk_gb": 1000},
+    )
+    dims = {"gpu_count": 1, "ram_gb": 64}
+    allocation_id = _reserve_with_dimensions(ledger, dims)
+    # Pinning the RAM-short resource explicitly must fail eligibility,
+    # checked before any assignment memoizes a different resource.
+    with pytest.raises(NoEligibleSettlementResourceError):
+        scheduler.select_resource(_request(
+            allocation_id, requirements={"dimensions": dims}, resource_id="ram-short",
+        ))
+    resource = scheduler.select_resource(
+        _request(allocation_id, requirements={"dimensions": dims})
+    )
+    assert resource.settlement_resource_id == "roomy"
+
+
+def test_scheduler_selects_candidate_that_fits_every_dimension(services):
+    pools, ledger, scheduler = services
+    _pool(pools, "pool-a")
+    _resource_with_capacity(
+        ledger, "r1", "pool-a",
+        capacity={"gpu_count": 8, "vcpu_count": 32, "ram_gb": 256, "disk_gb": 1000},
+    )
+    dims = {"gpu_count": 2, "vcpu_count": 8, "ram_gb": 64, "disk_gb": 200}
+    allocation_id = _reserve_with_dimensions(ledger, dims)
+    resource = scheduler.select_resource(
+        _request(allocation_id, requirements={"dimensions": dims})
+    )
+    assert resource.settlement_resource_id == "r1"
+
+
+def test_scheduler_still_schedules_legacy_gpu_only_requests(services):
+    """Reservations made before pass 1 (no dimensions) keep scheduling
+    exactly as they did under round-robin."""
+    pools, ledger, scheduler = services
+    _pool(pools, "pool-a")
+    _resource(ledger, "r1", "pool-a", units=10)
+    allocation_id = _reserve(ledger)
+    resource = scheduler.select_resource(_request(allocation_id))
+    assert resource.settlement_resource_id == "r1"

--- a/domains/vms/provisioning/service/src/tests/unit/test_database.py
+++ b/domains/vms/provisioning/service/src/tests/unit/test_database.py
@@ -1,11 +1,12 @@
 import pytest
 from sqlalchemy import create_engine, inspect, text
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from db.database import run_migrations
 from db.migrations import SchemaDriftError, check_schema_version
 from db.models import AnsibleJob, AnsiblePoolConfig, DEFAULT_POOL_ID, Host, ResourcePool
+from market_site.ledger import CapacityLedgerService
 
 
 def _sqlite_memory_engine():
@@ -70,6 +71,92 @@ def _create_pre_migration_tables(engine):
             )
             """
         ))
+        # Pre-POOLS-6 shape of the site-authority ledger tables: no
+        # capacity/dimensions/dimensions columns yet. A populated row
+        # here exercises the actual additive-column migration path,
+        # rather than only the fresh-create-all path a brand new table
+        # would take.
+        connection.execute(text(
+            """
+            CREATE TABLE site_resources (
+                resource_id VARCHAR NOT NULL,
+                resource_type VARCHAR NOT NULL,
+                resource_subtype VARCHAR,
+                total_units INTEGER NOT NULL,
+                attributes JSON,
+                enabled BOOLEAN NOT NULL,
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                updated_at DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                PRIMARY KEY (resource_id)
+            )
+            """
+        ))
+        connection.execute(text(
+            """
+            INSERT INTO site_resources (
+                resource_id, resource_type, resource_subtype, total_units,
+                attributes, enabled
+            ) VALUES (
+                'pre-existing-gpu', 'compute.gpu', 'h200', 8,
+                '{"vm_host": "kvm1"}', 1
+            )
+            """
+        ))
+        connection.execute(text(
+            """
+            CREATE TABLE site_allocations (
+                allocation_id VARCHAR NOT NULL,
+                resource_id VARCHAR NOT NULL,
+                units INTEGER NOT NULL,
+                state VARCHAR NOT NULL,
+                deal_ref JSON,
+                escrow_uid VARCHAR,
+                hold_expires_at VARCHAR,
+                executor_kind VARCHAR,
+                executor_target VARCHAR,
+                release_job_id VARCHAR,
+                executor_ref JSON,
+                vm_host VARCHAR,
+                vm_target VARCHAR,
+                lease_start_utc VARCHAR,
+                lease_end_utc VARCHAR,
+                create_job_id VARCHAR,
+                vm_remove_job_id VARCHAR,
+                failure_reason VARCHAR,
+                failure_message TEXT,
+                released_at VARCHAR,
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                updated_at DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                PRIMARY KEY (allocation_id)
+            )
+            """
+        ))
+        connection.execute(text(
+            """
+            INSERT INTO site_allocations (
+                allocation_id, resource_id, units, state, deal_ref
+            ) VALUES (
+                'pre-existing-alloc', 'pre-existing-gpu', 3, 'reserved', '{}'
+            )
+            """
+        ))
+        connection.execute(text(
+            """
+            CREATE TABLE capacity_events (
+                version INTEGER NOT NULL,
+                kind VARCHAR NOT NULL,
+                resource_id VARCHAR,
+                occurred_at DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                PRIMARY KEY (version)
+            )
+            """
+        ))
+        connection.execute(text(
+            """
+            INSERT INTO capacity_events (version, kind, resource_id)
+            VALUES (1, 'reserved', 'pre-existing-gpu')
+            """
+        ))
 
 
 def test_run_migrations_applies_versioned_migrations_to_old_sqlite_schema():
@@ -113,6 +200,31 @@ def test_run_migrations_applies_versioned_migrations_to_old_sqlite_schema():
         "release_job_id",
         "executor_ref",
     }.issubset(allocation_columns)
+
+    # capacity/dimensions columns land on genuinely
+    # pre-existing site-authority tables via the additive-column
+    # migration path, not only via create_all() on a brand new table
+    resource_columns = {
+        column["name"] for column in inspector.get_columns("site_resources")
+    }
+    event_columns = {
+        column["name"] for column in inspector.get_columns("capacity_events")
+    }
+    assert "capacity" in resource_columns
+    assert "dimensions" in allocation_columns
+    assert "dimensions" in event_columns
+
+    # The pre-existing row (inserted before the migration ran, with
+    # capacity/dimensions left NULL) reads correctly through the real
+    # ledger's fallback-to-legacy-fields logic, not just via a raw column
+    # check.
+    ledger = CapacityLedgerService(sessionmaker(bind=engine))
+    snapshot = {row["resource_id"]: row for row in ledger.snapshot()}
+    pre_existing = snapshot["pre-existing-gpu"]
+    assert pre_existing["capacity"] == {"gpu_count": 8}
+    assert pre_existing["available"] == {"gpu_count": 5}  # 8 total - 3 held
+    allocation = ledger.get_allocation("pre-existing-alloc")
+    assert allocation["dimensions"] == {"gpu_count": 3}
 
     assert "resource_pools" in inspector.get_table_names()
     assert "ansible_pool_configs" in inspector.get_table_names()
@@ -161,6 +273,7 @@ def test_run_migrations_applies_versioned_migrations_to_old_sqlite_schema():
         "20260713_001_ansible_jobs_contract_fields",
         "20260713_002_resource_pools_and_hosts_pool_id",
         "20260718_001_drop_vm_leases_table",
+        "20260720_001_multidimensional_capacity",
     }
 
 
@@ -194,6 +307,15 @@ def test_run_migrations_is_idempotent():
     assert allocation_columns.count("executor_target") == 1
     assert allocation_columns.count("release_job_id") == 1
     assert allocation_columns.count("executor_ref") == 1
+    assert allocation_columns.count("dimensions") == 1
+    resource_columns = [
+        column["name"] for column in inspector.get_columns("site_resources")
+    ]
+    event_columns = [
+        column["name"] for column in inspector.get_columns("capacity_events")
+    ]
+    assert resource_columns.count("capacity") == 1
+    assert event_columns.count("dimensions") == 1
 
     with Session(engine) as session:
         assert session.query(ResourcePool).filter(
@@ -204,7 +326,7 @@ def test_run_migrations_is_idempotent():
         migration_count = connection.execute(
             text("SELECT COUNT(*) FROM schema_migrations")
         ).scalar_one()
-    assert migration_count == 8
+    assert migration_count == 9
 
 
 # ---------------------------------------------------------------------------
@@ -230,7 +352,7 @@ class TestCheckSchemaVersion:
         with engine.begin() as connection:
             connection.execute(text(
                 "DELETE FROM schema_migrations WHERE id = "
-                "'20260718_001_drop_vm_leases_table'"
+                "'20260720_001_multidimensional_capacity'"
             ))
         with pytest.raises(SchemaDriftError):
             check_schema_version(engine)

--- a/domains/vms/storefront/src/market_storefront/services/capacity_client.py
+++ b/domains/vms/storefront/src/market_storefront/services/capacity_client.py
@@ -114,6 +114,12 @@ async def member_availability_view(
 # listings whose GPU slice no longer fits.
 _CONSUMING_DELTA_KINDS = frozenset({"reserved", "committed", "lease_truncated"})
 
+# A mixed-direction capacity registration (e.g. GPU count grew while RAM
+# shrank -- POOLS-6 pass 1) can simultaneously strand some listings and
+# free up others; neither "consuming" nor "released" alone is safe, so
+# both reconciliation passes run.
+_MIXED_DIRECTION_DELTA_KINDS = frozenset({"capacity_changed"})
+
 
 def _make_listing_reconcile_subscriber(
     sqlite_client_factory: SQLiteClientFactory,
@@ -124,7 +130,9 @@ def _make_listing_reconcile_subscriber(
     This is the storefront's *reaction* to a capacity delta, not part of
     the moving deal's flow — another seller's reservation invalidates
     our listings just the same. Consuming deltas close stranded
-    listings, "released" reopens ones that fit again.
+    listings, "released" reopens ones that fit again, and a mixed-
+    direction "capacity_changed" registration runs both passes since it
+    can do both at once.
     """
 
     async def _reconcile_listings(delta: CapacityDelta) -> None:
@@ -136,7 +144,7 @@ def _make_listing_reconcile_subscriber(
 
         db_path = sqlite_client_factory().db_path
         availability = await member_availability_view(client, db_path)
-        if delta.kind in _CONSUMING_DELTA_KINDS:
+        if delta.kind in _CONSUMING_DELTA_KINDS or delta.kind in _MIXED_DIRECTION_DELTA_KINDS:
             closed = await close_stale_compute_listings_after_capacity_change(
                 db_path, member_availability=availability,
             )
@@ -148,7 +156,7 @@ def _make_listing_reconcile_subscriber(
                     capacity_version=delta.version,
                     closed_listing_ids=closed,
                 )
-        elif delta.kind == "released":
+        if delta.kind == "released" or delta.kind in _MIXED_DIRECTION_DELTA_KINDS:
             reopened = await reopen_available_compute_listings_after_capacity_change(
                 db_path, member_availability=availability,
             )

--- a/domains/vms/storefront/src/market_storefront/services/capacity_client.py
+++ b/domains/vms/storefront/src/market_storefront/services/capacity_client.py
@@ -276,11 +276,21 @@ async def sync_site_resources(
             total_units = max(int(total), 0)
         except (TypeError, ValueError):
             total_units = 0
+        # forward whichever dimensions the row's attributes declare, using
+        # the same vocabulary resource_capacity_validator.py already checks
+        # host totals against. gpu_count always goes through explicitly so
+        # it's present even when the row's "value" (not its attributes) is
+        # the only place total GPU count is recorded.
+        capacity = {"gpu_count": total_units}
+        for key in ("vcpu_count", "ram_gb", "disk_gb"):
+            if attrs.get(key) is not None:
+                capacity[key] = attrs[key]
         await client.register_resource(
             str(row["resource_id"]),
             total_units=total_units,
             resource_subtype=row.get("resource_subtype"),
             attributes=attrs,
+            capacity=capacity,
             enabled=str(row.get("state") or "") != "deleted",
         )
         synced += 1

--- a/domains/vms/storefront/src/market_storefront/services/vm_job_spec_service.py
+++ b/domains/vms/storefront/src/market_storefront/services/vm_job_spec_service.py
@@ -14,8 +14,12 @@ _REQUIRED_COMPUTE_KEYS = (
     "resource_id",
     "region",
     "gpu_model",
-    "gpu_count",
 )
+
+# checked against a resource's multidimensional capacity with full
+# held/available accounting, forwarded only when the listing declares
+# them so older listings without a shape keep working unchanged.
+_DIMENSION_COMPUTE_KEYS = ("gpu_count", "vcpu_count", "ram_gb", "disk_gb")
 
 
 def compute_capacity_claim_from_order(order_dict: dict[str, Any] | None) -> dict[str, Any]:
@@ -33,6 +37,13 @@ def compute_capacity_claim_from_order(order_dict: dict[str, Any] | None) -> dict
     claim so matching pins to the named resource rather than requiring both
     to match (POOLS-4 design review, 2026-07-16).
 
+    The returned claim also carries a ``dimensions`` map (POOLS-6 pass 1)
+    built from ``gpu_count``/``vcpu_count``/``ram_gb``/``disk_gb`` — the
+    listing's fixed, seller-declared shape — so admission actually checks
+    memory/disk/vCPU fit a physical host, not just GPU count. This is the
+    concrete gap POOLS-6 pass 1 closes: previously nothing forwarded these
+    already-existing ``ComputeResource`` fields past this point.
+
     Raises ``ValueError`` if the order is missing or yields neither ``pool_id``
     nor ``resource_id`` — an under-specified claim would otherwise silently
     match on shape attributes (region/gpu_model/gpu_count) alone, which is
@@ -44,6 +55,7 @@ def compute_capacity_claim_from_order(order_dict: dict[str, Any] | None) -> dict
     if not order_dict:
         raise ValueError("Cannot build a capacity claim without a settlement order.")
     required_attributes: dict[str, Any] = {}
+    dimensions: dict[str, Any] = {}
     compute_resource = extract_compute_from_order(order_dict)
     if hasattr(compute_resource, "model_dump"):
         compute_resource = compute_resource.model_dump()
@@ -51,6 +63,9 @@ def compute_capacity_claim_from_order(order_dict: dict[str, Any] | None) -> dict
         for key in _REQUIRED_COMPUTE_KEYS:
             if compute_resource.get(key) is not None:
                 required_attributes[key] = compute_resource[key]
+        for key in _DIMENSION_COMPUTE_KEYS:
+            if compute_resource.get(key) is not None:
+                dimensions[key] = compute_resource[key]
     for identity_key in ("pool_id", "resource_id"):
         if identity_key in required_attributes:
             required_attributes[identity_key] = Listing.normalize_capacity_identifier(
@@ -64,6 +79,8 @@ def compute_capacity_claim_from_order(order_dict: dict[str, Any] | None) -> dict
             f"Cannot build a capacity claim for order {order_id!r}: neither "
             "pool_id nor resource_id is present on its offer_resource."
         )
+    if dimensions:
+        required_attributes["dimensions"] = dimensions
     return required_attributes
 
 

--- a/domains/vms/storefront/tests/fake_site.py
+++ b/domains/vms/storefront/tests/fake_site.py
@@ -74,6 +74,7 @@ class FakeSite:
                 "resource_id": rid,
                 "total_units": body["total_units"],
                 "attributes": body.get("attributes") or {},
+                "capacity": body.get("capacity"),
                 "enabled": body.get("enabled", True),
             }
             self._emit("released", rid)

--- a/domains/vms/storefront/tests/fake_site.py
+++ b/domains/vms/storefront/tests/fake_site.py
@@ -187,7 +187,14 @@ class FakeSite:
 
     def _match(self, claim: dict) -> dict | None:
         claim = claim or {}
-        requested = int(claim.get("gpu_count") or 1)
+        # compute_capacity_claim_from_order now always routes gpu_count.
+        # This fake only proves the GPU-count contract this test double
+        # documents itself as covering but it must at least read the
+        # quantity from the new location and skip "dimensions" in the
+        # attribute-equality mismatch check the same way the real
+        # ledger's _resource_matches skips it.
+        dimensions = claim.get("dimensions") or {}
+        requested = int(dimensions.get("gpu_count") or claim.get("gpu_count") or 1)
         for rid, row in self.resources.items():
             if not row["enabled"]:
                 continue
@@ -195,7 +202,7 @@ class FakeSite:
             top_level = {"resource_id": rid, "pool_id": rid}
             mismatched = any(
                 attrs.get(k, top_level.get(k)) != v
-                for k, v in claim.items() if k != "gpu_count"
+                for k, v in claim.items() if k not in ("gpu_count", "dimensions")
             )
             if mismatched:
                 continue

--- a/domains/vms/storefront/tests/unit/test_remote_capacity_client.py
+++ b/domains/vms/storefront/tests/unit/test_remote_capacity_client.py
@@ -203,6 +203,53 @@ async def test_sync_site_resources_preserves_shared_host_attributes(site: FakeSi
     assert "info-1" not in site.resources
 
 
+@pytest.mark.asyncio
+async def test_sync_site_resources_forwards_multidimensional_capacity(site: FakeSite):
+    rows = [
+        {
+            "resource_id": "compute-kvm1-002",
+            "resource_type": "compute.gpu",
+            "resource_subtype": "h200",
+            "value": 8,
+            "state": "available",
+            "attributes": {
+                "vm_host": "kvm2",
+                "vcpu_count": 64,
+                "ram_gb": 512,
+                "disk_gb": 4000,
+            },
+        },
+        {
+            # A listing without a declared shape (older listing) still
+            # syncs -- gpu_count only, nothing crashes on missing fields.
+            "resource_id": "compute-kvm1-003",
+            "resource_type": "compute.gpu",
+            "value": 4,
+            "state": "available",
+            "attributes": {"vm_host": "kvm3"},
+        },
+    ]
+
+    class FakeDb:
+        async def list_resources(self):
+            return rows
+
+    real_remote = cc.RemoteCapacityClient
+
+    def fake_remote(base_url, admin_key):
+        return real_remote(base_url, admin_key, transport=site.transport())
+
+    with patch("market_storefront.utils.config.settings", _settings()):
+        with patch.object(cc, "RemoteCapacityClient", fake_remote):
+            synced = await cc.sync_site_resources(lambda: FakeDb())
+
+    assert synced == 2
+    assert site.resources["compute-kvm1-002"]["capacity"] == {
+        "gpu_count": 8, "vcpu_count": 64, "ram_gb": 512, "disk_gb": 4000,
+    }
+    assert site.resources["compute-kvm1-003"]["capacity"] == {"gpu_count": 4}
+
+
 def test_build_always_aggregates_site_authorities():
     with patch("market_storefront.utils.config.settings", _settings()):
         built = cc.build_capacity_client(lambda: None)

--- a/domains/vms/storefront/tests/unit/test_remote_capacity_client.py
+++ b/domains/vms/storefront/tests/unit/test_remote_capacity_client.py
@@ -205,6 +205,8 @@ async def test_sync_site_resources_preserves_shared_host_attributes(site: FakeSi
 
 @pytest.mark.asyncio
 async def test_sync_site_resources_forwards_multidimensional_capacity(site: FakeSite):
+    """vcpu_count/ram_gb/disk_gb already sit in the local row's attributes.
+    Sync must forward them into the ledger's capacity map, not just gpu_count."""
     rows = [
         {
             "resource_id": "compute-kvm1-002",
@@ -316,6 +318,40 @@ async def test_subscriber_closes_and_reopens_with_site_availability(
     assert [c[0] for c in calls] == ["close", "reopen"]
     # Availability came from the site snapshot, keyed for the home site.
     assert calls[0][2][(None, "compute-kvm1-001")] == 6
+
+
+@pytest.mark.asyncio
+async def test_subscriber_runs_both_passes_for_mixed_direction_capacity_change(
+    client: cc.RemoteCapacityClient,
+):
+    """A mixed-direction registration e.g. GPU count grew while RAM shrank.
+    "capacity_changed" must run both reconciliation passes and not be silently
+    ignored like an unrecognized kind would be."""
+    calls: list[str] = []
+
+    async def fake_close(db_path, *, member_availability=None):
+        calls.append("close")
+        return []
+
+    async def fake_reopen(db_path, *, member_availability=None):
+        calls.append("reopen")
+        return []
+
+    subscriber = cc._make_listing_reconcile_subscriber(
+        lambda: SimpleNamespace(db_path="/tmp/x.db"), client,
+    )
+    with patch(
+        "market_storefront.services.publication_service."
+        "close_stale_compute_listings_after_capacity_change",
+        fake_close,
+    ), patch(
+        "market_storefront.services.publication_service."
+        "reopen_available_compute_listings_after_capacity_change",
+        fake_reopen,
+    ):
+        await subscriber(CapacityDelta(kind="capacity_changed", version=1))
+
+    assert calls == ["close", "reopen"]
 
 
 @pytest.mark.asyncio

--- a/domains/vms/storefront/tests/unit/test_two_phase_reserve.py
+++ b/domains/vms/storefront/tests/unit/test_two_phase_reserve.py
@@ -190,6 +190,56 @@ def test_claim_prefers_resource_id_over_pool_id():
     assert "pool_id" not in claim
 
 
+# ----------------------------------------------------------------------
+# multidimensional claim building
+# ----------------------------------------------------------------------
+
+def test_claim_carries_dimensions_when_listing_declares_a_shape():
+    """gpu_count/vcpu_count/ram_gb/disk_gb move into a dimensions map,
+    checked with full held/available accounting -- not required_attributes
+    exact-match, which would incorrectly demand every future claim declare
+    the identical quantity rather than merely fit within it."""
+    from market_storefront.services.vm_job_spec_service import (
+        compute_capacity_claim_from_order,
+    )
+
+    row = {
+        "listing_id": "lst-shaped",
+        "offer_resource": {
+            "resource_id": "res-shaped", "gpu_model": "H200", "gpu_count": 2,
+            "sla": 99.0, "region": "California, US",
+            "vcpu_count": 8, "ram_gb": 64, "disk_gb": 500,
+        },
+    }
+    claim = compute_capacity_claim_from_order(row)
+    assert claim["dimensions"] == {
+        "gpu_count": 2, "vcpu_count": 8, "ram_gb": 64, "disk_gb": 500,
+    }
+    # gpu_count moved off the top level entirely -- it's a dimensions-only
+    # key now, not also an exact-match attribute.
+    assert "gpu_count" not in claim
+    assert claim["resource_id"] == "res-shaped"
+
+
+def test_claim_omits_undeclared_dimensions_for_older_listings():
+    """A listing published before vcpu_count/ram_gb/disk_gb existed (or
+    that simply never set them) still produces a valid claim -- gpu_count
+    alone, exactly like every claim before this change."""
+    from market_storefront.services.vm_job_spec_service import (
+        compute_capacity_claim_from_order,
+    )
+
+    row = {
+        "listing_id": "lst-unshaped",
+        "offer_resource": {
+            "resource_id": "res-unshaped", "gpu_model": "H200", "gpu_count": 1,
+            "sla": 99.0, "region": "California, US",
+        },
+    }
+    claim = compute_capacity_claim_from_order(row)
+    assert claim["dimensions"] == {"gpu_count": 1}
+
+
 @pytest.mark.parametrize("order", [None, {}])
 def test_claim_raises_when_order_is_missing(order):
     from market_storefront.services.vm_job_spec_service import (

--- a/kit/site/src/market_site/db.py
+++ b/kit/site/src/market_site/db.py
@@ -76,6 +76,10 @@ class SiteResource(Base):
     resource_type = Column(String, nullable=False, default="compute.gpu")
     resource_subtype = Column(String, nullable=True)  # e.g. "h200"
     total_units = Column(Integer, nullable=False, default=0)
+    # total_units is a service-maintained mirror of capacity["gpu_count"]
+    # kept for payload/caller compatibility. May be null for pre-migration
+    # rows, in which case total_units is the only known dimension (gpu_count).
+    capacity = Column(JSON, nullable=True)
     attributes = Column(JSON, nullable=True)
     enabled = Column(Boolean, nullable=False, default=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
@@ -105,6 +109,9 @@ class SiteAllocation(Base):
     allocation_id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
     resource_id = Column(String, nullable=False, index=True)
     units = Column(Integer, nullable=False, default=1)
+    # units mirrors dimensions["gpu_count"] for payload/caller compatibility.
+    # May be null for pre-migration rows, in which case dimensions is {"gpu_count": units}.
+    dimensions = Column(JSON, nullable=True)
     state = Column(
         String, nullable=False, default=AllocationState.reserved.value, index=True
     )
@@ -145,4 +152,9 @@ class CapacityEvent(Base):
     version = Column(Integer, primary_key=True, autoincrement=True)
     kind = Column(String, nullable=False)  # "reserved"|"committed"|"released"|"lease_truncated"
     resource_id = Column(String, nullable=True, index=True)
+    # Signed per-dimension delta, e.g. {"gpu_count": -1, "vcpu": -4} for a
+    # reserve, {"gpu_count": 1, "vcpu": 4} for a release (POOLS-6 pass 1).
+    # Null for events that don't change held capacity (e.g. "committed",
+    # "lease_truncated") or for pre-migration rows.
+    dimensions = Column(JSON, nullable=True)
     occurred_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)

--- a/kit/site/src/market_site/db.py
+++ b/kit/site/src/market_site/db.py
@@ -150,7 +150,7 @@ class CapacityEvent(Base):
     __tablename__ = "capacity_events"
 
     version = Column(Integer, primary_key=True, autoincrement=True)
-    kind = Column(String, nullable=False)  # "reserved"|"committed"|"released"|"lease_truncated"
+    kind = Column(String, nullable=False)  # "reserved"|"committed"|"released"|"lease_truncated"|"capacity_changed"
     resource_id = Column(String, nullable=True, index=True)
     # Signed per-dimension delta, e.g. {"gpu_count": -1, "vcpu": -4} for a
     # reserve, {"gpu_count": 1, "vcpu": 4} for a release (POOLS-6 pass 1).

--- a/kit/site/src/market_site/http_models.py
+++ b/kit/site/src/market_site/http_models.py
@@ -33,6 +33,14 @@ class ResourceRegisterRequest(BaseModel):
             "Market schema (pricing, escrows) stays on the storefront."
         ),
     )
+    capacity: Optional[dict[str, Any]] = Field(
+        default=None,
+        description=(
+            "Multidimensional total capacity."
+            "e.g. {'gpu_count': 8, 'vcpu_count': 192, 'ram_gb': 2048, 'disk_gb': 20000}."
+            "When omitted, defaults to {'gpu_count': total_units}."
+        ),
+    )
     enabled: bool = Field(default=True)
 
 

--- a/kit/site/src/market_site/ledger.py
+++ b/kit/site/src/market_site/ledger.py
@@ -191,7 +191,32 @@ def _requested_dimensions(claim: Mapping[str, Any] | None) -> dict[str, Decimal]
 
 
 def _serialize_dimensions(dimensions: Mapping[str, Decimal]) -> dict[str, float | int]:
-    """JSON-column-safe representation: whole numbers as int, else float."""
+    """JSON-column-safe representation: whole numbers as int, else float.
+
+    KNOWN LIMITATION (code review, 2026-07-20): a non-integral amount
+    loses exact precision through this float conversion, e.g. 0.1 can't
+    be represented exactly in binary floating point. Pass 1's actual VM
+    dimensions (gpu_count/vcpu_count/ram_gb/disk_gb) are always integral
+    in practice, so this doesn't currently bite -- deferred rather than
+    fixed here per the same design-review decision that scoped pass 1 to
+    integral dimensions.
+
+    The suggested fix (serialize as a canonical decimal string via
+    ``format(amount, "f")``, parse back through ``Decimal`` on read) is
+    NOT purely a change to this function: `PhysicalSettlementScheduler`
+    (`domains/vms/provisioning/service/src/services/
+    physical_settlement_scheduler.py`) does raw ``+``/``>=`` arithmetic
+    directly on `_resource_payload()`'s output in the same process (no
+    JSON round-trip -- it holds a direct `CapacityLedgerService`
+    reference), so a string-valued `available` map would break that
+    arithmetic immediately, not just at a wire boundary. A correct fix
+    needs the scheduler to Decimal-parse before arithmetic too, plus
+    updating every test that currently asserts numeric literals against
+    these payloads (`test_ledger.py`, `test_physical_settlement_
+    scheduler.py`, `test_remote_capacity_client.py`,
+    `test_two_phase_reserve.py`, `test_database.py`). Revisit if a real
+    fractional dimension is ever needed.
+    """
     result: dict[str, float | int] = {}
     for key, amount in dimensions.items():
         as_int = int(amount)

--- a/kit/site/src/market_site/ledger.py
+++ b/kit/site/src/market_site/ledger.py
@@ -8,14 +8,24 @@ the ``/api/v1/capacity`` HTTP surface, which mirrors the
 ``core_storefront.capacity.CapacityClient`` contract verb for verb.
 
 Matching semantics: a claim is an exact-match attribute mapping plus a
-``units`` request (``gpu_count`` is the VM domain's alias), checked
-first against the resource's attributes JSON and then against its
-top-level fields. Domain-specific eligibility should normally be
-expressed in those claims — for example VM claims name ``vm_host`` while
-bare-metal claims name ``physical_host_id`` and ``allocation_mode``.
-``required_attributes`` remains available for single-domain hosts that
-need a coarse local invariant, but multi-domain provisioners should pass
-none.
+quantity request, checked first against the resource's attributes JSON
+and then against its top-level fields. Domain-specific eligibility should
+normally be expressed in those claims — for example VM claims name
+``vm_host`` while bare-metal claims name ``physical_host_id`` and
+``allocation_mode``. ``required_attributes`` remains available for
+single-domain hosts that need a coarse local invariant, but multi-domain
+provisioners should pass none.
+
+A claim's ``dimensions`` mapping is authoritative when present and is
+checked against every dimension a candidate resource declares in its
+``capacity`` map.
+
+Legacy single-quantity claims (``units``/``gpu_count``) keep working.
+They translate internally to ``dimensions={"gpu_count": n}``.
+``SiteResource.total_units`` and ``SiteAllocation.units`` remain
+service-maintained mirrors for payload and caller compatibility.
+
+``capacity``/``dimensions`` are the source of truth.
 
 Mutations serialize on a process-level lock: the site authority is the
 serialization point for reserves across storefronts, and that point is
@@ -30,6 +40,7 @@ import logging
 import threading
 import uuid
 from datetime import datetime, timedelta, timezone
+from decimal import Decimal, InvalidOperation
 from typing import Any, Mapping, Optional, Sequence
 
 from sqlalchemy.orm import Session, sessionmaker
@@ -115,9 +126,16 @@ def _windows_overlap(
 # Claim keys that request a unit count rather than matching an attribute.
 # "units" is the generic key; "gpu_count" is the VM domain's alias.
 _UNIT_CLAIM_KEYS = ("units", "gpu_count")
+_DIMENSIONS_CLAIM_KEY = "dimensions"
+
+# The dimension that SiteResource.total_units / SiteAllocation.units /
+# legacy single-quantity claims all mean. Every pre-pass-1 caller speaks
+# only this one dimension, so it's what they mirror into/out of.
+PRIMARY_DIMENSION = "gpu_count"
 
 
 def _requested_units(claim: Mapping[str, Any] | None) -> int:
+    """Legacy single-quantity parse, kept for the primary-dimension mirror."""
     claim = claim or {}
     key = next((k for k in _UNIT_CLAIM_KEYS if claim.get(k) is not None), None)
     if key is None:
@@ -130,6 +148,82 @@ def _requested_units(claim: Mapping[str, Any] | None) -> int:
     if requested < 1:
         raise ValueError(f"{key} must be >= 1, got {requested}")
     return requested
+
+
+def _to_decimal(value: Any, *, label: str) -> Decimal:
+    try:
+        amount = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError) as exc:
+        raise ValueError(f"{label} must be numeric, got {value!r}") from exc
+    if amount <= 0:
+        raise ValueError(f"{label} must be > 0, got {amount}")
+    return amount
+
+
+def _requested_dimensions(claim: Mapping[str, Any] | None) -> dict[str, Decimal]:
+    """Parse a claim's quantity request as a dimensions map.
+
+    ``dimensions`` is authoritative when present. Otherwise falls back to
+    the legacy single-quantity claim (``units``/``gpu_count``), translated
+    to ``{"gpu_count": n}`` so every existing caller's claim shape keeps
+    working unchanged.
+    """
+    claim = claim or {}
+    raw = claim.get(_DIMENSIONS_CLAIM_KEY)
+    if raw:
+        return {
+            str(key): _to_decimal(value, label=f"dimensions[{key}]")
+            for key, value in raw.items()
+        }
+    return {PRIMARY_DIMENSION: Decimal(_requested_units(claim))}
+
+
+def _serialize_dimensions(dimensions: Mapping[str, Decimal]) -> dict[str, float | int]:
+    """JSON-column-safe representation: whole numbers as int, else float."""
+    result: dict[str, float | int] = {}
+    for key, amount in dimensions.items():
+        as_int = int(amount)
+        result[key] = as_int if Decimal(as_int) == amount else float(amount)
+    return result
+
+
+def _to_decimal_nonneg(value: Any, *, label: str) -> Decimal:
+    """Like :func:`_to_decimal` but allows zero (a declared-but-empty dimension)."""
+    try:
+        amount = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError) as exc:
+        raise ValueError(f"{label} must be numeric, got {value!r}") from exc
+    if amount < 0:
+        raise ValueError(f"{label} must be >= 0, got {amount}")
+    return amount
+
+
+def _resource_capacity(resource: SiteResource) -> dict[str, Decimal]:
+    """A resource's declared total capacity per dimension.
+
+    Falls back to ``{"gpu_count": total_units}`` for pre-migration rows
+    that have never had ``capacity`` populated.
+    """
+    if resource.capacity:
+        return {
+            str(key): _to_decimal_nonneg(value, label=f"capacity[{key}]")
+            for key, value in resource.capacity.items()
+        }
+    return {PRIMARY_DIMENSION: Decimal(int(resource.total_units or 0))}
+
+
+def _allocation_dimensions(allocation: SiteAllocation) -> dict[str, Decimal]:
+    """An allocation's held quantity per dimension.
+
+    Falls back to ``{"gpu_count": units}`` for pre-migration rows that
+    have never had ``dimensions`` populated.
+    """
+    if allocation.dimensions:
+        return {
+            str(key): Decimal(str(value))
+            for key, value in allocation.dimensions.items()
+        }
+    return {PRIMARY_DIMENSION: Decimal(int(allocation.units or 0))}
 
 
 def _resource_matches(
@@ -151,7 +245,7 @@ def _resource_matches(
         "gpu_count": resource.total_units,
     }
     for key, expected in claim.items():
-        if key in _UNIT_CLAIM_KEYS:
+        if key in _UNIT_CLAIM_KEYS or key == _DIMENSIONS_CLAIM_KEY:
             continue
         actual = attrs.get(key, top_level.get(key))
         if actual != expected:
@@ -194,38 +288,59 @@ class CapacityLedgerService:
         resource_type: str = "compute.gpu",
         resource_subtype: str | None = None,
         attributes: Mapping[str, Any] | None = None,
+        capacity: Mapping[str, Any] | None = None,
         enabled: bool = True,
     ) -> dict[str, Any]:
         """Insert or update a ledger resource; emits a delta on change.
+
+        ``capacity`` is the multidimensional total.
+        ``total_units`` remains a service-maintained mirror of ``capacity["gpu_count"]``.
+        When ``capacity`` omits ``gpu_count``, the supplied ``total_units`` fills it in.
 
         An upsert that changes capacity (units, enablement) emits a
         "released" or "reserved"-equivalent availability change; we use
         "released" for grows/registrations and "reserved" for shrinks so
         subscribers reconcile in the right direction without a new kind.
+        The event's ``dimensions`` carries the signed per-dimension delta.
         """
         with self._lock, self._session_factory() as db:
             row = db.get(SiteResource, resource_id)
+            old_capacity = _resource_capacity(row) if row is not None else {}
+            new_dimensions = dict(capacity or {})
+            new_dimensions.setdefault(PRIMARY_DIMENSION, int(total_units))
+            new_capacity = {
+                str(key): _to_decimal_nonneg(value, label=f"capacity[{key}]")
+                for key, value in new_dimensions.items()
+            }
+            mirrored_units = int(new_capacity.get(PRIMARY_DIMENSION, Decimal(int(total_units))))
             grew = True
             if row is None:
                 row = SiteResource(
                     resource_id=resource_id,
                     resource_type=resource_type,
                     resource_subtype=resource_subtype,
-                    total_units=int(total_units),
+                    total_units=mirrored_units,
+                    capacity=_serialize_dimensions(new_capacity),
                     attributes=dict(attributes or {}),
                     enabled=enabled,
                 )
                 db.add(row)
             else:
-                grew = (int(total_units), enabled) >= (int(row.total_units), bool(row.enabled))
+                grew = (mirrored_units, enabled) >= (int(row.total_units), bool(row.enabled))
                 row.resource_type = resource_type
                 row.resource_subtype = resource_subtype
-                row.total_units = int(total_units)
+                row.total_units = mirrored_units
+                row.capacity = _serialize_dimensions(new_capacity)
                 row.attributes = dict(attributes or {})
                 row.enabled = enabled
+            delta = {
+                key: new_capacity.get(key, Decimal(0)) - old_capacity.get(key, Decimal(0))
+                for key in set(new_capacity) | set(old_capacity)
+            }
             db.add(CapacityEvent(
                 kind="released" if grew else "reserved",
                 resource_id=resource_id,
+                dimensions=_serialize_dimensions(delta),
             ))
             db.commit()
             return self._resource_payload(db, db.get(SiteResource, resource_id))
@@ -256,7 +371,7 @@ class CapacityLedgerService:
         lease_duration_seconds: int | None = None,
     ) -> dict[str, Any] | None:
         """Dry-run match for ``claim`` — consumes nothing."""
-        requested = _requested_units(claim)
+        requested = _requested_dimensions(claim)
         window_start, window_end = _lease_window(
             lease_start_utc=lease_start_utc,
             lease_duration_seconds=lease_duration_seconds,
@@ -279,7 +394,7 @@ class CapacityLedgerService:
         lease_duration_seconds: int | None = None,
     ) -> dict[str, Any] | None:
         """Atomically check-and-reserve capacity matching ``claim``."""
-        requested = _requested_units(claim)
+        requested = _requested_dimensions(claim)
         deal = dict(deal_ref or {})
         window_start, window_end = _lease_window(
             lease_start_utc=lease_start_utc,
@@ -296,10 +411,12 @@ class CapacityLedgerService:
                 hold_expires_at = (
                     datetime.now(timezone.utc) + timedelta(seconds=float(ttl_seconds))
                 ).isoformat()
+            mirrored_units = int(requested.get(PRIMARY_DIMENSION, Decimal(0)))
             allocation = SiteAllocation(
                 allocation_id=str(uuid.uuid4()),
                 resource_id=resource.resource_id,
-                units=requested,
+                units=mirrored_units,
+                dimensions=_serialize_dimensions(requested),
                 state=AllocationState.reserved.value,
                 deal_ref=deal,
                 escrow_uid=deal.get("escrow_uid"),
@@ -314,9 +431,17 @@ class CapacityLedgerService:
                 lease_end_utc=window_end.isoformat() if window_end else None,
             )
             db.add(allocation)
-            db.add(CapacityEvent(kind="reserved", resource_id=resource.resource_id))
+            db.add(CapacityEvent(
+                kind="reserved",
+                resource_id=resource.resource_id,
+                dimensions=_serialize_dimensions({k: -v for k, v in requested.items()}),
+            ))
             db.commit()
-            payload = self._match_payload(resource, available - requested, requested)
+            available_after = {
+                key: available.get(key, Decimal(0)) - requested.get(key, Decimal(0))
+                for key in set(available) | set(requested)
+            }
+            payload = self._match_payload(resource, available_after, requested)
             payload["allocation_id"] = allocation.allocation_id
             payload["hold_expires_at"] = hold_expires_at
             return payload
@@ -346,21 +471,31 @@ class CapacityLedgerService:
                 raise CapacityConflictError(
                     f"settlement resource {settlement_resource_id!r} is unavailable"
                 )
-            held = sum(
-                row.units for row in db.query(SiteAllocation).filter(
-                    SiteAllocation.resource_id == settlement_resource_id,
-                    SiteAllocation.state.in_(HELD_ALLOCATION_STATES),
-                ).all()
+            allocation_dims = _allocation_dimensions(allocation)
+            held = self._held_dimensions(db, settlement_resource_id)
+            capacity = _resource_capacity(destination)
+            insufficient = any(
+                capacity.get(dim, Decimal(0)) - held.get(dim, Decimal(0)) < amount
+                for dim, amount in allocation_dims.items()
             )
-            if destination.total_units - held < allocation.units:
+            if insufficient:
                 raise CapacityConflictError(
                     f"settlement resource {settlement_resource_id!r} lacks capacity"
                 )
             source_id = allocation.resource_id
             allocation.resource_id = settlement_resource_id
             allocation.vm_host = (destination.attributes or {}).get("vm_host")
-            db.add(CapacityEvent(kind="capacity_released_for_reassignment", resource_id=source_id))
-            db.add(CapacityEvent(kind="capacity_assigned_for_settlement", resource_id=settlement_resource_id))
+            serialized_dims = _serialize_dimensions(allocation_dims)
+            db.add(CapacityEvent(
+                kind="capacity_released_for_reassignment",
+                resource_id=source_id,
+                dimensions=serialized_dims,
+            ))
+            db.add(CapacityEvent(
+                kind="capacity_assigned_for_settlement",
+                resource_id=settlement_resource_id,
+                dimensions=_serialize_dimensions({k: -v for k, v in allocation_dims.items()}),
+            ))
             db.commit()
             return self._allocation_payload(allocation)
 
@@ -436,7 +571,11 @@ class CapacityLedgerService:
             allocation.released_at = datetime.now(timezone.utc).isoformat()
             allocation.failure_reason = failure_reason
             allocation.failure_message = failure_message
-            db.add(CapacityEvent(kind="released", resource_id=allocation.resource_id))
+            db.add(CapacityEvent(
+                kind="released",
+                resource_id=allocation.resource_id,
+                dimensions=_serialize_dimensions(_allocation_dimensions(allocation)),
+            ))
             db.commit()
             return self._allocation_payload(allocation)
 
@@ -703,6 +842,7 @@ class CapacityLedgerService:
                     "version": row.version,
                     "kind": row.kind,
                     "resource_id": row.resource_id,
+                    "dimensions": dict(row.dimensions) if row.dimensions else None,
                     "occurred_at": (
                         row.occurred_at.isoformat() if row.occurred_at else None
                     ),
@@ -787,13 +927,17 @@ class CapacityLedgerService:
         if lapsed:
             db.commit()
 
-    def _held_units(
+    def _held_dimensions(
         self,
         db: Session,
         resource_id: str,
         lease_start: datetime | None = None,
         lease_end: datetime | None = None,
-    ) -> int:
+    ) -> dict[str, Decimal]:
+        """Sum held quantity per dimension across overlapping allocations.
+
+        Generalizes the old single-dimension ``_held_units``.
+        """
         rows = (
             db.query(SiteAllocation)
             .filter(
@@ -802,35 +946,53 @@ class CapacityLedgerService:
             )
             .all()
         )
+        totals: dict[str, Decimal] = {}
+
+        def _accumulate(row: SiteAllocation) -> None:
+            for key, amount in _allocation_dimensions(row).items():
+                totals[key] = totals.get(key, Decimal(0)) + amount
+
         if lease_start is None and lease_end is None:
-            return sum(int(row.units or 0) for row in rows)
-        total = 0
+            for row in rows:
+                _accumulate(row)
+            return totals
         for row in rows:
             if row.state in {
                 AllocationState.releasing.value,
                 AllocationState.release_failed.value,
                 AllocationState.unmanaged.value,
             }:
-                total += int(row.units or 0)
+                _accumulate(row)
                 continue
             row_start = parse_utc(row.lease_start_utc)
             row_end = parse_utc(row.lease_end_utc)
             if row_start is None and row_end is None:
                 # Legacy/current holds without a window block every window.
-                total += int(row.units or 0)
+                _accumulate(row)
                 continue
             if _windows_overlap(lease_start, lease_end, row_start, row_end):
-                total += int(row.units or 0)
-        return total
+                _accumulate(row)
+        return totals
+
+    def _held_units(
+        self,
+        db: Session,
+        resource_id: str,
+        lease_start: datetime | None = None,
+        lease_end: datetime | None = None,
+    ) -> int:
+        """Legacy single-dimension accessor, kept for the primary mirror."""
+        held = self._held_dimensions(db, resource_id, lease_start, lease_end)
+        return int(held.get(PRIMARY_DIMENSION, Decimal(0)))
 
     def _find_candidate(
         self,
         db: Session,
         claim: Mapping[str, Any] | None,
-        requested: int,
+        requested: Mapping[str, Decimal],
         lease_start: datetime | None = None,
         lease_end: datetime | None = None,
-    ) -> tuple[SiteResource, int] | None:
+    ) -> tuple[SiteResource, dict[str, Decimal]] | None:
         rows = (
             db.query(SiteResource)
             .filter(SiteResource.enabled.is_(True))
@@ -850,10 +1012,20 @@ class CapacityLedgerService:
                 db, resource, lease_start, lease_end,
             ):
                 continue
-            available = int(resource.total_units or 0) - self._held_units(
-                db, resource.resource_id, lease_start, lease_end
+            capacity = _resource_capacity(resource)
+            held = self._held_dimensions(db, resource.resource_id, lease_start, lease_end)
+            available = {
+                key: capacity.get(key, Decimal(0)) - held.get(key, Decimal(0))
+                for key in capacity
+            }
+            # Hard fit: every requested dimension must both be declared by
+            # this resource (a dimension the resource never mentions can't
+            # be assumed to have room) and have enough unallocated capacity.
+            fits = all(
+                available.get(dim, Decimal(0)) >= amount
+                for dim, amount in requested.items()
             )
-            if available < requested:
+            if not fits:
                 continue
             return resource, available
         return None
@@ -881,24 +1053,30 @@ class CapacityLedgerService:
 
     def _resource_payload(self, db: Session, row: SiteResource) -> dict[str, Any]:
         now = datetime.now(timezone.utc)
-        held = self._held_units(
+        capacity = _resource_capacity(row)
+        held = self._held_dimensions(
             db,
             row.resource_id,
             now,
             now + timedelta(microseconds=1),
         )
         total = int(row.total_units or 0)
+        held_primary = int(held.get(PRIMARY_DIMENSION, Decimal(0)))
         blocked = self._has_physical_host_conflict(
             db, row, now, now + timedelta(microseconds=1),
         )
         if blocked:
-            available = 0
+            available_map = {key: Decimal(0) for key in capacity}
             state = "leased"
         else:
-            available = max(total - held, 0)
-            if available >= total or held <= 0:
+            available_map = {
+                key: max(capacity.get(key, Decimal(0)) - held.get(key, Decimal(0)), Decimal(0))
+                for key in capacity
+            }
+            available_primary = int(available_map.get(PRIMARY_DIMENSION, Decimal(total)))
+            if available_primary >= total or held_primary <= 0:
                 state = "available"
-            elif available > 0:
+            elif available_primary > 0:
                 state = "available"
             else:
                 state = "leased"
@@ -909,7 +1087,9 @@ class CapacityLedgerService:
             "unit": "count",
             "value": total,
             "state": state,
-            "available_units": available,
+            "available_units": int(available_map.get(PRIMARY_DIMENSION, Decimal(total))),
+            "capacity": _serialize_dimensions(capacity),
+            "available": _serialize_dimensions(available_map),
             "attributes": dict(row.attributes or {}),
             "enabled": bool(row.enabled),
         }
@@ -980,14 +1160,22 @@ class CapacityLedgerService:
 
     @staticmethod
     def _match_payload(
-        resource: SiteResource, available: int, requested: int
+        resource: SiteResource,
+        available: Mapping[str, Decimal],
+        requested: Mapping[str, Decimal],
     ) -> dict[str, Any]:
         """Shape a probe/reserve result like the embedded adapter's.
 
         pool/member are storefront (aggregator) concepts the site does not
         know; they are present-and-None for payload compatibility.
+        ``requested``/``available`` are full per-dimension maps (POOLS-6
+        pass 1); ``allocated_units``/``available_units`` and their
+        ``*_gpu_count`` aliases stay byte-compatible by mirroring the
+        primary (``gpu_count``) dimension.
         """
         attrs = dict(resource.attributes or {})
+        allocated_primary = int(requested.get(PRIMARY_DIMENSION, Decimal(0)))
+        available_primary = int(available.get(PRIMARY_DIMENSION, Decimal(0)))
         return {
             "resource_id": resource.resource_id,
             "pool_id": None,
@@ -997,12 +1185,15 @@ class CapacityLedgerService:
             "unit": "count",
             "state": "available",
             "value": int(resource.total_units or 0),
-            "allocated_units": requested,
-            "available_units": available,
+            "allocated_units": allocated_primary,
+            "available_units": available_primary,
             # VM-domain aliases, kept so the remote client stays
             # byte-compatible with the embedded adapter it replaced.
-            "allocated_gpu_count": requested,
-            "available_gpu_count": available,
+            "allocated_gpu_count": allocated_primary,
+            "available_gpu_count": available_primary,
+            "dimensions": _serialize_dimensions(requested),
+            "available": _serialize_dimensions(available),
+            "capacity": _serialize_dimensions(_resource_capacity(resource)),
             "attributes": attrs,
         }
 
@@ -1014,6 +1205,7 @@ class CapacityLedgerService:
             "pool_id": None,
             "units": int(allocation.units or 0),
             "allocated_gpu_count": int(allocation.units or 0),
+            "dimensions": _serialize_dimensions(_allocation_dimensions(allocation)),
             "state": allocation.state,
             "deal_ref": dict(allocation.deal_ref or {}),
             "escrow_uid": allocation.escrow_uid,

--- a/kit/site/src/market_site/ledger.py
+++ b/kit/site/src/market_site/ledger.py
@@ -155,6 +155,9 @@ def _to_decimal(value: Any, *, label: str) -> Decimal:
         amount = Decimal(str(value))
     except (InvalidOperation, TypeError, ValueError) as exc:
         raise ValueError(f"{label} must be numeric, got {value!r}") from exc
+    # NaN/Infinity parse without error but raise InvalidOperation on comparison
+    if not amount.is_finite():
+        raise ValueError(f"{label} must be a finite number, got {value!r}")
     if amount <= 0:
         raise ValueError(f"{label} must be > 0, got {amount}")
     return amount
@@ -163,19 +166,28 @@ def _to_decimal(value: Any, *, label: str) -> Decimal:
 def _requested_dimensions(claim: Mapping[str, Any] | None) -> dict[str, Decimal]:
     """Parse a claim's quantity request as a dimensions map.
 
-    ``dimensions`` is authoritative when present. Otherwise falls back to
-    the legacy single-quantity claim (``units``/``gpu_count``), translated
-    to ``{"gpu_count": n}`` so every existing caller's claim shape keeps
+    ``dimensions`` is authoritative when *present* — not merely truthy.
+    ``{"dimensions": {}}`` is a malformed claim (declares nothing to
+    request) and must fail loudly rather than silently falling through to
+    the legacy single-quantity parse, which would otherwise default to a
+    request the caller never actually made.
+    Only the *absence* of the key falls back to the legacy
+    single-quantity claim (``units``/``gpu_count``), translated to
+    ``{"gpu_count": n}`` so every existing caller's claim shape keeps
     working unchanged.
     """
     claim = claim or {}
-    raw = claim.get(_DIMENSIONS_CLAIM_KEY)
-    if raw:
-        return {
-            str(key): _to_decimal(value, label=f"dimensions[{key}]")
-            for key, value in raw.items()
-        }
-    return {PRIMARY_DIMENSION: Decimal(_requested_units(claim))}
+    if _DIMENSIONS_CLAIM_KEY not in claim:
+        return {PRIMARY_DIMENSION: Decimal(_requested_units(claim))}
+    raw = claim[_DIMENSIONS_CLAIM_KEY]
+    if not isinstance(raw, Mapping) or not raw:
+        raise ValueError(
+            f"dimensions must be a non-empty mapping, got {raw!r}"
+        )
+    return {
+        str(key): _to_decimal(value, label=f"dimensions[{key}]")
+        for key, value in raw.items()
+    }
 
 
 def _serialize_dimensions(dimensions: Mapping[str, Decimal]) -> dict[str, float | int]:
@@ -193,6 +205,8 @@ def _to_decimal_nonneg(value: Any, *, label: str) -> Decimal:
         amount = Decimal(str(value))
     except (InvalidOperation, TypeError, ValueError) as exc:
         raise ValueError(f"{label} must be numeric, got {value!r}") from exc
+    if not amount.is_finite():
+        raise ValueError(f"{label} must be a finite number, got {value!r}")
     if amount < 0:
         raise ValueError(f"{label} must be >= 0, got {amount}")
     return amount
@@ -224,6 +238,29 @@ def _allocation_dimensions(allocation: SiteAllocation) -> dict[str, Decimal]:
             for key, value in allocation.dimensions.items()
         }
     return {PRIMARY_DIMENSION: Decimal(int(allocation.units or 0))}
+
+
+def _capacity_change_kind(
+    delta: Mapping[str, Decimal], *, old_enabled: bool | None, new_enabled: bool,
+) -> str:
+    """Classify a capacity-registration delta for the event feed's ``kind``.
+
+    A single grew/shrank boolean cannot represent a mixed-direction
+    change (e.g. GPU count grows while RAM shrinks). Returns "capacity_changed"
+    for that case rather than mislabeling it "released" or "reserved".
+    Enablement toggling folds in as its own signed contribution: going disabled is a
+    decrease, going enabled is an increase, regardless of the capacity
+    numbers, since a disabled resource is unavailable no matter what its
+    declared capacity says.
+    """
+    signs = {1 if amount > 0 else -1 for amount in delta.values() if amount != 0}
+    if old_enabled is not None and old_enabled != new_enabled:
+        signs.add(1 if new_enabled else -1)
+    if not signs or signs == {1}:
+        return "released"
+    if signs == {-1}:
+        return "reserved"
+    return "capacity_changed"
 
 
 def _resource_matches(
@@ -295,26 +332,43 @@ class CapacityLedgerService:
 
         ``capacity`` is the multidimensional total.
         ``total_units`` remains a service-maintained mirror of ``capacity["gpu_count"]``.
-        When ``capacity`` omits ``gpu_count``, the supplied ``total_units`` fills it in.
+        When ``capacity`` includes ``gpu_count`` *and* it disagrees with
+        ``total_units``, that is a caller bug, raises ``ValueError``.
 
-        An upsert that changes capacity (units, enablement) emits a
-        "released" or "reserved"-equivalent availability change; we use
-        "released" for grows/registrations and "reserved" for shrinks so
-        subscribers reconcile in the right direction without a new kind.
-        The event's ``dimensions`` carries the signed per-dimension delta.
+        An upsert emits a signed per-dimension delta on the event
+        (authoritative). ``kind`` is a coarser hint for legacy
+        single-dimension consumers: "released" when every changed
+        dimension and enablement moved to a non-decreasing net effect,
+        "reserved" when every changed dimension and enablement moved to a
+        non-increasing net effect, and "capacity_changed" when the
+        direction is genuinely mixed (e.g. GPU count grew while RAM
+        shrank) -- a case a single grew/shrank boolean cannot represent.
+        First-time registration is always "released": brand new capacity
+        appearing is unambiguous.
         """
         with self._lock, self._session_factory() as db:
             row = db.get(SiteResource, resource_id)
             old_capacity = _resource_capacity(row) if row is not None else {}
+            old_enabled = bool(row.enabled) if row is not None else None
             new_dimensions = dict(capacity or {})
-            new_dimensions.setdefault(PRIMARY_DIMENSION, int(total_units))
+            if PRIMARY_DIMENSION in new_dimensions:
+                supplied = _to_decimal_nonneg(
+                    new_dimensions[PRIMARY_DIMENSION], label="capacity[gpu_count]",
+                )
+                if supplied != Decimal(int(total_units)):
+                    raise ValueError(
+                        f"capacity['gpu_count']={supplied} disagrees with "
+                        f"total_units={total_units}; pass one consistent value"
+                    )
+            else:
+                new_dimensions[PRIMARY_DIMENSION] = int(total_units)
             new_capacity = {
                 str(key): _to_decimal_nonneg(value, label=f"capacity[{key}]")
                 for key, value in new_dimensions.items()
             }
-            mirrored_units = int(new_capacity.get(PRIMARY_DIMENSION, Decimal(int(total_units))))
-            grew = True
-            if row is None:
+            mirrored_units = int(new_capacity[PRIMARY_DIMENSION])
+            is_new = row is None
+            if is_new:
                 row = SiteResource(
                     resource_id=resource_id,
                     resource_type=resource_type,
@@ -326,7 +380,6 @@ class CapacityLedgerService:
                 )
                 db.add(row)
             else:
-                grew = (mirrored_units, enabled) >= (int(row.total_units), bool(row.enabled))
                 row.resource_type = resource_type
                 row.resource_subtype = resource_subtype
                 row.total_units = mirrored_units
@@ -337,8 +390,11 @@ class CapacityLedgerService:
                 key: new_capacity.get(key, Decimal(0)) - old_capacity.get(key, Decimal(0))
                 for key in set(new_capacity) | set(old_capacity)
             }
+            kind = "released" if is_new else _capacity_change_kind(
+                delta, old_enabled=old_enabled, new_enabled=enabled,
+            )
             db.add(CapacityEvent(
-                kind="released" if grew else "reserved",
+                kind=kind,
                 resource_id=resource_id,
                 dimensions=_serialize_dimensions(delta),
             ))

--- a/kit/site/src/market_site/router.py
+++ b/kit/site/src/market_site/router.py
@@ -77,6 +77,7 @@ def make_capacity_router(
             resource_type=body.resource_type,
             resource_subtype=body.resource_subtype,
             attributes=body.attributes,
+            capacity=body.capacity,
             enabled=body.enabled,
         )
         logger.info(

--- a/kit/site/tests/unit/test_ledger.py
+++ b/kit/site/tests/unit/test_ledger.py
@@ -653,3 +653,165 @@ def test_gpu_count_validation(seeded: CapacityLedgerService):
         seeded.probe(claim={"gpu_count": "many"})
     with pytest.raises(ValueError):
         seeded.reserve(claim={"gpu_count": 0}, deal_ref={})
+
+
+# ----------------------------------------------------------------------
+# multidimensional capacity
+# ----------------------------------------------------------------------
+
+@pytest.fixture
+def multidim(ledger: CapacityLedgerService) -> CapacityLedgerService:
+    ledger.register_resource(
+        resource_id="compute-kvm2-001",
+        total_units=8,
+        resource_subtype="h200",
+        attributes={"vm_host": "kvm2", "gpu_model": "H200", "region": "us-west"},
+        capacity={"gpu_count": 8, "vcpu_count": 64, "ram_gb": 512, "disk_gb": 4000},
+    )
+    return ledger
+
+
+def test_register_resource_reports_multidimensional_capacity(
+    multidim: CapacityLedgerService,
+):
+    row = multidim.snapshot()[0]
+    assert row["capacity"] == {"gpu_count": 8, "vcpu_count": 64, "ram_gb": 512, "disk_gb": 4000}
+    assert row["available"] == {"gpu_count": 8, "vcpu_count": 64, "ram_gb": 512, "disk_gb": 4000}
+    # total_units mirrors capacity["gpu_count"] for payload compatibility.
+    assert row["available_units"] == 8
+
+
+def test_dimension_claim_fits_and_holds_every_dimension(
+    multidim: CapacityLedgerService,
+):
+    reserved = multidim.reserve(
+        claim={"dimensions": {"gpu_count": 2, "vcpu_count": 8, "ram_gb": 64, "disk_gb": 500}},
+        deal_ref={"escrow_uid": "0xdim"},
+    )
+    assert reserved is not None
+    assert reserved["dimensions"] == {"gpu_count": 2, "vcpu_count": 8, "ram_gb": 64, "disk_gb": 500}
+    assert reserved["available"] == {
+        "gpu_count": 6, "vcpu_count": 56, "ram_gb": 448, "disk_gb": 3500,
+    }
+    row = multidim.snapshot()[0]
+    assert row["available"] == {
+        "gpu_count": 6, "vcpu_count": 56, "ram_gb": 448, "disk_gb": 3500,
+    }
+    # Legacy single-quantity fields still mirror the primary dimension.
+    assert reserved["allocated_gpu_count"] == 2
+    assert reserved["available_gpu_count"] == 6
+
+
+def test_dimension_claim_rejected_when_secondary_dimension_does_not_fit(
+    multidim: CapacityLedgerService,
+):
+    """GPU count alone would fit; RAM would not -- must still be rejected.
+    """
+    assert multidim.probe(
+        claim={"dimensions": {"gpu_count": 1, "ram_gb": 9999}},
+    ) is None
+    assert multidim.reserve(
+        claim={"dimensions": {"gpu_count": 1, "ram_gb": 9999}},
+        deal_ref={"escrow_uid": "0xtoobig"},
+    ) is None
+    # Capacity is untouched by the rejected attempt.
+    assert multidim.snapshot()[0]["available"]["ram_gb"] == 512
+
+
+def test_dimension_claim_rejected_for_dimension_resource_never_declares(
+    multidim: CapacityLedgerService,
+):
+    """A dimension the candidate never mentions can't be assumed to have
+    room -- distinct from "declared but full"."""
+    assert multidim.probe(
+        claim={"dimensions": {"gpu_count": 1, "network_bandwidth_gbps": 10}},
+    ) is None
+
+
+def test_concurrent_shareable_holds_accumulate_per_dimension(
+    multidim: CapacityLedgerService,
+):
+    """Two separate holds on one shareable resource must both be counted
+    against RAM, not just against GPU count -- the correctness gap a
+    declared-capacity-only gate would have missed."""
+    first = multidim.reserve(
+        claim={"dimensions": {"gpu_count": 1, "ram_gb": 300}},
+        deal_ref={"escrow_uid": "0xfirst"},
+    )
+    assert first is not None
+    # A second hold that alone would fit RAM's remainder does fit...
+    second = multidim.reserve(
+        claim={"dimensions": {"gpu_count": 1, "ram_gb": 200}},
+        deal_ref={"escrow_uid": "0xsecond"},
+    )
+    assert second is not None
+    # ...but a third that would push combined RAM over capacity must not.
+    assert multidim.reserve(
+        claim={"dimensions": {"gpu_count": 1, "ram_gb": 50}},
+        deal_ref={"escrow_uid": "0xthird"},
+    ) is None
+    assert multidim.snapshot()[0]["available"]["ram_gb"] == 12
+
+
+def test_legacy_claim_without_dimensions_still_works_on_multidim_resource(
+    multidim: CapacityLedgerService,
+):
+    reserved = multidim.reserve(
+        claim={"gpu_count": 3}, deal_ref={"escrow_uid": "0xlegacy"},
+    )
+    assert reserved is not None
+    assert reserved["allocated_gpu_count"] == 3
+    assert reserved["available_gpu_count"] == 5
+    # Legacy claims never mention the secondary dimensions, so they are
+    # not checked or held -- documented pass-1 scope, not a regression:
+    # legacy claims behave exactly as they did before this change.
+    assert multidim.snapshot()[0]["available"]["ram_gb"] == 512
+
+
+def test_pre_migration_resource_falls_back_to_gpu_count_only_capacity(
+    seeded: CapacityLedgerService,
+):
+    """A resource registered without ``capacity`` only ever declares
+    gpu_count. Any other requested dimension correctly fails to fit
+    rather than being silently ignored."""
+    assert seeded.probe(claim={"dimensions": {"gpu_count": 1}}) is not None
+    assert seeded.probe(claim={"dimensions": {"gpu_count": 1, "ram_gb": 1}}) is None
+
+
+def test_release_restores_every_dimension(multidim: CapacityLedgerService):
+    reserved = multidim.reserve(
+        claim={"dimensions": {"gpu_count": 2, "vcpu_count": 8, "ram_gb": 64, "disk_gb": 500}},
+        deal_ref={"escrow_uid": "0xrelease"},
+    )
+    multidim.release(allocation_id=reserved["allocation_id"])
+    row = multidim.snapshot()[0]
+    assert row["available"] == {"gpu_count": 8, "vcpu_count": 64, "ram_gb": 512, "disk_gb": 4000}
+
+
+def test_capacity_events_carry_signed_per_dimension_deltas(
+    multidim: CapacityLedgerService,
+):
+    reserved = multidim.reserve(
+        claim={"dimensions": {"gpu_count": 2, "ram_gb": 64}},
+        deal_ref={"escrow_uid": "0xevt"},
+    )
+    multidim.release(allocation_id=reserved["allocation_id"])
+    events, _ = multidim.events_after(0)
+    by_kind = {e["kind"]: e for e in events}
+    assert by_kind["reserved"]["dimensions"] == {"gpu_count": -2, "ram_gb": -64}
+    assert by_kind["released"]["dimensions"] == {"gpu_count": 2, "ram_gb": 64}
+
+
+def test_registration_event_delta_is_capacity_minus_previous_capacity(
+    ledger: CapacityLedgerService,
+):
+    ledger.register_resource(
+        resource_id="growing", total_units=2, capacity={"gpu_count": 2, "ram_gb": 100},
+    )
+    ledger.register_resource(
+        resource_id="growing", total_units=4, capacity={"gpu_count": 4, "ram_gb": 100},
+    )
+    events, _ = ledger.events_after(0)
+    deltas = [e["dimensions"] for e in events if e["resource_id"] == "growing"]
+    assert deltas[0] == {"gpu_count": 2, "ram_gb": 100}
+    assert deltas[1] == {"gpu_count": 2, "ram_gb": 0}

--- a/kit/site/tests/unit/test_ledger.py
+++ b/kit/site/tests/unit/test_ledger.py
@@ -815,3 +815,110 @@ def test_registration_event_delta_is_capacity_minus_previous_capacity(
     deltas = [e["dimensions"] for e in events if e["resource_id"] == "growing"]
     assert deltas[0] == {"gpu_count": 2, "ram_gb": 100}
     assert deltas[1] == {"gpu_count": 2, "ram_gb": 0}
+
+def test_explicit_empty_dimensions_map_is_rejected(seeded: CapacityLedgerService):
+    """{"dimensions": {}} declares nothing to request -- must fail loudly,
+    not silently fall through to the legacy single-quantity default of 1
+    (a real bug found in code review: presence was checked as truthiness)."""
+    with pytest.raises(ValueError):
+        seeded.probe(claim={"dimensions": {}})
+    with pytest.raises(ValueError):
+        seeded.reserve(claim={"dimensions": {}}, deal_ref={})
+
+
+@pytest.mark.parametrize("raw", [[], "not-a-mapping", None, 5])
+def test_malformed_dimensions_types_are_rejected(seeded: CapacityLedgerService, raw):
+    with pytest.raises(ValueError):
+        seeded.probe(claim={"dimensions": raw})
+
+
+@pytest.mark.parametrize("value", [0, -1, "not-a-number"])
+def test_dimensions_values_must_be_positive_numbers(
+    seeded: CapacityLedgerService, value,
+):
+    with pytest.raises(ValueError):
+        seeded.probe(claim={"dimensions": {"gpu_count": value}})
+
+
+def test_dimensions_reject_nan_and_infinity(seeded: CapacityLedgerService):
+    """NaN/Infinity parse cleanly into Decimal but raise InvalidOperation
+    on comparison -- must surface as the same clean ValueError as any
+    other malformed quantity, not an uncaught decimal.InvalidOperation
+    """
+    with pytest.raises(ValueError):
+        seeded.probe(claim={"dimensions": {"gpu_count": float("nan")}})
+    with pytest.raises(ValueError):
+        seeded.probe(claim={"dimensions": {"gpu_count": float("inf")}})
+
+
+def test_register_resource_rejects_conflicting_total_units_and_capacity(
+    ledger: CapacityLedgerService,
+):
+    """total_units is documented as a mirror of capacity['gpu_count']; two
+    disagreeing values is a caller bug, not something to silently resolve
+    in capacity's favor."""
+    with pytest.raises(ValueError):
+        ledger.register_resource(
+            resource_id="conflicted", total_units=8, capacity={"gpu_count": 4},
+        )
+    # Consistent values are fine.
+    ledger.register_resource(
+        resource_id="consistent", total_units=8, capacity={"gpu_count": 8, "ram_gb": 64},
+    )
+    assert ledger.snapshot()[0]["capacity"]["gpu_count"] == 8
+
+
+def test_mixed_direction_capacity_change_gets_neutral_event_kind(
+    ledger: CapacityLedgerService,
+):
+    """GPU count growing while RAM shrinks has no single grew/shrank
+    direction -- must not be mislabeled "released" (implying availability
+    only increased) or "reserved"."""
+    ledger.register_resource(
+        resource_id="host-1", total_units=4, capacity={"gpu_count": 4, "ram_gb": 512},
+    )
+    ledger.register_resource(
+        resource_id="host-1", total_units=8, capacity={"gpu_count": 8, "ram_gb": 128},
+    )
+    events, _ = ledger.events_after(0)
+    kinds = [e["kind"] for e in events if e["resource_id"] == "host-1"]
+    assert kinds == ["released", "capacity_changed"]
+
+
+def test_pure_grow_and_pure_shrink_keep_their_kind(ledger: CapacityLedgerService):
+    ledger.register_resource(
+        resource_id="r", total_units=4, capacity={"gpu_count": 4, "ram_gb": 100},
+    )
+    ledger.register_resource(
+        resource_id="r", total_units=8, capacity={"gpu_count": 8, "ram_gb": 200},
+    )
+    ledger.register_resource(
+        resource_id="r", total_units=2, capacity={"gpu_count": 2, "ram_gb": 50},
+    )
+    events, _ = ledger.events_after(0)
+    kinds = [e["kind"] for e in events if e["resource_id"] == "r"]
+    assert kinds == ["released", "released", "reserved"]
+
+
+def test_disabling_alone_is_reserved_even_with_unchanged_capacity(
+    ledger: CapacityLedgerService,
+):
+    ledger.register_resource(resource_id="r", total_units=4, enabled=True)
+    ledger.register_resource(resource_id="r", total_units=4, enabled=False)
+    events, _ = ledger.events_after(0)
+    kinds = [e["kind"] for e in events if e["resource_id"] == "r"]
+    assert kinds == ["released", "reserved"]
+
+
+def test_scheduler_credit_back_covers_full_capacity_legacy_allocation():
+    """Ledger-level regression test for the scheduler-level one in
+    test_physical_settlement_scheduler.py: reserving *all* of a
+    resource's capacity via a legacy gpu_count-only claim must still
+    report a fully-populated dimensions map, since the scheduler's
+    credit-back logic depends on it never being empty for a
+    pre-migration-style allocation."""
+    ledger = _make_ledger()
+    ledger.register_resource(resource_id="r1", total_units=4)
+    reserved = ledger.reserve(claim={"gpu_count": 4}, deal_ref={})
+    allocation = ledger.get_allocation(reserved["allocation_id"])
+    assert allocation["dimensions"] == {"gpu_count": 4}

--- a/openspec/changes/pools-6-multidimensional-fair-scheduling/design.md
+++ b/openspec/changes/pools-6-multidimensional-fair-scheduling/design.md
@@ -19,28 +19,90 @@ The previous draft grouped independent resource rows by `resource_type`, calcula
 
 A future policy must score actual concrete candidates or explicitly model a schedulable resource bundle whose dimensions are co-located.
 
-## Candidate capacity model
+## Candidate capacity model — resolved for pass 1 (design review, 2026-07-20)
 
-A future candidate may expose maps such as:
+The sketch below is now the actual implementation shape, not a future
+possibility. `SettlementCandidate.available` and
+`SettlementRequirement.dimensions` (`compute_provisioning/physical_settlement.py`)
+are `dict[str, Decimal]` maps, e.g. `{"gpu_count": 1, "vcpu": 4,
+"memory_mb": 16384, "disk_gb": 200}` — a generic map was chosen over fixed
+named fields to stay multi-domain-ready without a fixed vocabulary baked
+into the type.
 
 ```python
-class MultidimensionalCandidate:
+class SettlementCandidate(BaseModel):
     resource_id: str
     pool_id: str
-    total: Mapping[str, Decimal]
-    allocated: Mapping[str, Decimal]
-    attributes: Mapping[str, object]
+    resource_kind: str
+    available: dict[str, Decimal]      # replaces available_units
+    enabled: bool = True
+    provider: str
+    attributes: dict[str, Any] = Field(default_factory=dict)
+
+
+class SettlementRequirement(BaseModel):
+    resource_kind: str
+    dimensions: dict[str, Decimal]     # replaces units
+    attributes: dict[str, Any] = Field(default_factory=dict)
 ```
 
-A reservation may expose:
+Hard fit is evaluated before fairness: for every required dimension, the
+candidate must define positive total capacity and have enough unallocated
+capacity. `DeterministicRoundRobinPolicy` needs no change — it only sorts
+`pool_id`/`resource_id` strings and never inspects dimensions, confirming
+the caller-contract-stability goal above.
 
-```python
-class MultidimensionalRequirement:
-    dimensions: Mapping[str, Decimal]
-    attributes: Mapping[str, object]
-```
+For the VM domain, dimensions on different concrete resources are never
+combined: a `SiteResource` row already corresponds 1:1 to one physical
+host (existing `vm_host` attribute), so the row itself is the schedulable
+bundle. No cross-row bundling machinery was needed for pass 1. A future
+domain that needs dimensions spread across rows (e.g. a bundle spanning
+multiple discrete cards) will need to design that explicitly — pass 1
+does not generalize to it.
 
-Hard fit is evaluated before fairness. For every required dimension, the candidate must define positive total capacity and have enough unallocated capacity. Dimensions on different concrete resources cannot be combined unless the resource model explicitly declares them one schedulable bundle.
+### Ledger and scheduler changes backing this
+
+- `SiteResource` gains a `capacity: dict[str, Decimal]` column.
+  `total_units` is kept as a service-maintained mirror of
+  `capacity["gpu_count"]` rather than replaced outright — an
+  intermediate-state limitation in the same spirit as POOLS-2's
+  process-local assignment cursors, chosen to avoid a breaking payload-shape
+  migration for existing callers.
+- `SiteAllocation` gains a `dimensions: dict[str, Decimal]` column.
+  `CapacityLedgerService`'s held-units accounting (`_held_units` and
+  friends) generalizes to sum `dimensions` per key across overlapping held
+  allocations in a lease window, falling back to `{"gpu_count": units}`
+  for pre-migration rows. This gives full per-dimension held/available
+  accounting under concurrency — a declared-capacity-only gate (checking
+  the request against a host's total without accounting for other current
+  holds) was considered and rejected: it would still let two shareable
+  allocations on one host jointly overcommit a secondary dimension like
+  RAM even though each fits the host's total individually.
+- `probe`/`reserve` claims gain an optional `dimensions` map, authoritative
+  when present. Legacy single-quantity claims (`units`/`gpu_count`) keep
+  working unchanged via internal translation to
+  `dimensions={"gpu_count": n}` — no existing caller's claim shape breaks.
+- `CapacityEvent` payloads are extended with per-dimension deltas in pass 1
+  (not deferred to pass 2), matching the observability goal below.
+- `PhysicalSettlementScheduler._requirement`/`_eligible_candidates` build
+  and evaluate `dimensions` the same way.
+
+### VM domain wiring — deliberately scoped down for pass 1
+
+`ComputeResource` (`domains/vms/listings/models.py`) had no vCPU/RAM/disk
+field at all before pass 1, and no code path negotiated one — VM shape was
+effectively unspecified below the listing's `gpu_model`/`gpu_count`. Pass 1
+adds `vcpu_count`/`ram_gb`/`disk_gb` to `ComputeResource` as a **fixed,
+seller-declared listing attribute**, the same way `gpu_model` already
+works — every order against a listing gets the same shape. This is enough
+to prove the multidimensional admission path end-to-end for the VM domain
+without opening the negotiation-protocol question of buyer-selectable VM
+sizing, which is real future work (long-term direction, per the change
+owner) but needs its own design review and stakeholder team sign-off
+before it's picked up. `capacity_client.py` and `vm_job_spec_service.py`
+wire this fixed shape through registration and claim-building
+respectively; nothing here should be read as precedent for skipping that
+future review when negotiated sizing is eventually designed.
 
 ## Projected dominant utilization
 
@@ -123,6 +185,37 @@ The policy should be tested through simulations and invariants rather than only 
 - topology-constrained candidate sets;
 - failure and explicit reassignment workflows.
 
-## Non-Work / Deferred Decisions
+## Package boundary (resolved, 2026-07-20)
 
-The proposal's deferred questions are intentionally unresolved. This design must be revised in a later discuss → plan → implement session before normative requirements or code are added.
+Pass 1 keeps all its changes inside the current package boundaries
+(`compute_provisioning`, `kit/site`). `pools-7`'s design already planned to
+move `PhysicalSettlementScheduler`, `DeterministicRoundRobinPolicy`, and a
+shared `resource_satisfies_requirement` predicate into a new
+`kit/physical-settlement` package (final home between that and `kit/site`
+left to `pools-7`'s own planning). That package doesn't exist yet because
+`pools-7` hasn't started. Pools-6 does not create it or preempt that
+decision — the pass-1 dimension model is written against the existing
+`compute_provisioning`/`kit/site` locations and pools-7 inherits the move.
+
+## `resource_capacity_validator.py` (resolved, 2026-07-20)
+
+Left as-is for pass 1 rather than migrated or deleted. It's a
+storefront-local data-integrity check on operator CSV input (does an
+import overcommit a host's declared totals), a different concern from the
+admission-time fit gate this change adds to `CapacityLedgerService`. It
+also operates on the storefront's local `resources` table, which
+`pools-8`'s `CapacityProjection` is already slated to retire — extracting
+a shared kit helper now would invest in a mechanism scheduled for deletion
+in a change that hasn't started. Dimension vocabulary
+(`vcpu_count`/`ram_gb`/`disk_gb`) is converged between the two so the
+validator can be deleted outright, not migrated, once `pools-8` lands.
+
+## Non-Work / Deferred Decisions (pass 2)
+
+Pass 1's dimension model, admission correctness, and VM-domain wiring are
+resolved above and ready to implement. Everything below is pass 2 —
+fairness/placement policy selection — and remains genuinely open. This
+design must be revised in a later discuss → plan → implement session
+before pass-2 normative requirements or code are added. Confirmed so far:
+fairness subject leaned toward buyer/agreement in the 2026-07-20 review
+but was not pinned down; treat it as still open.

--- a/openspec/changes/pools-6-multidimensional-fair-scheduling/design.md
+++ b/openspec/changes/pools-6-multidimensional-fair-scheduling/design.md
@@ -55,12 +55,35 @@ capacity. `DeterministicRoundRobinPolicy` needs no change — it only sorts
 the caller-contract-stability goal above.
 
 For the VM domain, dimensions on different concrete resources are never
-combined: a `SiteResource` row already corresponds 1:1 to one physical
-host (existing `vm_host` attribute), so the row itself is the schedulable
-bundle. No cross-row bundling machinery was needed for pass 1. A future
-domain that needs dimensions spread across rows (e.g. a bundle spanning
-multiple discrete cards) will need to design that explicitly — pass 1
-does not generalize to it.
+combined: each requested dimension is checked against the *one*
+`SiteResource` row admission targets, not aggregated across rows, so the
+row itself is the schedulable bundle. No cross-row bundling machinery
+was needed for pass 1. A future domain that needs dimensions spread
+across rows (e.g. a bundle spanning multiple discrete cards) will need
+to design that explicitly — pass 1 does not generalize to it.
+
+**Correction (code review, 2026-07-20):** an earlier version of this
+paragraph claimed a `SiteResource` row is "1:1 with one physical host."
+That's wrong — this codebase already registers *multiple* `SiteResource`
+rows against the same physical host (see `test_ledger.py`'s
+`_shared_host_ledger`/`_register_dual_mode_host` fixtures, which predate
+this change: a shareable VM-slice row and an exclusive bare-metal row
+can share one `physical_host_id`). `_has_physical_host_conflict` only
+guards **exclusive-vs-shareable mode conflicts** between sibling rows on
+one host — it has never been a general "sum of sibling capacities ≤ host
+total" check, not even for GPU count before pools-6. That invariant has
+always been enforced only at data-entry time, by
+`resource_capacity_validator.py`, on the storefront's local inventory
+table — not by the site ledger. Pass 1 does not introduce a *new* hole
+here: vcpu/ram/disk get exactly the level of protection GPU count
+already had (checked against the specific resource row admission
+targets, not cross-checked against sibling rows sharing a host). But
+**ledger-level enforcement that sibling slices sharing a physical host
+don't jointly oversubscribe it (on any dimension, not just exclusive
+mode) remains an open gap**, unchanged by this change and not claimed to
+be closed by it. Recorded here as a known limitation and candidate for a
+future change, not silently resolved by this paragraph's earlier
+inaccurate framing.
 
 ### Ledger and scheduler changes backing this
 

--- a/openspec/changes/pools-6-multidimensional-fair-scheduling/design.md
+++ b/openspec/changes/pools-6-multidimensional-fair-scheduling/design.md
@@ -111,6 +111,18 @@ inaccurate framing.
   (not deferred to pass 2), matching the observability goal below.
 - `PhysicalSettlementScheduler._requirement`/`_eligible_candidates` build
   and evaluate `dimensions` the same way.
+- **Decimal precision (resolved, code review 2026-07-20):** JSON storage
+  serializes non-integral `Decimal` amounts as Python `float`
+  (`_serialize_dimensions`), which loses exact precision for values like
+  0.1. Pass 1's actual VM dimensions are always integral in practice, so
+  this is documented as a known limitation rather than fixed now. A real
+  fix (canonical decimal strings, parsed back through `Decimal` on read)
+  is not confined to that one function: `PhysicalSettlementScheduler`
+  does raw arithmetic directly on ledger payloads in the same process (no
+  JSON boundary to hide behind), so a string-valued `available` map would
+  need the scheduler updated too, plus every test asserting numeric
+  literals against these payloads. Revisit if a real fractional dimension
+  is ever needed.
 
 ### VM domain wiring — deliberately scoped down for pass 1
 

--- a/openspec/changes/pools-6-multidimensional-fair-scheduling/design.md
+++ b/openspec/changes/pools-6-multidimensional-fair-scheduling/design.md
@@ -24,10 +24,12 @@ A future policy must score actual concrete candidates or explicitly model a sche
 The sketch below is now the actual implementation shape, not a future
 possibility. `SettlementCandidate.available` and
 `SettlementRequirement.dimensions` (`compute_provisioning/physical_settlement.py`)
-are `dict[str, Decimal]` maps, e.g. `{"gpu_count": 1, "vcpu": 4,
-"memory_mb": 16384, "disk_gb": 200}` — a generic map was chosen over fixed
+are `dict[str, Decimal]` maps, e.g. `{"gpu_count": 1, "vcpu_count": 4,
+"ram_gb": 16, "disk_gb": 200}` — a generic map was chosen over fixed
 named fields to stay multi-domain-ready without a fixed vocabulary baked
-into the type.
+into the type. Key names follow the vocabulary `ComputeResource` and
+`resource_capacity_validator.py` already used, rather than introducing a
+second one (e.g. `memory_mb`) for the same quantities.
 
 ```python
 class SettlementCandidate(BaseModel):
@@ -89,20 +91,27 @@ does not generalize to it.
 
 ### VM domain wiring — deliberately scoped down for pass 1
 
-`ComputeResource` (`domains/vms/listings/models.py`) had no vCPU/RAM/disk
-field at all before pass 1, and no code path negotiated one — VM shape was
-effectively unspecified below the listing's `gpu_model`/`gpu_count`. Pass 1
-adds `vcpu_count`/`ram_gb`/`disk_gb` to `ComputeResource` as a **fixed,
-seller-declared listing attribute**, the same way `gpu_model` already
-works — every order against a listing gets the same shape. This is enough
-to prove the multidimensional admission path end-to-end for the VM domain
-without opening the negotiation-protocol question of buyer-selectable VM
-sizing, which is real future work (long-term direction, per the change
-owner) but needs its own design review and stakeholder team sign-off
-before it's picked up. `capacity_client.py` and `vm_job_spec_service.py`
-wire this fixed shape through registration and claim-building
-respectively; nothing here should be read as precedent for skipping that
-future review when negotiated sizing is eventually designed.
+`ComputeResource` (`domains/vms/listings/models.py`) already has
+`vcpu_count`/`ram_gb`/`disk_gb` fields — a per-slice, seller-declared
+shape, populated the same way `gpu_model`/`gpu_count` are. (Correcting the
+proposal's original "concrete gap" framing, which said `ComputeResource`
+had no such fields at all — that was wrong; the actual gap was narrower.)
+What was missing was purely in claim-building:
+`compute_capacity_claim_from_order` (`vm_job_spec_service.py`) only ever
+forwarded `pool_id`/`resource_id`/`region`/`gpu_model`/`gpu_count` into the
+reservation claim, so the already-existing shape fields never reached
+admission. Pass 1 adds a `dimensions` map (`gpu_count`, and
+`vcpu_count`/`ram_gb`/`disk_gb` when the listing declares them) to that
+claim, and `capacity_client.py`'s `sync_site_resources` forwards the same
+vocabulary from the storefront's local inventory into
+`SiteResource.capacity`. No schema change to `ComputeResource` was needed.
+VM shape is still a **fixed, seller-declared listing attribute** for pass
+1, not a per-order negotiated dimension — every order against a listing
+gets the same shape, and buyer-selectable VM sizing remains real future
+work (long-term direction, per the change owner) that needs its own
+design review and stakeholder team sign-off before it's picked up.
+Nothing here should be read as precedent for skipping that future review
+when negotiated sizing is eventually designed.
 
 ## Projected dominant utilization
 

--- a/openspec/changes/pools-6-multidimensional-fair-scheduling/proposal.md
+++ b/openspec/changes/pools-6-multidimensional-fair-scheduling/proposal.md
@@ -102,15 +102,24 @@ only tracks pass-2 questions.
 ## Pass 1 design resolution (2026-07-20)
 
 - **Dimension representation:** a generic `dict[str, Decimal]` map (e.g.
-  `{"gpu_count": 1, "vcpu": 4, "memory_mb": 16384, "disk_gb": 200}`) on
+  `{"gpu_count": 1, "vcpu_count": 4, "ram_gb": 16, "disk_gb": 200}`) on
   requirements, candidates, `SiteResource.capacity`, and
   `SiteAllocation.dimensions` — not fixed named fields. Multi-domain-ready,
   matches `design.md`'s original candidate-model sketch.
-- **Resource-bundle semantics:** for the VM domain, a `SiteResource` row
-  already corresponds 1:1 to one physical host (existing `vm_host`
-  attribute). No new cross-row bundling machinery is needed for pass 1;
-  bundling is deferred to whenever a domain needs dimensions spread across
-  rows.
+- **Resource-bundle semantics:** each requested dimension is checked
+  against the *one* `SiteResource` row admission targets, not aggregated
+  across rows sharing a physical host. No new cross-row bundling
+  machinery is needed for pass 1; bundling is deferred to whenever a
+  domain needs dimensions spread across rows. **Correction (code review,
+  2026-07-20):** this bullet previously (and wrongly) claimed a
+  `SiteResource` row is 1:1 with one physical host — this codebase
+  already registers multiple rows against one host (VM-slice + bare-metal
+  sharing a `physical_host_id`, pre-dating this change). See `design.md`'s
+  "Ledger and scheduler changes backing this" section for the corrected
+  account, including the resulting known limitation: ledger-level
+  enforcement that sibling slices on one host don't jointly oversubscribe
+  it (beyond the existing exclusive/shareable mode conflict check) remains
+  an open gap, unchanged by this pass.
 - **Fit-check correctness:** full per-dimension held/available accounting,
   extending `CapacityLedgerService`'s existing lease-window held-units
   machinery, not a declared-capacity-only gate. The storefront's

--- a/openspec/changes/pools-6-multidimensional-fair-scheduling/proposal.md
+++ b/openspec/changes/pools-6-multidimensional-fair-scheduling/proposal.md
@@ -32,6 +32,7 @@ A richer scheduler must still preserve the durable properties established by POO
 - Moving provider-specific health, credentials, or execution checks into generic policy code.
 - Treating abstract aggregate capacity as proof that one concrete resource can fit a request.
 - Changing Capacity Settlement Assignment or physical-settlement caller contracts solely to accommodate one algorithm.
+- Making VM shape (vcpu/ram/disk) a buyer-negotiated, per-order dimension. Pass 1 treats it as a fixed, seller-declared listing attribute; negotiated sizing is deferred future work requiring its own design review of the negotiation-protocol boundary.
 
 ## Concrete, currently-unenforced gap (found during POOLS-7 design review, 2026-07-17)
 
@@ -65,9 +66,75 @@ just establishes that at minimum, VM memory/disk/vCPU must become
 first-class, admission-time-checked dimensions before `pools-7`'s
 reservation-admission path can be considered correct.
 
+## Two-pass implementation split (decided in design review, 2026-07-20)
+
+This change is split into two passes so the concrete admission-correctness
+gap doesn't wait on the much larger fairness-policy question:
+
+- **Pass 1** — give the capacity model a real multidimensional
+  representation and make reservation admission check it, so a reservation
+  can never be admitted for a shape no physical host could serve. Selection
+  among fitting candidates stays deterministic round-robin (POOLS-2)
+  unchanged. This closes the "Concrete, currently-unenforced gap" section
+  above and is what `pools-7` is blocked on.
+- **Pass 2** — pick and implement an actual fairness/placement policy
+  (lowest projected dominant utilization, consumer-aware DRF, or another
+  candidate direction below) as a second `SettlementSchedulingPolicy`,
+  proving the protocol's generality.
+
+Pass 1's design questions are resolved below. Pass 2's are not — see
+`design.md` and the "Non-Work / Deferred Decisions" section, which now
+only tracks pass-2 questions.
+
+## Pass 1 design resolution (2026-07-20)
+
+- **Dimension representation:** a generic `dict[str, Decimal]` map (e.g.
+  `{"gpu_count": 1, "vcpu": 4, "memory_mb": 16384, "disk_gb": 200}`) on
+  requirements, candidates, `SiteResource.capacity`, and
+  `SiteAllocation.dimensions` — not fixed named fields. Multi-domain-ready,
+  matches `design.md`'s original candidate-model sketch.
+- **Resource-bundle semantics:** for the VM domain, a `SiteResource` row
+  already corresponds 1:1 to one physical host (existing `vm_host`
+  attribute). No new cross-row bundling machinery is needed for pass 1;
+  bundling is deferred to whenever a domain needs dimensions spread across
+  rows.
+- **Fit-check correctness:** full per-dimension held/available accounting,
+  extending `CapacityLedgerService`'s existing lease-window held-units
+  machinery, not a declared-capacity-only gate. The storefront's
+  pre-reservation checks remain projections that can be invalidated at
+  actual reserve time — only the site-authority ledger's own accounting
+  needs to be exact under concurrency.
+- **`total_units` handling:** stays as a service-maintained mirror of
+  `capacity["gpu_count"]` rather than a full cutover of every existing
+  reader — the same documented intermediate-state-limitation pattern
+  POOLS-2 used for its process-local assignment cursors.
+- **`CapacityEvent` payload:** extended with per-dimension deltas in pass 1,
+  not deferred.
+- **VM shape scope:** vcpu/ram/disk become a **fixed, seller-declared
+  listing attribute** (like `gpu_model` already is) for pass 1, not a
+  per-order negotiated dimension — `ComputeResource` currently has no
+  vCPU/RAM/disk field at all, and no code path negotiates one. Making VM
+  shape buyer-negotiable is real, larger future work that touches the
+  negotiation-protocol boundary; it needs its own design review with
+  stakeholder sign-off before it's picked up. Do not let pass 1 or pass 2
+  quietly grow to cover it.
+- **`resource_capacity_validator.py`:** left as-is. It validates operator
+  CSV input against the storefront's local `resources` table, a different
+  concern from the admission-time fit gate, and that local table is
+  already slated for retirement by `pools-8`'s `CapacityProjection`.
+  Dimension vocabulary (`vcpu_count`/`ram_gb`/`disk_gb`) is converged so
+  the validator can be deleted outright when `pools-8` lands, instead of
+  migrated now — recorded as a dependency in `pools-8`'s proposal.
+- **Package boundary:** pass 1 stays inside current package boundaries
+  (`compute_provisioning`, `kit/site`). Moving
+  `PhysicalSettlementScheduler`/`DeterministicRoundRobinPolicy` and the
+  shared `resource_satisfies_requirement` predicate into a new
+  `kit/physical-settlement` package is `pools-7`'s decision and its scope
+  to execute, not pools-6's to preempt.
+
 ## Status of the requirement delta
 
-The `## ADDED Requirements` in this change's `specs/physical-provisioning/spec.md` use the standard openspec delta header — openspec's delta model has no separate "proposed but not yet decided" state, every change is a proposal until archived. That header does **not** mean this is implementation-ready: the "Non-Work / Deferred Decisions" list below and the open questions in `design.md` must be resolved in a dedicated design session before any of these requirements are implemented or this change is archived. Treat this change directory as a placeholder for problem framing, not a ready-to-build spec.
+The `## ADDED Requirements` in this change's `specs/physical-provisioning/spec.md` use the standard openspec delta header — openspec's delta model has no separate "proposed but not yet decided" state, every change is a proposal until archived. Pass 1's design is now resolved (above) and ready to implement; pass 2's is not. The "Non-Work / Deferred Decisions" list below and the open questions in `design.md` cover only pass 2 and must be resolved in a follow-up design session before pass-2 requirements are implemented or this change is archived.
 
 ## Candidate directions
 
@@ -92,13 +159,14 @@ No candidate is selected by this change.
 - External scheduler dependencies may bring worker, queue, or cluster-runtime assumptions larger than the policy boundary.
 - Explainability is required so operators can understand why a resource won or why no candidate fit.
 
-## Non-Work / Deferred Decisions
+## Non-Work / Deferred Decisions (pass 2)
 
-This change records questions for a future design session; it does not answer them now.
+Pass 1's dimension-representation and admission-correctness questions are
+resolved above. These remaining questions are pass 2's — a future design
+session must answer them before a fairness/placement policy is implemented.
 
-- What is the fairness subject: buyer, agreement, organization, queue, workload class, or another principal?
+- What is the fairness subject: buyer, agreement, organization, queue, workload class, or another principal? (Buyer/agreement was the leading candidate raised in the 2026-07-20 review — it matches the Market Agreement identity already in the system — but it was not confirmed; pin this at the start of pass 2.)
 - What is the fairness scope: provisioning domain, market, provider, compatible pool group, or global installation?
-- Which dimensions are first-class, what units do they use, and how are quantities normalized?
 - Are pools equal participants or weighted by total usable capacity?
 - Is the primary objective spreading, dominant-share fairness, utilization, bin packing, cost, or an ordered combination?
 - How are indivisible resources such as bare-metal nodes represented?

--- a/openspec/changes/pools-6-multidimensional-fair-scheduling/proposal.md
+++ b/openspec/changes/pools-6-multidimensional-fair-scheduling/proposal.md
@@ -66,6 +66,19 @@ just establishes that at minimum, VM memory/disk/vCPU must become
 first-class, admission-time-checked dimensions before `pools-7`'s
 reservation-admission path can be considered correct.
 
+**Correction (implementation, 2026-07-20):** the framing above is
+accurate for `Host` (the provisioning service's own inventory table,
+used for Ansible dispatch) but overstates the gap on the listing side.
+`ComputeResource` (`domains/vms/listings/models.py`) already has
+`vcpu_count`/`ram_gb`/`disk_gb` fields — a per-slice, seller-declared
+shape, populated the same way `gpu_model`/`gpu_count` are. The actual gap
+was narrower: `compute_capacity_claim_from_order`
+(`vm_job_spec_service.py`) never forwarded those already-existing fields
+past claim-building, so nothing downstream ever saw them. No schema
+change to `ComputeResource` was needed; the fix was in claim-building and
+the ledger's admission check. See `design.md`'s "Pass 1 design resolution"
+section for the corrected account.
+
 ## Two-pass implementation split (decided in design review, 2026-07-20)
 
 This change is split into two passes so the concrete admission-correctness
@@ -110,11 +123,13 @@ only tracks pass-2 questions.
   POOLS-2 used for its process-local assignment cursors.
 - **`CapacityEvent` payload:** extended with per-dimension deltas in pass 1,
   not deferred.
-- **VM shape scope:** vcpu/ram/disk become a **fixed, seller-declared
+- **VM shape scope:** vcpu/ram/disk are a **fixed, seller-declared
   listing attribute** (like `gpu_model` already is) for pass 1, not a
-  per-order negotiated dimension — `ComputeResource` currently has no
-  vCPU/RAM/disk field at all, and no code path negotiates one. Making VM
-  shape buyer-negotiable is real, larger future work that touches the
+  per-order negotiated dimension. `ComputeResource` already has
+  `vcpu_count`/`ram_gb`/`disk_gb` fields (correcting the "concrete gap"
+  framing above, which understated what already existed) — the gap was
+  that claim-building never forwarded them. Making VM shape
+  buyer-negotiable is real, larger future work that touches the
   negotiation-protocol boundary; it needs its own design review with
   stakeholder sign-off before it's picked up. Do not let pass 1 or pass 2
   quietly grow to cover it.

--- a/openspec/changes/pools-6-multidimensional-fair-scheduling/tasks.md
+++ b/openspec/changes/pools-6-multidimensional-fair-scheduling/tasks.md
@@ -51,26 +51,36 @@ Design resolution (2026-07-20, resolved):
 
 Implementation:
 
-- [ ] Add `dimensions`/`available` maps to `SettlementRequirement`/
+- [x] Add `dimensions`/`available` maps to `SettlementRequirement`/
       `SettlementCandidate` in `compute_provisioning/physical_settlement.py`.
-- [ ] Add `SiteResource.capacity` and `SiteAllocation.dimensions` columns
+- [x] Add `SiteResource.capacity` and `SiteAllocation.dimensions` columns
       (`kit/site/src/market_site/db.py`) plus additive migrations in
-      `domains/vms/provisioning/service/src/db/migrations.py`.
-- [ ] Generalize `CapacityLedgerService` held/available accounting,
+      `domains/vms/provisioning/service/src/db/migrations.py` (also added
+      `CapacityEvent.dimensions` for the per-dimension delta feed).
+- [x] Generalize `CapacityLedgerService` held/available accounting,
       matching, `register_resource`, `probe`/`reserve`, and payload
       builders to be dimension-aware; keep legacy single-quantity claims
       (`units`/`gpu_count`) working unchanged via internal translation.
-- [ ] Update `PhysicalSettlementScheduler._requirement`/
+- [x] Update `PhysicalSettlementScheduler._requirement`/
       `_eligible_candidates` to build/evaluate `dimensions`.
-- [ ] Add fixed `vcpu_count`/`ram_gb`/`disk_gb` fields to `ComputeResource`
-      (`domains/vms/listings/models.py`).
-- [ ] Wire `capacity_client.py`'s `register_resource` call to populate
-      `capacity` from the already-present host CSV columns.
-- [ ] Wire `vm_job_spec_service.py`'s claim building to include
-      `dimensions` from the listing's fixed shape.
-- [ ] Update/add tests: `kit/site` ledger, scheduler, capacity_client,
-      vm_job_spec_service, listings model.
-- [ ] Promote the shipped pass-1 behavior from this change's spec delta
+- [x] ~~Add fixed `vcpu_count`/`ram_gb`/`disk_gb` fields to
+      `ComputeResource`~~ — not needed; those fields already existed
+      (see `design.md`'s "VM domain wiring" correction). The actual gap
+      was `compute_capacity_claim_from_order` never forwarding them.
+- [x] Wire `vm_job_spec_service.py`'s claim building to include a
+      `dimensions` map (`gpu_count`, `vcpu_count`, `ram_gb`, `disk_gb`)
+      from the listing's fixed shape, alongside the existing exact-match
+      attributes.
+- [x] Wire `capacity_client.py`'s `register_resource` call to populate
+      `capacity` from the storefront's local row attributes (same
+      vocabulary as `resource_capacity_validator.py`). Plumbed `capacity`
+      through the HTTP boundary (`http_models.py`, `router.py`,
+      `RemoteCapacityClient`).
+- [x] Update/add tests: `kit/site` ledger (10 new + 30 existing passing),
+      scheduler (3 new + 9 existing passing), `capacity_client`/
+      `sync_site_resources` (1 new, existing passing),
+      `vm_job_spec_service` claim-building (2 new, existing passing).
+- [x] Promote the shipped pass-1 behavior from this change's spec delta
       into baseline `site-capacity`/`physical-provisioning` specs; record
       the deferred negotiated-VM-sizing question and the pools-8
       validator-deletion dependency in the relevant proposals.

--- a/openspec/changes/pools-6-multidimensional-fair-scheduling/tasks.md
+++ b/openspec/changes/pools-6-multidimensional-fair-scheduling/tasks.md
@@ -14,9 +14,16 @@ Design resolution (2026-07-20, resolved):
       candidates, `SiteResource.capacity`, and `SiteAllocation.dimensions`
       (not fixed named fields) — multi-domain-ready, matches this file's
       original candidate-model sketch.
-- [x] Resource-bundle semantics: a `SiteResource` row already corresponds
-      1:1 to one physical host for the VM domain (existing `vm_host`
-      attribute) — no new cross-row bundling machinery needed for pass 1.
+- [x] Resource-bundle semantics: each requested dimension is checked
+      against the *one* `SiteResource` row admission targets, not
+      aggregated across rows sharing a physical host — no new cross-row
+      bundling machinery needed for pass 1. (Corrected 2026-07-20: this
+      bullet originally claimed a row is 1:1 with a physical host, which
+      is wrong — this codebase already registers multiple rows against
+      one host. See `design.md`'s "Ledger and scheduler changes backing
+      this" section for the accurate account and the resulting known
+      limitation: ledger-level cross-slice host-total enforcement remains
+      an open gap, unchanged by this pass.)
 - [x] Admission-time fit-check correctness: full per-dimension held/available
       accounting, extending `CapacityLedgerService`'s existing lease-window
       held-units machinery rather than a declared-capacity-only gate.

--- a/openspec/changes/pools-6-multidimensional-fair-scheduling/tasks.md
+++ b/openspec/changes/pools-6-multidimensional-fair-scheduling/tasks.md
@@ -1,25 +1,112 @@
 # POOLS-6 tasks
 
-## Design resolution
+This change is split into two implementation passes, decided in design
+review (2026-07-20). Pass 1 resolves only the questions blocking pools-7's
+admission-time correctness gap and keeps deterministic round-robin as the
+selection policy. Pass 2 picks and implements an actual fairness/placement
+policy. See `design.md` for the full resolution record.
 
-- [ ] Confirm domain boundaries and whether VM and pod compute share a provisioning domain.
-- [ ] Choose the fairness subject and fairness scope.
-- [ ] Define multidimensional units, normalization, and concrete resource-bundle semantics.
-- [ ] Choose pool weighting and the precedence of fit, fairness, utilization, spreading, cost, and topology.
-- [ ] Specify indivisible resources, quotas, priorities, preemption, and starvation behavior.
-- [ ] Specify historical accounting, persistence, decay, restart recovery, and exact-resource accounting.
+## Pass 1 — Multidimensional capacity model (unblocks POOLS-7)
+
+Design resolution (2026-07-20, resolved):
+
+- [x] Dimension representation: generic `dict[str, Decimal]` on requirements,
+      candidates, `SiteResource.capacity`, and `SiteAllocation.dimensions`
+      (not fixed named fields) — multi-domain-ready, matches this file's
+      original candidate-model sketch.
+- [x] Resource-bundle semantics: a `SiteResource` row already corresponds
+      1:1 to one physical host for the VM domain (existing `vm_host`
+      attribute) — no new cross-row bundling machinery needed for pass 1.
+- [x] Admission-time fit-check correctness: full per-dimension held/available
+      accounting, extending `CapacityLedgerService`'s existing lease-window
+      held-units machinery rather than a declared-capacity-only gate.
+      Storefront-side pre-checks remain projections that can be invalidated
+      at actual reserve time — only the site-authority ledger's accounting
+      needs to be exact.
+- [x] `SiteResource.total_units` becomes a service-maintained mirror of
+      `capacity["gpu_count"]`, not a full cutover — same documented
+      intermediate-state-limitation pattern POOLS-2 used for its
+      process-local assignment cursors.
+- [x] `CapacityEvent` payload is extended with per-dimension deltas now,
+      not deferred to pass 2.
+- [x] VM shape (vcpu/ram/disk) is a **fixed, seller-declared listing
+      attribute** for pass 1, not a per-order negotiated dimension.
+      Buyer-negotiated VM sizing is real future work but out of scope here
+      — it touches the negotiation-protocol boundary and needs a separate
+      design discussion before it's picked up (owner's team review
+      pending). Do not quietly widen pass 1 to cover it.
+- [x] `resource_capacity_validator.py` stays as-is for pass 1. It is a
+      storefront-local data-integrity check on operator CSV input, a
+      different concern from the admission-time fit gate, and it sits on
+      the storefront's local `resources` table that `pools-8`'s
+      `CapacityProjection` is already slated to retire. Converge dimension
+      vocabulary (`vcpu_count`/`ram_gb`/`disk_gb`) so it can be deleted
+      outright when `pools-8` lands, instead of migrated now.
+- [x] Package boundary: pass 1 changes stay inside current package
+      boundaries (`compute_provisioning`, `kit/site`). The planned move of
+      `PhysicalSettlementScheduler`/`DeterministicRoundRobinPolicy` (and the
+      shared `resource_satisfies_requirement` predicate) into a new
+      `kit/physical-settlement` package is pools-7's decision to make and
+      execute, not pools-6's to preempt.
+
+Implementation:
+
+- [ ] Add `dimensions`/`available` maps to `SettlementRequirement`/
+      `SettlementCandidate` in `compute_provisioning/physical_settlement.py`.
+- [ ] Add `SiteResource.capacity` and `SiteAllocation.dimensions` columns
+      (`kit/site/src/market_site/db.py`) plus additive migrations in
+      `domains/vms/provisioning/service/src/db/migrations.py`.
+- [ ] Generalize `CapacityLedgerService` held/available accounting,
+      matching, `register_resource`, `probe`/`reserve`, and payload
+      builders to be dimension-aware; keep legacy single-quantity claims
+      (`units`/`gpu_count`) working unchanged via internal translation.
+- [ ] Update `PhysicalSettlementScheduler._requirement`/
+      `_eligible_candidates` to build/evaluate `dimensions`.
+- [ ] Add fixed `vcpu_count`/`ram_gb`/`disk_gb` fields to `ComputeResource`
+      (`domains/vms/listings/models.py`).
+- [ ] Wire `capacity_client.py`'s `register_resource` call to populate
+      `capacity` from the already-present host CSV columns.
+- [ ] Wire `vm_job_spec_service.py`'s claim building to include
+      `dimensions` from the listing's fixed shape.
+- [ ] Update/add tests: `kit/site` ledger, scheduler, capacity_client,
+      vm_job_spec_service, listings model.
+- [ ] Promote the shipped pass-1 behavior from this change's spec delta
+      into baseline `site-capacity`/`physical-provisioning` specs; record
+      the deferred negotiated-VM-sizing question and the pools-8
+      validator-deletion dependency in the relevant proposals.
+
+## Pass 2 — Fairness / placement policy (not started)
+
+Design resolution — still open:
+
+- [ ] Confirm domain boundaries and whether VM and pod compute share a
+      provisioning domain.
+- [ ] Choose the fairness subject and fairness scope (raised in review
+      2026-07-20: buyer/agreement was the leading candidate but not
+      confirmed — pin this at the start of pass 2).
+- [ ] Choose pool weighting and the precedence of fit, fairness,
+      utilization, spreading, cost, and topology.
+- [ ] Specify indivisible resources, quotas, priorities, preemption, and
+      starvation behavior.
+- [ ] Specify historical accounting, persistence, decay, restart recovery,
+      and exact-resource accounting.
 - [ ] Specify provider-failure and explicit reassignment behavior.
 
-## Evaluation
+Evaluation:
 
-- [ ] Evaluate maintained external scheduler libraries against the policy protocol and operational constraints.
-- [ ] Compare lowest projected dominant utilization, capacity-weighted pool fairness, and consumer-aware DRF through simulations.
+- [ ] Evaluate maintained external scheduler libraries against the policy
+      protocol and operational constraints.
+- [ ] Compare lowest projected dominant utilization, capacity-weighted pool
+      fairness, and consumer-aware DRF through simulations.
 - [ ] Define policy explanation, metrics, and debugging surfaces.
 
-## Implementation after design approval
+Implementation after design approval:
 
-- [ ] Add multidimensional requirement and candidate contracts.
-- [ ] Implement a second policy beside round-robin to prove interface generality.
-- [ ] Persist fairness state transactionally with capacity claims and assignments.
-- [ ] Add simulation, concurrency, restart, starvation, and adversarial-shape tests.
-- [ ] Promote approved requirements into baseline OpenSpec and update architecture pointers only after behavior becomes current state.
+- [ ] Implement a second policy beside round-robin to prove interface
+      generality.
+- [ ] Persist fairness state transactionally with capacity claims and
+      assignments.
+- [ ] Add simulation, concurrency, restart, starvation, and
+      adversarial-shape tests.
+- [ ] Promote approved requirements into baseline OpenSpec and update
+      architecture pointers only after behavior becomes current state.

--- a/openspec/changes/pools-8-capacity-projection-and-listing-hints/proposal.md
+++ b/openspec/changes/pools-8-capacity-projection-and-listing-hints/proposal.md
@@ -83,6 +83,19 @@ storefront to reliably send *valid* claims in the first place.
   lands (see "Why" above).
 - Depends on `kit/resource-pools`' `GET /api/v1/pools` admin API
   (already exists) for the pull source.
+- **`resource_capacity_validator.py` deletion (from `pools-6` pass 1,
+  design review 2026-07-20):** this module validates operator CSV
+  imports against the storefront's local `resources` table — the same
+  table this change retires in favor of `CapacityProjection`. It was
+  deliberately left as-is during `pools-6` pass 1 rather than migrated,
+  specifically so it could be deleted outright once this change removes
+  the table it operates on, instead of needing its own migration path.
+  Dimension vocabulary (`vcpu_count`/`ram_gb`/`disk_gb`) was converged
+  between it and the site ledger's admission-time capacity check in pass
+  1 for exactly this reason. When planning this change, confirm the
+  local `resources` table has no remaining readers before deleting
+  `resource_capacity_validator.py` and its call site in
+  `SQLiteClient.upsert_resource`.
 
 ## Impact
 

--- a/openspec/specs/physical-provisioning/spec.md
+++ b/openspec/specs/physical-provisioning/spec.md
@@ -87,6 +87,7 @@ Shared storefront/provisioner DTOs, executor-neutral resource-pool models, and g
 ## Evidence
 
 - VM and bare-metal allocation executor metadata: `domains/vms/provisioning/service/tests/integration/test_leases_api.py` and `test_bare_metal_leases_api.py`.
+- Multidimensional scheduling eligibility (fit rejected on a secondary dimension even when GPU count would fit, legacy gpu-only requests unaffected): `domains/vms/provisioning/service/src/tests/unit/services/test_physical_settlement_scheduler.py` (POOLS-6 pass 1 tests).
 - Persisted asynchronous job lifecycle and polling: `domains/vms/provisioning/service/tests/integration/test_vms_api.py`.
 - Executor-specific release, failed-release capacity retention, retry, and force release: `domains/vms/provisioning/service/tests/integration/test_bare_metal_leases_api.py`, `test_leases_api.py`, and `unit/services/test_ledger_lease_lifecycle.py`.
 
@@ -96,4 +97,4 @@ Shared storefront/provisioner DTOs, executor-neutral resource-pool models, and g
 
 Physical provisioning distinguishes **Capacity Reservation → Capacity Settlement Assignment → Physical Settlement → Provisioned Resource / Active Workload**. Generic scheduling chooses an eligible Settlement Resource. Physical Settlement is provider-specific execution on that assigned resource. Provider-specific reachability, credentials, topology, and execution failures remain downstream of generic scheduling eligibility.
 
-The current scheduling policy is deterministic round-robin through a replaceable policy interface. Generic policy and orchestration code use resource kind, units, pool identity, and opaque attributes and do not import market-specific executor persistence models.
+The current scheduling policy is deterministic round-robin through a replaceable policy interface. Generic policy and orchestration code use resource kind, a per-dimension quantity map (`dimensions`/`available`, checked against every dimension a candidate declares — POOLS-6 pass 1), pool identity, and opaque attributes and do not import market-specific executor persistence models.

--- a/openspec/specs/site-capacity/spec.md
+++ b/openspec/specs/site-capacity/spec.md
@@ -42,7 +42,7 @@ Shareable VM slices and exclusive bare-metal allocations referring to the same p
 - **THEN** the site ledger rejects the exclusive reservation
 
 ### Requirement: Multidimensional capacity accounting
-A site resource MAY declare total capacity across more than one named quantity dimension (for example `gpu_count`, `vcpu_count`, `ram_gb`, `disk_gb`); a claim's requested quantities MUST be checked and held against every declared dimension, not only a single default quantity, with held/available accounting kept exact under concurrent holds. A dimension a resource does not declare MUST NOT be assumed to have room.
+A site resource MAY declare total capacity across more than one named quantity dimension (for example `gpu_count`, `vcpu_count`, `ram_gb`, `disk_gb`); a claim's requested quantities MUST be checked and held against every declared dimension, not only a single default quantity, with held/available accounting kept exact under concurrent holds. A dimension a resource does not declare MUST NOT be assumed to have room. This accounting is per resource row: it does not aggregate or cross-check declared or held capacity across multiple resource rows that happen to share a physical host (see "Cross-mode physical accounting" above for the one cross-row check that does exist, which is scoped to exclusive/shareable mode conflicts, not capacity sums).
 
 #### Scenario: A reservation would exceed a secondary dimension
 - **WHEN** a claim requests more of a declared dimension (for example memory) than the resource has available, even though another dimension (for example GPU count) would fit

--- a/openspec/specs/site-capacity/spec.md
+++ b/openspec/specs/site-capacity/spec.md
@@ -41,6 +41,21 @@ Shareable VM slices and exclusive bare-metal allocations referring to the same p
 - **WHEN** an exclusive bare-metal reservation targets the same physical host
 - **THEN** the site ledger rejects the exclusive reservation
 
+### Requirement: Multidimensional capacity accounting
+A site resource MAY declare total capacity across more than one named quantity dimension (for example `gpu_count`, `vcpu_count`, `ram_gb`, `disk_gb`); a claim's requested quantities MUST be checked and held against every declared dimension, not only a single default quantity, with held/available accounting kept exact under concurrent holds. A dimension a resource does not declare MUST NOT be assumed to have room.
+
+#### Scenario: A reservation would exceed a secondary dimension
+- **WHEN** a claim requests more of a declared dimension (for example memory) than the resource has available, even though another dimension (for example GPU count) would fit
+- **THEN** the reservation is rejected rather than admitted for a shape the resource cannot serve
+
+#### Scenario: Concurrent holds accumulate per dimension
+- **WHEN** two separate holds are placed on one shareable resource
+- **THEN** each declared dimension's available quantity reflects the sum of both holds, not just the dimension the first hold happened to request
+
+#### Scenario: Legacy single-quantity claims are unaffected
+- **WHEN** a claim requests a quantity using the legacy `units`/`gpu_count` key instead of a dimensions map
+- **THEN** it is checked and held exactly as it was before multidimensional capacity existed, translated internally to the primary dimension
+
 ### Requirement: Executor-neutral site authority
 The site authority MUST own Physical Resources, settlement-relevant Resource Pool identities, Capacity Reservations, committed allocations, deal ownership references, capacity versions, and capacity events without depending on lease watchdogs, job runners, or concrete executor teardown states. A provisioner MAY stage administrative pool membership and provider configuration, but those records MUST NOT alter settlement selection until integrated through the site-authority boundary.
 
@@ -73,6 +88,7 @@ Capacity projection events MUST remain anonymous and versioned, while deal-scope
 ## Evidence
 
 - Reserve/commit/release, hold TTL, versioned anonymous events, and cross-mode conflicts: `kit/site/tests/unit/test_ledger.py`.
+- Multidimensional capacity (declared-dimension fit, concurrent per-dimension holds, legacy-claim compatibility, per-dimension event deltas): `kit/site/tests/unit/test_ledger.py` (POOLS-6 pass 1 tests).
 - Site-tagged soft-state aggregation and failure isolation: `core/storefront/tests/unit/test_aggregation.py`.
 - Storefront-to-site HTTP contract: `domains/vms/storefront/tests/unit/test_remote_capacity_client.py`.
 - “Do not close on ignorance” reconciliation: `domains/vms/storefront/tests/unit/test_cli_publish_helpers.py`.

--- a/provisioning/compute/src/compute_provisioning/physical_settlement.py
+++ b/provisioning/compute/src/compute_provisioning/physical_settlement.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from decimal import Decimal
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class PhysicalSettlementError(Exception):
@@ -44,20 +45,37 @@ class PhysicalSettlementRequest(BaseModel):
 
 
 class SettlementRequirement(BaseModel):
-    """Generic capacity shape used to evaluate concrete candidates."""
+    """Generic capacity shape used to evaluate concrete candidates.
+
+    ``dimensions`` At least one positive dimension is required.
+    """
 
     resource_kind: str
-    units: int = Field(gt=0)
+    dimensions: dict[str, Decimal] = Field(default_factory=dict)
     attributes: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("dimensions")
+    @classmethod
+    def _dimensions_positive_and_nonempty(cls, value: dict[str, Decimal]) -> dict[str, Decimal]:
+        if not value:
+            raise ValueError("dimensions must declare at least one quantity")
+        for key, amount in value.items():
+            if amount <= 0:
+                raise ValueError(f"dimensions[{key}] must be > 0, got {amount}")
+        return value
 
 
 class SettlementCandidate(BaseModel):
-    """One concrete resource eligible for physical settlement evaluation."""
+    """One concrete resource eligible for physical settlement evaluation.
+
+    ``available`` A dimension a candidate never mentions is treated
+    as unavailable (zero), matching the ledger's hard fit rule.
+    """
 
     resource_id: str
     pool_id: str
     resource_kind: str
-    available_units: int
+    available: dict[str, Decimal] = Field(default_factory=dict)
     enabled: bool = True
     provider: str
     attributes: dict[str, Any] = Field(default_factory=dict)

--- a/provisioning/compute/src/compute_provisioning/physical_settlement.py
+++ b/provisioning/compute/src/compute_provisioning/physical_settlement.py
@@ -60,6 +60,10 @@ class SettlementRequirement(BaseModel):
         if not value:
             raise ValueError("dimensions must declare at least one quantity")
         for key, amount in value.items():
+            # NaN/Infinity parse cleanly through pydantic's Decimal
+            # coercion but raise InvalidOperation on comparison.
+            if not amount.is_finite():
+                raise ValueError(f"dimensions[{key}] must be a finite number, got {amount}")
             if amount <= 0:
                 raise ValueError(f"dimensions[{key}] must be > 0, got {amount}")
         return value


### PR DESCRIPTION
## POOLS-6 pass 1: multidimensional capacity accounting

### Summary

Reservation admission today only ever checks GPU count. Nothing verifies that a negotiated shape's memory, disk, or vCPU actually fits any physical host before a Capacity Reservation is admitted — the mismatch only surfaces later, as an unexplained fulfillment failure. This is the concrete gap `pools-7` is blocked on.

This PR closes it: the site-authority ledger, the physical-settlement scheduler, and the VM domain's claim-building now speak a generic multidimensional capacity vocabulary (`gpu_count`, `vcpu_count`, `ram_gb`, `disk_gb`, extensible to other domains) instead of a single GPU unit count. Selection among fitting candidates is unchanged — still deterministic round-robin (`pools-2`). Picking a fairness/placement policy is pass 2, tracked separately in `pools-6`'s `tasks.md`.

Full design rationale, resolved decisions, and known limitations are recorded in `openspec/changes/pools-6-multidimensional-fair-scheduling/{proposal.md,design.md,tasks.md}`.

### What changed

**Site-authority ledger** (`kit/site`)
- `SiteResource.capacity` / `SiteAllocation.dimensions` / `CapacityEvent.dimensions`: new JSON columns holding a `dict[str, Decimal]` per-dimension map. `total_units` / `units` remain service-maintained mirrors of `capacity["gpu_count"]` / `dimensions["gpu_count"]` for payload and caller compatibility — not a breaking cutover.
- `CapacityLedgerService` held/available accounting is now per-dimension, extending the existing lease-window held-units machinery rather than adding a declared-capacity-only check. Legacy single-quantity claims (`units`/`gpu_count`) keep working unchanged, translated internally.
- `register_resource`/`probe`/`reserve` accept an optional `dimensions` map; `capacity` is plumbed through the HTTP boundary (`http_models.py`, `router.py`, `RemoteCapacityClient`).
- `CapacityEvent.kind` gains a `capacity_changed` value for registrations where dimensions move in different directions (e.g. GPU count grows while RAM shrinks) — a single grew/shrank boolean can't represent that. Storefront listing reconciliation (`capacity_client.py`) runs both close and reopen passes for it.
- Additive migration for the three new columns (`domains/vms/provisioning/service/src/db/migrations.py`), following the existing pattern.

**Scheduler** (`compute_provisioning`, provisioning service)
- `SettlementRequirement.dimensions` / `SettlementCandidate.available` replace `units` / `available_units`.
- `PhysicalSettlementScheduler` builds and evaluates dimension maps; `DeterministicRoundRobinPolicy` needed no changes (confirmed dimension-agnostic — it only sorts `pool_id`/`resource_id` strings).

**VM domain wiring**
- `compute_capacity_claim_from_order` now forwards `vcpu_count`/`ram_gb`/`disk_gb` (fields that already existed on `ComputeResource`, just never reached the claim) into a `dimensions` map, alongside the existing exact-match attributes.
- `capacity_client.py`'s `sync_site_resources` forwards the same vocabulary into `SiteResource.capacity`, sourced from data already present in the storefront's local inventory.
- VM shape is a **fixed, seller-declared listing attribute** for this pass, not a per-order negotiated dimension — buyer-selectable VM sizing is real future work that touches the negotiation-protocol boundary and needs its own design review.

**Docs**
- `pools-6`'s `proposal.md`/`design.md`/`tasks.md` updated with the resolved pass-1 design and a corrected account of resource-to-host cardinality (see "Known limitations" below).
- Baseline `site-capacity` and `physical-provisioning` specs promoted with the shipped multidimensional-accounting behavior.
- `pools-8`'s proposal records a dependency: `resource_capacity_validator.py` is left as-is for this pass (different concern, different table) but is expected to be deleted outright, not migrated, once `pools-8` retires the storefront's local inventory table it operates on.

### Known limitations (documented, not regressions)

- **Cross-slice host oversubscription is not ledger-enforced.** A `SiteResource` row's capacity is checked in isolation, not aggregated against sibling rows sharing a physical host. This is pre-existing behavior (GPU count never had cross-row enforcement either, before this PR) — vcpu/ram/disk now get the same level of protection GPU count already had, no more, no less. Ledger-level enforcement here remains an open gap for a future change.
- **Decimal dimension values serialize to JSON as `float`,** which loses exact precision for non-integral amounts. Pass 1's actual dimensions are always integral in practice, so this is scoped out rather than fixed — the scheduler does raw arithmetic on ledger payloads in-process, so a string-serialized fix isn't confined to one function. Documented in `_serialize_dimensions`.
- **Negotiated VM sizing is out of scope.** VM shape is fixed per listing; buyer-selectable sizing needs a separate design review of the negotiation-protocol boundary before it's picked up.

### Follow-ups tracked elsewhere

- Pass 2 (fairness/placement policy selection) — `pools-6`'s `tasks.md`.
- Storefront cutover to the real scheduler/fulfillment path — `pools-7`.
- Retiring the storefront's local resource inventory table and `resource_capacity_validator.py` — `pools-8`.