### PR TITLE
Make the release path reach the producer release this source actually binds

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -129,7 +129,7 @@ jobs:
             {"key": "vms-buyer",              "path": "domains/vms/buyer",                "dist": "arkhai-vms-buyer", "wheel_only": true},
             {"key": "vms-provisioning-adapter", "path": "domains/vms/provisioning/adapter", "dist": "arkhai-vms-provisioning-adapter"},
             {"key": "compute-provisioning-service", "path": "provisioning/compute/service", "dist": "arkhai-compute-provisioning-service"},
-            {"key": "vms-storefront",         "path": "domains/vms/storefront",           "dist": "arkhai-vms-storefront"},
+            {"key": "vms-storefront",         "path": "domains/vms/storefront",           "dist": "arkhai-vms-storefront", "wheel_only": true},
             {"key": "apicredits-domain",       "path": "domains/apicredits",               "dist": "arkhai-apicredits-domain"},
             {"key": "apicredits-buyer",        "path": "domains/apicredits/buyer",          "dist": "arkhai-apicredits-buyer", "wheel_only": true},
             {"key": "apicredits-middleware",   "path": "domains/apicredits/middleware/python", "dist": "arkhai-apicredits-middleware"},

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -74,7 +74,7 @@ jobs:
             kit-policy: ['kit/policy/**', '.github/workflows/publish-pypi.yml']
             kit-settlement-runtime: ['kit/settlement-runtime/**', '.github/workflows/publish-pypi.yml']
             kit-negotiation-runtime: ['kit/negotiation-runtime/**', '.github/workflows/publish-pypi.yml']
-            kit-hosted-settlement: ['kit/hosted-settlement/**', 'manifests/hosted-settlement-v0.2.1-trust.json', '.github/workflows/publish-pypi.yml']
+            kit-hosted-settlement: ['kit/hosted-settlement/**', 'manifests/**', '.github/workflows/publish-pypi.yml']
             core: ['core/src/**', 'core/pyproject.toml', 'core/README.md', '.github/workflows/publish-pypi.yml']
             core-buyer: ['core/buyer/**', '.github/workflows/publish-pypi.yml']
             core-storefront: ['core/storefront/**', '.github/workflows/publish-pypi.yml']
@@ -184,28 +184,39 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
             echo "::notice::publishing ${DIST} ${version}"
           fi
-      - name: Download exact hosted release assets
+      # Read the trust configuration for the version this source pins, not one
+      # named here. Naming the file was already half-derived -- the repository,
+      # the tag and the artifact names came out of the JSON -- so the filename
+      # was the only stale part, and it was enough: it pointed at v0.2.1 after
+      # the pin moved to v0.4.2, and the download failed with `release not
+      # found` because no such producer release exists.
+      - name: Select the hosted release this source binds
+        id: hosted
         if: steps.check.outputs.skip == 'false' && matrix.dist == 'arkhai-kit-hosted-settlement'
+        run: python scripts/select-hosted-client-channel.py >>"$GITHUB_OUTPUT"
+      - name: Download exact hosted release assets
+        if: steps.hosted.outputs.channel == 'release'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
           mkdir -p .dist
-          repository="$(python -c 'import json; print(json.load(open("manifests/hosted-settlement-v0.2.1-trust.json"))["repository"])')"
-          version="$(python -c 'import json; print(json.load(open("manifests/hosted-settlement-v0.2.1-trust.json"))["release_version"])')"
-          manifest="$(python -c 'import json; print(json.load(open("manifests/hosted-settlement-v0.2.1-trust.json"))["manifest_filename"])')"
-          wheel="$(python -c 'import json; print(json.load(open("manifests/hosted-settlement-v0.2.1-trust.json"))["client_wheel"]["filename"])')"
-          test -n "$repository"
-          gh release download "v$version" --repo "$repository" --dir .dist \
-            --pattern "$manifest" \
-            --pattern "$wheel" \
-            --pattern "openapi-v0.2.1.json" \
-            --pattern "conformance-v0.2.1.json" \
-            --pattern "migrations-v5.json" \
+          gh release download "v${{ steps.hosted.outputs.version }}" \
+            --repo "${{ steps.hosted.outputs.repository }}" --dir .dist \
+            --pattern "${{ steps.hosted.outputs.manifest }}" \
+            --pattern "${{ steps.hosted.outputs.wheel }}" \
+            --pattern "openapi-v${{ steps.hosted.outputs.version }}.json" \
+            --pattern "conformance-v${{ steps.hosted.outputs.version }}.json" \
+            --pattern "migrations-v${{ steps.hosted.outputs.schema_version }}.json" \
             --pattern "sbom.spdx.json" \
             --pattern "provenance.intoto.json"
+      # An unsigned pin has nothing signed to verify. `make verify-hosted-release`
+      # says exactly that and succeeds, so the wheel this job publishes is built
+      # against a client it cannot vouch for -- which is the internal channel
+      # working as designed, not something to hide behind a passing step.
       - name: Verify staged hosted client release
         if: steps.check.outputs.skip == 'false' && matrix.dist == 'arkhai-kit-hosted-settlement'
-        run: make verify-hosted-release
+        run: make verify-hosted-release HOSTED_RELEASE_TRUST="${{ steps.hosted.outputs.trust }}"
       - name: Build distribution
         if: steps.check.outputs.skip == 'false'
         working-directory: ${{ matrix.path }}

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -187,19 +187,29 @@ jobs:
       # Read the trust configuration for the version this source pins, not one
       # named here. Naming the file was already half-derived -- the repository,
       # the tag and the artifact names came out of the JSON -- so the filename
-      # was the only stale part, and it was enough: it pointed at v0.2.1 after
-      # the pin moved to v0.4.2, and the download failed with `release not
-      # found` because no such producer release exists.
+      # was the only stale part, and it was enough: it kept pointing at v0.2.1
+      # after the pin moved to v0.4.2, which would have staged one release's
+      # assets for a wheel built against another and failed in the verifier.
       - name: Select the hosted release this source binds
         id: hosted
         if: steps.check.outputs.skip == 'false' && matrix.dist == 'arkhai-kit-hosted-settlement'
         run: python scripts/select-hosted-client-channel.py >>"$GITHUB_OUTPUT"
+      # The producer repository is private and this one is public, so the
+      # workspace token cannot see it: GitHub answers a private release with
+      # `release not found`, which reads as a missing tag and is really a
+      # missing permission. `release.yml` has always used the producer token
+      # for exactly this; this job was reaching for the release with the one
+      # token that cannot reach it.
       - name: Download exact hosted release assets
         if: steps.hosted.outputs.channel == 'release'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.HOSTED_RELEASE_TOKEN }}
         run: |
           set -euo pipefail
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::error::HOSTED_RELEASE_TOKEN is unset; the private producer release cannot be read"
+            exit 1
+          fi
           mkdir -p .dist
           gh release download "v${{ steps.hosted.outputs.version }}" \
             --repo "${{ steps.hosted.outputs.repository }}" --dir .dist \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,6 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     env:
-      HOSTED_RELEASE_TAG: v0.2.1
-      HOSTED_RELEASE_REPOSITORY: arkhai-io/stripe-settlement-service
       IMAGE_REPOSITORY: ghcr.io/arkhai-io/simple-compute-market
       RELEASE_DIR: marketplace-release
     steps:
@@ -33,6 +31,25 @@ jobs:
           python-version: 3.13.7
           enable-cache: true
 
+      # Which producer release this tag binds is already stated, by the pin
+      # and by the trust configuration signing it. Naming a tag here made a
+      # third statement, and it was the one that went stale: it still said
+      # v0.2.1 after the source moved to v0.4.2, so a release cut from this
+      # workflow would have fetched a producer the source does not consume --
+      # or, as it did, no producer at all.
+      - name: Select the hosted release this source binds
+        id: hosted
+        run: python scripts/select-hosted-client-channel.py >>"$GITHUB_OUTPUT"
+
+      # An unsigned pin is a supported state for a test run, which compiles
+      # against the wheel and cites it for nothing. It is not a state a
+      # release can be cut from: there would be no signature to carry.
+      - name: Refuse to release against an unsigned hosted pin
+        if: steps.hosted.outputs.channel != 'release'
+        run: |
+          echo "::error::hosted client ${{ steps.hosted.outputs.version }} is pinned but unsigned; sign that release before tagging a marketplace release"
+          exit 1
+
       - name: Download exact hosted producer release
         env:
           GH_TOKEN: ${{ secrets.HOSTED_RELEASE_TOKEN }}
@@ -40,8 +57,8 @@ jobs:
           set -euo pipefail
           test -n "$GH_TOKEN"
           mkdir -p .hosted-release
-          gh release download "$HOSTED_RELEASE_TAG" \
-            --repo "$HOSTED_RELEASE_REPOSITORY" \
+          gh release download "v${{ steps.hosted.outputs.version }}" \
+            --repo "${{ steps.hosted.outputs.repository }}" \
             --dir .hosted-release
 
       - name: Verify and build exact marketplace wheel set

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,11 +86,21 @@ jobs:
         id: hosted
         if: matrix.requires_hosted
         run: python scripts/select-hosted-client-channel.py >>"$GITHUB_OUTPUT"
+      # Same private producer, same reason as in publish-pypi.yml: the
+      # workspace token answers a private release with `release not found`.
+      # This repository is public, so a pull request from a fork is handed no
+      # secret at all -- say which of the two happened rather than letting `gh`
+      # report a missing tag for both.
       - name: Download exact hosted release assets
         if: matrix.requires_hosted && steps.hosted.outputs.channel == 'release'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.HOSTED_RELEASE_TOKEN }}
         run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::error::HOSTED_RELEASE_TOKEN is unset (forked pull requests receive no secrets); the private producer release cannot be read"
+            exit 1
+          fi
           mkdir -p .dist
           gh release download "v${{ steps.hosted.outputs.version }}" \
             --repo "${{ steps.hosted.outputs.repository }}" --dir .dist \

--- a/scripts/tests/test_hosted_client_channel.py
+++ b/scripts/tests/test_hosted_client_channel.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -167,3 +168,42 @@ def test_an_unreachable_index_reports_the_version_and_the_channel() -> None:
     assert "::error::hosted client" in WORKFLOW
     assert "AR_WORKLOAD_IDENTITY_PROVIDER" in WORKFLOW
     assert "or release that version" in WORKFLOW
+
+
+#: Names a producer release asset carries, spelled with the version in them.
+#: Each is derivable from the pin, so a literal one in a workflow is a second
+#: statement of which release is bound -- and the one that goes stale, because
+#: nothing reads it back.
+_STALE_HOSTED_LITERALS = (
+    re.compile(r"hosted-settlement-v\d+\.\d+\.\d+-trust\.json"),
+    re.compile(r"(?:openapi|conformance)-v\d+\.\d+\.\d+\.json"),
+    re.compile(r"migrations-v\d+\.json"),
+    re.compile(r"HOSTED_RELEASE_TAG"),
+)
+
+
+@pytest.mark.parametrize(
+    "workflow",
+    sorted((REPO_ROOT / ".github" / "workflows").glob("*.yml")),
+    ids=lambda path: path.name,
+)
+def test_no_workflow_names_a_hosted_release_of_its_own(workflow: Path) -> None:
+    """Every workflow asks the selector which release is bound, or asks nobody.
+
+    Three workflows consume the producer and only one derived the version.
+    `release.yml` carried `HOSTED_RELEASE_TAG: v0.2.1` and `publish-pypi.yml`
+    opened `hosted-settlement-v0.2.1-trust.json` by name; both survived the
+    move to v0.4.2 unchanged, and both then reached for a release that does
+    not exist. The failure was a publish job reporting `release not found`,
+    which names neither the version it wanted nor where it got it.
+    """
+
+    text = workflow.read_text(encoding="utf-8")
+    found = sorted(
+        {match.group(0) for pattern in _STALE_HOSTED_LITERALS for match in pattern.finditer(text)}
+    )
+
+    assert not found, (
+        f"{workflow.name} names {found}; derive it from "
+        "scripts/select-hosted-client-channel.py instead"
+    )

--- a/scripts/tests/test_publish_matrix.py
+++ b/scripts/tests/test_publish_matrix.py
@@ -1,0 +1,70 @@
+"""What the publish workflow builds follows from what each package declares."""
+
+from __future__ import annotations
+
+import json
+import re
+import tomllib
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "publish-pypi.yml"
+
+
+def _packages() -> list[dict[str, object]]:
+    """The PACKAGES table the workflow heredocs into `packages.json`."""
+
+    text = WORKFLOW.read_text(encoding="utf-8")
+    body = re.search(r"cat > packages\.json <<'JSON'\n(.*?)\n\s*JSON\n", text, re.S)
+    assert body, "publish-pypi.yml no longer states its package table as a heredoc"
+    return json.loads(re.sub(r"^ {10}", "", body.group(1), flags=re.M))
+
+
+def _escaping_force_includes(package: Path) -> list[str]:
+    """Wheel contents this package pulls from outside its own directory.
+
+    A `../` source is the thing an sdist tarball cannot carry: the tarball is
+    rooted at the package, so `uv build`'s default sdist->wheel rebuild finds
+    nothing at that path and fails.
+    """
+
+    declared = tomllib.loads((package / "pyproject.toml").read_text(encoding="utf-8"))
+    forced = (
+        declared.get("tool", {})
+        .get("hatch", {})
+        .get("build", {})
+        .get("targets", {})
+        .get("wheel", {})
+        .get("force-include", {})
+    )
+    return sorted(source for source in forced if source.startswith("../"))
+
+
+@pytest.mark.parametrize("package", _packages(), ids=lambda entry: str(entry["key"]))
+def test_a_package_reaching_outside_itself_publishes_a_wheel_only(
+    package: dict[str, object],
+) -> None:
+    """The two facts have to agree, and only one of them was maintained.
+
+    The workflow's own comment says why the buyer plugins are wheel-only, and
+    names them as if that set were closed. `vms-storefront` acquired the same
+    `../` force-includes and nothing noticed, so every publish of it since has
+    died inside `hatchling.build.build_wheel` with `Forced include not found`
+    pointing at a path in uv's sdist cache -- a message that names neither the
+    package nor the reason.
+    """
+
+    directory = REPO_ROOT / str(package["path"])
+    if not (directory / "pyproject.toml").is_file():
+        pytest.skip(f"{package['path']} is not checked out here")
+
+    escaping = _escaping_force_includes(directory)
+    if not escaping:
+        return
+
+    assert package.get("wheel_only") is True, (
+        f"{package['dist']} force-includes {escaping} from outside {package['path']}, "
+        "which an sdist cannot carry; publish it as a wheel only"
+    )


### PR DESCRIPTION
Merging #164 fired `publish-pypi` on `main` for the first time since the hosted client moved to `v0.4.2`. It failed, and the failure was three separate bugs wearing one error message. `release.yml` — the workflow that cuts a marketplace release, and the next thing that needs to run — carried the first of them and has not been exercised since 2026-08-16.

## Three bugs

**1. Two workflows named the producer version themselves.** `scripts/select-hosted-client-channel.py` exists to own the relationship between the version `kit/hosted-settlement/pyproject.toml` pins and the trust configuration signing it; its docstring says no third place should state it. There were two more. `release.yml` carried `HOSTED_RELEASE_TAG: v0.2.1` and `publish-pypi.yml` opened `hosted-settlement-v0.2.1-trust.json` by name, along with `openapi-v0.2.1.json`, `conformance-v0.2.1.json` and `migrations-v5.json`. The pinned release is `v0.4.2` at schema 7, so every one of those names is wrong — `migrations-v5.json` would not even exist in the release being fetched. Both workflows now ask the selector, and `release.yml` refuses outright to cut a release against an unsigned pin rather than carrying a signature it does not have.

**2. `release not found` was a permission, not a missing tag.** `v0.2.1` does exist in the producer repository. That repository is private and this one is public, so `github.token` cannot see it, and GitHub answers a private release with a 404 rather than a denial. `publish-pypi.yml` and `tests.yml` were both reaching for the release with the one credential that cannot reach any. `release.yml` has always used `secrets.HOSTED_RELEASE_TOKEN`; the other two now do too, and a forked pull request — handed no secret at all in a public repository — now says that instead of also saying `not found`.

**3. `vms-storefront` has never been publishable.** It force-includes 27 sibling modules through `../` paths. An sdist is rooted at the package, so those paths are not in the tarball and `uv build`'s default sdist→wheel rebuild dies in `hatchling.build.build_wheel` with `Forced include not found` pointing at a path inside uv's sdist cache. The workflow already explains this for the buyer plugins and marks them `wheel_only`, naming that set as if it were closed. `vms-storefront` joined it and nothing noticed.

## Guards

Each bug is the same shape: a fact stated twice, where only one copy is ever read back. Two tests now derive the second copy instead of trusting it.

- `test_no_workflow_names_a_hosted_release_of_its_own` reads every file in `.github/workflows/` for a hosted trust filename, a versioned producer artifact name, or `HOSTED_RELEASE_TAG`.
- `test_a_package_reaching_outside_itself_publishes_a_wheel_only` parses the workflow's own package table and each package's `pyproject.toml`, and requires the two to agree on which packages escape their directory.

Both were confirmed to fail against the unfixed tree before the fixes were applied.

## Verified locally

- `make test-release-tooling` — 155 passed (was 118 before this branch's tests).
- `make verify-hosted-release` — passes with the trust file derived from the pin, resolving `v0.4.2` / `migrations-v7.json`.
- `uv build --wheel --no-sources` in `domains/vms/storefront` — builds `arkhai_vms_storefront-0.3.5-py3-none-any.whl`, the build that failed on `main`.
- Both modified workflows parse as YAML.

## Not fixed here

Nine distributions failed the run with `invalid-publisher`: `arkhai-kit-settlement-runtime`, `arkhai-kit-negotiation-runtime`, `arkhai-kit-site-client`, `arkhai-vms`, `arkhai-bare-metal`, `arkhai-bare-metal-storefront`, `arkhai-apicredits-domain`, `arkhai-apicredits-buyer`, `arkhai-apicredits-storefront`. None of them exists on PyPI, and a trusted publisher has to be created there before a workflow change can help. That is account configuration, not repository code.

`tests.yml` still triggers only on `staging` and `dev`, so no CI runs on this pull request either.