### PR TITLE
Tell a protected run which configuration this run generated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -331,6 +331,8 @@ hosted-stripe-test: hosted-preflight ## Run one protected Stripe test-mode syste
 		--account-ref "$(HOSTED_STRIPE_TEST_ACCOUNT_REF)" \
 		--authority-environment "$(HOSTED_STRIPE_TEST_AUTHORITY_ENVIRONMENT)" \
 		--hosted-service-env-base "$(HOSTED_STRIPE_TEST_AUTHORITY_ENV_FILE)" \
+		--storefront-config "$(HOSTED_STRIPE_TEST_STOREFRONT_CONFIG)" \
+		--buyer-config "$(HOSTED_STRIPE_TEST_BUYER_CONFIG)" \
 		$(if $(HOSTED_STRIPE_TEST_VISIBLE_BROWSER),--visible-browser,) \
 		$(if $(HOSTED_STRIPE_TEST_ATTENDED),--attended,) \
 		$(if $(HOSTED_STRIPE_TEST_LIFECYCLE_TIMEOUT),--lifecycle-timeout "$(HOSTED_STRIPE_TEST_LIFECYCLE_TIMEOUT)",) \

--- a/scripts/tests/test_hosted_run_targets.py
+++ b/scripts/tests/test_hosted_run_targets.py
@@ -1,0 +1,67 @@
+"""The protected run and the development run differ only where they must."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MAKEFILE = (REPO_ROOT / "Makefile").read_text(encoding="utf-8")
+
+#: The one flag a protected run is right to omit. `--release-mode local` is
+#: what makes a run development, and a protected run takes the default.
+DEVELOPMENT_ONLY = {"--release-mode"}
+
+
+def _driver_flags(target: str) -> set[str]:
+    """Flags a Makefile target hands the hosted-settlement driver."""
+
+    body = re.search(rf"^{re.escape(target)}:.*?(?=\n\n)", MAKEFILE, re.S | re.M)
+    assert body, f"{target} is no longer a Makefile target"
+    assert "src.hosted_real_stripe.driver" in body.group(0), (
+        f"{target} no longer invokes the driver"
+    )
+    return set(re.findall(r"^\s+(--[a-z-]+)", body.group(0), re.M))
+
+
+def test_a_protected_run_is_told_everything_a_development_run_is_told() -> None:
+    """Both invocations describe the same run; only the binding differs.
+
+    `hosted-stripe-test` omitted `--storefront-config` and `--buyer-config`,
+    so a protected run silently took argparse's default -- the checked-in
+    template -- while a development run got the configuration the credential
+    assembler had just generated. The template pins a fixed identity and the
+    assembler mints a fresh one per run, so the storefront's credential never
+    matched the identity the protected run read, and every protected lane died
+    at `account_readiness` with `authorization_rejected`.
+
+    A protected run keeps no diagnostics, so all it could report was that
+    something about authorization was wrong. Nothing said which file it read.
+    """
+
+    protected = _driver_flags("hosted-stripe-test")
+    development = _driver_flags("hosted-stripe-test-local")
+
+    missing = development - protected - DEVELOPMENT_ONLY
+
+    assert not missing, (
+        "hosted-stripe-test does not pass " + ", ".join(sorted(missing)) + "; a protected "
+        "run would fall back to the checked-in default while a development run uses the "
+        "value generated for the run"
+    )
+
+
+def test_the_generated_configuration_is_what_both_targets_name() -> None:
+    """Neither target may hardcode a path the assembler overrides."""
+
+    for target in ("hosted-stripe-test", "hosted-stripe-test-local"):
+        body = re.search(rf"^{re.escape(target)}:.*?(?=\n\n)", MAKEFILE, re.S | re.M)
+        assert body
+        for flag, variable in (
+            ("--storefront-config", "HOSTED_STRIPE_TEST_STOREFRONT_CONFIG"),
+            ("--buyer-config", "HOSTED_STRIPE_TEST_BUYER_CONFIG"),
+        ):
+            assert f'{flag} "$({variable})"' in body.group(0), (
+                f"{target} must pass {flag} as $({variable}), which the credential "
+                "assembler exports per run"
+            )


### PR DESCRIPTION
`marketplace-v0.2.28` released cleanly and the first protected `card.v1` lane failed at `account_readiness` with `authorization_rejected`, before the browser ever opened.

## The bug

`hosted-stripe-test` never passed `--storefront-config` or `--buyer-config`. `hosted-stripe-test-local` passes both. Everything else the two targets differ by is deliberate — the release pins belong only to the protected run, and `--release-mode local` belongs only to the development one.

So a protected run fell back to argparse's default, `e2e-tests/config/hosted-storefront.toml` — the checked-in template — while the credential assembler had just written a different file for this run. The template pins a fixed identity; the assembler mints a fresh one per run:

```
generated for the run:   ed25519:35mpo6iNnoeDJ7DRxtU1GjiJXwyESW5sYf8KfeBM_9s
checked-in template:     ed25519:0EqyMnQrtKs6E2i9RhXk5tAiSrcaAWuvhSCjMsl3hzc
```

`_maintained_account_binding` loads the credential for the first and compares it against the identity read from the second, so `signer.identity.identifier != identifier` and the run is refused. The credential a protected run holds has never matched the identity a protected run reads.

## Why this took a release to find

The development lanes pass, and have all along, because they were the only ones being handed the generated configuration. Nothing on the protected path had ever got as far as needing it — earlier attempts stopped at `payer_profile_unavailable` and then at the storefront caller allowlist. This is the first protected run to reach `account_readiness` at all.

A protected run keeps no diagnostics, by design, so all it could report was that something about authorization was wrong. Nothing said the two files were different files.

## The guard

Two targets describing the same run had drifted, and only one was exercised. `test_a_protected_run_is_told_everything_a_development_run_is_told` holds them to differing by `--release-mode` alone; `test_the_generated_configuration_is_what_both_targets_name` requires both to pass the flags as the variables the assembler exports, so neither can hardcode a path again. Both were confirmed to fail against the unfixed Makefile.

`make test-release-tooling` is 186 passed.

## This needs a new release

A protected run refuses when `observed_marketplace_commit != marketplace_commit`, so the lanes run from the released commit — which means the fix only takes effect once it is in a release. After merging, the qualification wizard cuts `marketplace-v0.2.29`, checks it out, and re-runs the lanes; `v0.2.28` cannot be re-used.