### PR TITLE
Give a publish build the empty wheel directory it reads

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -227,6 +227,18 @@ jobs:
       - name: Verify staged hosted client release
         if: steps.check.outputs.skip == 'false' && matrix.dist == 'arkhai-kit-hosted-settlement'
         run: make verify-hosted-release HOSTED_RELEASE_TRUST="${{ steps.hosted.outputs.trust }}"
+      # Four published packages point `tool.uv.find-links` at the repository's
+      # .dist so a local build resolves sibling arkhai-* wheels from there.
+      # uv reads that directory even under --no-sources, and a fresh checkout
+      # has no .dist at all, so the build died before it started -- reported as
+      # a bare `No such file or directory (os error 2)` naming a path nobody
+      # asked for. Empty is the right state here rather than merely a tolerable
+      # one: a published wheel must record plain PyPI dependencies, so there is
+      # nothing a publish build should be resolving locally. The hosted client
+      # job fills the same directory on purpose, and only it should.
+      - name: Ensure the local wheel directory exists but is empty
+        if: steps.check.outputs.skip == 'false' && matrix.dist != 'arkhai-kit-hosted-settlement'
+        run: mkdir -p .dist
       - name: Build distribution
         if: steps.check.outputs.skip == 'false'
         working-directory: ${{ matrix.path }}

--- a/scripts/tests/test_publish_matrix.py
+++ b/scripts/tests/test_publish_matrix.py
@@ -68,3 +68,50 @@ def test_a_package_reaching_outside_itself_publishes_a_wheel_only(
         f"{package['dist']} force-includes {escaping} from outside {package['path']}, "
         "which an sdist cannot carry; publish it as a wheel only"
     )
+
+
+def _find_links(package: Path) -> list[str]:
+    declared = tomllib.loads((package / "pyproject.toml").read_text(encoding="utf-8"))
+    return list(declared.get("tool", {}).get("uv", {}).get("find-links", []))
+
+
+@pytest.mark.parametrize("package", _packages(), ids=lambda entry: str(entry["key"]))
+def test_a_published_package_looks_for_local_wheels_only_in_dist(
+    package: dict[str, object],
+) -> None:
+    """The one local directory a publish build may consult is the one CI makes.
+
+    uv reads `find-links` even under `--no-sources`, so a directory named here
+    has to exist by the time the workflow builds -- and on a fresh checkout the
+    only one that does is the `.dist` the workflow creates. Four packages named
+    it and nothing created it, so their builds failed with an `os error 2`
+    naming a path that appears in no build command. A publish only ever
+    resolves from PyPI, so pointing anywhere else is the mistake, not the
+    missing directory.
+    """
+
+    directory = REPO_ROOT / str(package["path"])
+    if not (directory / "pyproject.toml").is_file():
+        pytest.skip(f"{package['path']} is not checked out here")
+
+    for entry in _find_links(directory):
+        resolved = (directory / entry).resolve()
+        assert resolved == (REPO_ROOT / ".dist").resolve(), (
+            f"{package['dist']} resolves find-links {entry!r} to {resolved}, which no "
+            "publish job creates; a publish build resolves from PyPI"
+        )
+
+
+def test_the_publish_job_creates_the_directory_those_packages_look_in() -> None:
+    """The other half of the pair above, which is otherwise only true by luck.
+
+    Requiring every `find-links` to point at `.dist` means nothing unless the
+    workflow actually makes `.dist`. It did not, which is the whole bug: the
+    hosted client job created it as a side effect of staging release assets,
+    so that one package built and the four that merely declared it did not.
+    """
+
+    text = WORKFLOW.read_text(encoding="utf-8")
+    creates = text.index("mkdir -p .dist\n      - name: Build distribution")
+
+    assert creates < text.index("run: |\n          if [ \"${{ matrix.wheel_only }}\" = \"true\" ]")


### PR DESCRIPTION
Dispatching `publish-pypi` after #165 got much further: all nine distributions that previously failed with `invalid-publisher` now publish, and `vms-storefront` builds. Seven packages still fail, for two reasons — and only one of them is repository code.

## The bug this fixes

`kit/site`, `provisioning/compute/service`, `domains/apicredits/service` and `domains/vms/provisioning/adapter` never reached a compiler:

```
× Failed to build `/home/runner/work/simple-compute-market/simple-compute-market/kit/site`
├─▶ Failed to read `--find-links` directory: .../.dist
╰─▶ No such file or directory (os error 2)
```

Each declares `tool.uv.find-links = ["../../.dist"]` so a local build resolves sibling `arkhai-*` wheels from the repository's wheel directory. uv reads that directory **even under `--no-sources`**, and a fresh CI checkout has no `.dist`. The error names a path that appears in none of the commands the job runs, which is why it reads as a broken package rather than a missing directory.

Only the hosted-client job ever created `.dist`, as a side effect of staging release assets — so the one package that needs it *populated* worked, and the four that merely declare it did not.

**Why a push never showed this:** the path filters had not selected any of the four since those entries were added. A `workflow_dispatch` considers every package, so this is the first run that ever tried to build them.

Empty is the correct state rather than a tolerable one: a published wheel records plain PyPI dependencies, so a publish build has nothing to resolve locally. The hosted-client job is excluded from the new step because it fills the same directory deliberately.

## Verified

Reproduced on a clean `git archive` export of `main`, which is what CI actually gets:

| package | no `.dist` | empty `.dist` |
|---|---|---|
| `kit/site` | fails | builds |
| `provisioning/compute/service` | fails | builds |
| `domains/apicredits/service` | fails | builds |
| `domains/vms/provisioning/adapter` | fails | builds |

Two tests hold the halves together, since either alone is true only by luck — every published package resolves `find-links` to that one directory, and the workflow creates it before it builds. Both were confirmed to fail against mutations of the thing they assert. `make test-release-tooling` is 184 passed.

## Not fixed here

Seven distributions still need a PyPI trusted publisher, and none exists on PyPI yet:

`arkhai-kit-hosted-settlement`, `arkhai-kit-site`, `arkhai-bare-metal-provisioning-adapter`, `arkhai-vms-provisioning-adapter`, `arkhai-compute-provisioning-service`, `arkhai-apicredits-middleware`, `arkhai-apicredits-service`

Four of them are the packages above, whose build failure was hiding the same publisher gap. That is account configuration, not repository code.

Separately, `kit-hosted-settlement` confirms #165 worked: it downloaded `v0.4.2` and passed `make verify-hosted-release` against the derived trust file, failing only at the publisher.