### PR TITLE
feat(registry): publish signed self-description

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ dist-registry-client: ## Build arkhai-core-registry-client wheel into .dist/
 	@ls $(DIST_DIR)/arkhai_core_registry_client-*-none-any.whl > /dev/null 2>&1 || \
 		(echo "ERROR: arkhai-core-registry-client produced a platform-specific wheel — must build inside Docker" && exit 1)
 
-dist-arkhai-core-registry: dist-registry-client ## Build arkhai-core-registry wheel into .dist/
+dist-arkhai-core-registry: dist-core dist-registry-client ## Build arkhai-core-registry wheel into .dist/
 	-mkdir -p $(DIST_DIR)
 	cd core/registry && uv build --wheel --out-dir $(DIST_DIR)
 	@ls $(DIST_DIR)/arkhai_core_registry-*-none-any.whl > /dev/null 2>&1 || \

--- a/compose.apicredits.yml
+++ b/compose.apicredits.yml
@@ -13,6 +13,9 @@ services:
       - REGISTRY_AUTHORITY_SCHEME=ed25519
       - REGISTRY_AUTHORITY_IDENTIFIER=skkdlQKuKGMKK6yy4MdFEP_N0yjDNP8-E5PnWy0x59w
       - REGISTRY_AUTHORITY_CREDENTIAL_FILE=/run/secrets/arkhai/registry-identity/credential
+      - REGISTRY_DESCRIPTOR_BASE_URL=http://localhost:8090
+      - REGISTRY_DESCRIPTOR_DISPLAY_NAME=Local API Credits Registry
+      - REGISTRY_DESCRIPTOR_OPERATOR_IDENTITY=Arkhai local development
     volumes:
       - ${APICREDITS_REGISTRY_IDENTITY_CREDENTIAL_FILE:?set API-credits registry signer credential file}:/run/secrets/arkhai/registry-identity/credential:ro
   credits-storefront:

--- a/compose.bare-metal.yml
+++ b/compose.bare-metal.yml
@@ -11,6 +11,9 @@ services:
       - REGISTRY_AUTHORITY_SCHEME=${BARE_METAL_REGISTRY_AUTHORITY_SCHEME:?set registry authority scheme}
       - REGISTRY_AUTHORITY_IDENTIFIER=${BARE_METAL_REGISTRY_AUTHORITY_IDENTIFIER:?set canonical registry principal}
       - REGISTRY_AUTHORITY_CREDENTIAL_FILE=/run/secrets/arkhai/registry-identity/credential
+      - REGISTRY_DESCRIPTOR_BASE_URL=${BARE_METAL_REGISTRY_PUBLIC_URL:?set externally reachable registry URL}
+      - REGISTRY_DESCRIPTOR_DISPLAY_NAME=${BARE_METAL_REGISTRY_DISPLAY_NAME:-Bare Metal Compute Registry}
+      - REGISTRY_DESCRIPTOR_OPERATOR_IDENTITY=${BARE_METAL_OPERATOR_IDENTITY:?set public operator identity}
     volumes:
       - ${BARE_METAL_REGISTRY_IDENTITY_CREDENTIAL_FILE:?set registry signer credential file}:/run/secrets/arkhai/registry-identity/credential:ro
 

--- a/compose.vms.yml
+++ b/compose.vms.yml
@@ -12,6 +12,9 @@ services:
       - REGISTRY_AUTHORITY_SCHEME=eip191
       - REGISTRY_AUTHORITY_IDENTIFIER=0x90f79bf6eb2c4f870365e785982e1f101e93b906
       - REGISTRY_AUTHORITY_CREDENTIAL_FILE=/run/secrets/arkhai/registry-identity/credential
+      - REGISTRY_DESCRIPTOR_BASE_URL=http://localhost:8080
+      - REGISTRY_DESCRIPTOR_DISPLAY_NAME=Local VM Compute Registry
+      - REGISTRY_DESCRIPTOR_OPERATOR_IDENTITY=Arkhai local development
     volumes:
       - ${VMS_REGISTRY_IDENTITY_CREDENTIAL_FILE:?set registry signer credential file}:/run/secrets/arkhai/registry-identity/credential:ro
   registry-b:
@@ -20,6 +23,10 @@ services:
       - REGISTRY_AUTHORITY_ID=registry-b
       - REGISTRY_AUTHORITY_IDENTIFIER=0x15d34aaf54267db7d7c367839aaf71a00a2c6a65
       - REGISTRY_AUTHORITY_CREDENTIAL_FILE=/run/secrets/arkhai/registry-identity/credential
+      - REGISTRY_DESCRIPTOR_BASE_URL=http://localhost:8082
+      - REGISTRY_DESCRIPTOR_DISPLAY_NAME=Local Private VM Compute Registry
+      - REGISTRY_DESCRIPTOR_OPERATOR_IDENTITY=Arkhai local development
+      - REGISTRY_DESCRIPTOR_ACCESS_ACQUISITION_POINTER=http://localhost:8082/docs#/admin/create_api_key
     volumes:
       - ${VMS_REGISTRY_B_IDENTITY_CREDENTIAL_FILE:?set private registry signer credential file}:/run/secrets/arkhai/registry-identity/credential:ro
   bob-storefront:

--- a/core/registry-client/src/registry_client/__init__.py
+++ b/core/registry-client/src/registry_client/__init__.py
@@ -9,6 +9,7 @@ Both accept a ``transport=`` kwarg for in-process test injection.
 """
 
 from registry_client.client import RegistryClient, SyncRegistryClient
+from market_core import RegistryDescriptor
 from registry_client.auth import (
     RegistryClientError,
     authenticate_request,
@@ -40,6 +41,7 @@ __all__ = [
     "RegistryClient",
     "SyncRegistryClient",
     "RegistryClientError",
+    "RegistryDescriptor",
     "authenticate_request",
     "authentication_headers",
     "FilterSpecResponse",

--- a/core/registry-client/src/registry_client/client.py
+++ b/core/registry-client/src/registry_client/client.py
@@ -9,12 +9,14 @@ from typing import Any, Optional, cast
 import httpx
 from market_identity import (
     EMPTY_BODY,
+    AuthenticatedRequest,
     Identity,
     RotationIntent,
     Signer,
     TrustedIdentitySet,
     sign_rotation,
 )
+from market_core import RegistryDescriptor
 
 from registry_client.auth import (
     REQUEST_ID_HEADER,
@@ -37,7 +39,6 @@ from registry_client.models import (
     ValidatePublishRequest,
     ValidatePublishResponse,
 )
-
 
 
 class _RegistryClientBase:
@@ -102,6 +103,8 @@ class _RegistryClientBase:
             return "listing.validate", "listings"
         if path == "/filter-spec":
             return "filter.get", "filter-spec"
+        if path == "/.well-known/arkhai/registry-descriptor.json":
+            return "registry.descriptor.read", "registry-descriptor"
         if parts[:1] == ["listings"]:
             if len(parts) == 1:
                 return (
@@ -140,9 +143,7 @@ class _RegistryClientBase:
         }
         if_match = httpx.Headers(headers or {}).get("If-Match")
         if if_match is not None:
-            body["if_match"] = (
-                if_match.strip().removeprefix("W/").strip().strip('"')
-            )
+            body["if_match"] = if_match.strip().removeprefix("W/").strip().strip('"')
         return body
 
     @staticmethod
@@ -171,6 +172,72 @@ class _RegistryClientBase:
             return None
         normalized = etag if etag.startswith('"') else f'"{etag}"'
         return {"If-Match": normalized}
+
+    @staticmethod
+    def _request_identity_headers(
+        request_id: str | None,
+        timestamp: int | None,
+    ) -> dict[str, str] | None:
+        headers: dict[str, str] = {}
+        if request_id is not None:
+            headers[REQUEST_ID_HEADER] = request_id
+        if timestamp is not None:
+            headers[TIMESTAMP_HEADER] = str(timestamp)
+        return headers or None
+
+    @classmethod
+    def _descriptor_bootstrap_request(
+        cls,
+        *,
+        signer: Signer,
+        caller_role: str,
+    ) -> AuthenticatedRequest:
+        if caller_role not in {"buyer", "seller", "service"}:
+            raise ValueError("caller_role must be buyer, seller, or service")
+        return authenticate_request(
+            signer=signer,
+            role=caller_role,
+            method="GET",
+            operation="registry.descriptor.read",
+            resource="registry-descriptor",
+            body=cls._query_body(None, None),
+        )
+
+    @staticmethod
+    def _verify_bootstrap_descriptor(
+        *,
+        response: httpx.Response,
+        request: AuthenticatedRequest,
+        url: str,
+    ) -> RegistryDescriptor:
+        if response.status_code != 200:
+            raise RegistryClientError("GET", url, response.status_code, response.text)
+        try:
+            descriptor = RegistryDescriptor.model_validate(response.json())
+        except ValueError as exc:
+            raise RegistryClientError(
+                "GET",
+                url,
+                502,
+                "registry descriptor is not canonical JSON",
+            ) from exc
+        expected_registries = TrustedIdentitySet(
+            identities=tuple(
+                Identity.model_validate(principal.model_dump(mode="json"))
+                for principal in descriptor.authority.principals
+            )
+        )
+        try:
+            verify_authenticated_response(
+                headers=response.headers,
+                expected_registries=expected_registries,
+                request=request,
+                status=response.status_code,
+                body=descriptor.to_wire(),
+            )
+        except ValueError as exc:
+            raise RegistryClientError("GET", url, 502, str(exc)) from exc
+        return descriptor
 
     def _publish_listing_request(
         self,
@@ -358,6 +425,39 @@ class RegistryClient(_RegistryClientBase):
     async def __aexit__(self, *_: Any) -> None:
         await self.close()
 
+    @classmethod
+    async def bootstrap_registry_descriptor(
+        cls,
+        base_url: str,
+        *,
+        signer: Signer,
+        caller_role: str,
+        timeout: float = 30.0,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> RegistryDescriptor:
+        """Read a descriptor and verify possession of its advertised key."""
+
+        path = "/.well-known/arkhai/registry-descriptor.json"
+        request = cls._descriptor_bootstrap_request(
+            signer=signer,
+            caller_role=caller_role,
+        )
+        async with httpx.AsyncClient(
+            base_url=base_url.rstrip("/"),
+            timeout=timeout,
+            transport=transport,
+            headers={"Accept": "application/json"},
+        ) as client:
+            response = await client.get(
+                path,
+                headers=authentication_headers(request),
+            )
+        return cls._verify_bootstrap_descriptor(
+            response=response,
+            request=request,
+            url=f"{base_url.rstrip('/')}{path}",
+        )
+
     async def _request(
         self,
         method: str,
@@ -421,9 +521,7 @@ class RegistryClient(_RegistryClientBase):
         return None if empty_response else response_body
 
     async def get_health(self) -> HealthResponse:
-        return self._parse_health(
-            await self._request("GET", "/api/v1/system/health")
-        )
+        return self._parse_health(await self._request("GET", "/api/v1/system/health"))
 
     async def get_system_stats(self) -> SystemStatsResponse:
         return self._parse_system_stats(
@@ -488,8 +586,20 @@ class RegistryClient(_RegistryClientBase):
         return ValidatePublishResponse.from_dict(data)
 
     async def get_filter_spec(self) -> FilterSpecResponse:
-        return FilterSpecResponse.from_dict(
-            await self._request("GET", "/filter-spec")
+        return FilterSpecResponse.from_dict(await self._request("GET", "/filter-spec"))
+
+    async def get_registry_descriptor(
+        self,
+        *,
+        request_id: str | None = None,
+        timestamp: int | None = None,
+    ) -> RegistryDescriptor:
+        return RegistryDescriptor.model_validate(
+            await self._request(
+                "GET",
+                "/.well-known/arkhai/registry-descriptor.json",
+                headers=self._request_identity_headers(request_id, timestamp),
+            )
         )
 
     async def list_listings(
@@ -691,6 +801,39 @@ class SyncRegistryClient(_RegistryClientBase):
     def __exit__(self, *_: Any) -> None:
         self.close()
 
+    @classmethod
+    def bootstrap_registry_descriptor(
+        cls,
+        base_url: str,
+        *,
+        signer: Signer,
+        caller_role: str,
+        timeout: float = 30.0,
+        transport: httpx.BaseTransport | None = None,
+    ) -> RegistryDescriptor:
+        """Read a descriptor and verify possession of its advertised key."""
+
+        path = "/.well-known/arkhai/registry-descriptor.json"
+        request = cls._descriptor_bootstrap_request(
+            signer=signer,
+            caller_role=caller_role,
+        )
+        with httpx.Client(
+            base_url=base_url.rstrip("/"),
+            timeout=timeout,
+            transport=transport,
+            headers={"Accept": "application/json"},
+        ) as client:
+            response = client.get(
+                path,
+                headers=authentication_headers(request),
+            )
+        return cls._verify_bootstrap_descriptor(
+            response=response,
+            request=request,
+            url=f"{base_url.rstrip('/')}{path}",
+        )
+
     def _request(
         self,
         method: str,
@@ -754,14 +897,10 @@ class SyncRegistryClient(_RegistryClientBase):
         return None if empty_response else response_body
 
     def get_health(self) -> HealthResponse:
-        return self._parse_health(
-            self._request("GET", "/api/v1/system/health")
-        )
+        return self._parse_health(self._request("GET", "/api/v1/system/health"))
 
     def get_system_stats(self) -> SystemStatsResponse:
-        return self._parse_system_stats(
-            self._request("GET", "/api/v1/system/stats")
-        )
+        return self._parse_system_stats(self._request("GET", "/api/v1/system/stats"))
 
     def list_publishers(
         self,
@@ -822,6 +961,20 @@ class SyncRegistryClient(_RegistryClientBase):
 
     def get_filter_spec(self) -> FilterSpecResponse:
         return FilterSpecResponse.from_dict(self._request("GET", "/filter-spec"))
+
+    def get_registry_descriptor(
+        self,
+        *,
+        request_id: str | None = None,
+        timestamp: int | None = None,
+    ) -> RegistryDescriptor:
+        return RegistryDescriptor.model_validate(
+            self._request(
+                "GET",
+                "/.well-known/arkhai/registry-descriptor.json",
+                headers=self._request_identity_headers(request_id, timestamp),
+            )
+        )
 
     def list_listings(
         self,

--- a/core/registry/Dockerfile
+++ b/core/registry/Dockerfile
@@ -32,6 +32,7 @@ RUN sed -E -i 's|registry = "[^"]*\.dist"|registry = "/.dist"|' uv.lock
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --no-sources --no-dev --no-install-project --find-links /.dist \
+        --refresh-package arkhai-core \
         --refresh-package arkhai-core-registry-client \
         --refresh-package arkhai-kit-identity
 

--- a/core/registry/README.md
+++ b/core/registry/README.md
@@ -18,6 +18,8 @@ Stable publisher rows and listings are owned through canonical
 - Optional API-key auth, gated independently for read and write
   (`REGISTRY_REQUIRE_READ_API_KEY`, `REGISTRY_REQUIRE_WRITE_API_KEY`);
   keys carry a read/write scope.
+- Authority-authenticated self-description at
+  `/.well-known/arkhai/registry-descriptor.json`.
 
 ## Quick start (local docker-compose)
 
@@ -52,6 +54,25 @@ routes require `Authorization: Bearer <key>` against an active row in
 `scope: read|write`; a single write-scoped bootstrap key can be seeded
 via `REGISTRY_BOOTSTRAP_API_KEY` on first start.
 
+## Registry descriptor
+
+Startup requires `REGISTRY_DESCRIPTOR_BASE_URL`,
+`REGISTRY_DESCRIPTOR_DISPLAY_NAME`, and
+`REGISTRY_DESCRIPTOR_OPERATOR_IDENTITY`. The service combines those public
+operator assertions with the active authority signer, filter-spec schema, and
+read gate. If reads require an API key,
+`REGISTRY_DESCRIPTOR_ACCESS_ACQUISITION_POINTER` is also required; public
+registries reject that setting.
+
+Authenticated buyers, sellers, and services can bootstrap from only a URL and
+their own signer with `RegistryClient.bootstrap_registry_descriptor()`. That
+method verifies the response against the principals carried in the descriptor
+before returning it. A normally constructed, externally pinned client uses
+`get_registry_descriptor()` instead. The endpoint does not require the registry
+read key, so a caller can discover the acquisition pointer first. Its signed
+response proves possession of the registry signing credential; it is not
+third-party endorsement of the operator or URL.
+
 ## Database
 
 - Dev: SQLite (`DATABASE_URL=sqlite:///./indexer.db`)
@@ -73,6 +94,7 @@ endpoints:
 - `POST /publishers/{publisher_id}/identity-rotations`
 - `POST /publishers/{publisher_id}/identity-rotations/{nonce}/retire`
 - `GET /filter-spec` (returns the active filter spec + ETag)
+- `GET /.well-known/arkhai/registry-descriptor.json` (signed self-description)
 - `POST /admin/api-keys` (admin)
 - `GET /api/v1/system/config`
 - `GET /api/v1/system/stats`

--- a/core/registry/pyproject.toml
+++ b/core/registry/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "pyyaml>=6.0",
     "jsonschema>=4.20",
     "jsonpath-ng>=1.6",
+    "arkhai-core==0.2.0",
     "arkhai-kit-identity==0.3.0",
 ]
 

--- a/core/registry/src/api/descriptor_routes.py
+++ b/core/registry/src/api/descriptor_routes.py
@@ -1,0 +1,59 @@
+"""Authority-authenticated registry self-description route."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from market_core import RegistryDescriptor
+from sqlalchemy.orm import Session
+
+from src.api.publisher_auth import (
+    authenticate_publisher_request,
+    cached_response,
+    canonical_query_body,
+    complete_authenticated_request,
+    registry_authority_signer,
+    signed_response,
+)
+from src.db.database import get_db
+
+router = APIRouter(tags=["registry-descriptor"])
+
+
+@router.get(
+    "/.well-known/arkhai/registry-descriptor.json",
+    summary="Registry authority, schema, and access descriptor",
+)
+async def get_registry_descriptor(
+    request: Request,
+    db: Session = Depends(get_db),
+) -> Response:
+    authenticated = authenticate_publisher_request(
+        request=request,
+        db=db,
+        method="GET",
+        operation="registry.descriptor.read",
+        resource="registry-descriptor",
+        body=canonical_query_body(request),
+        allowed_roles=frozenset({"buyer", "seller", "service"}),
+    )
+    signer = registry_authority_signer(request)
+    replay = cached_response(authenticated, signer=signer)
+    if replay is not None:
+        return replay
+    descriptor = getattr(request.app.state, "registry_descriptor", None)
+    if not isinstance(descriptor, RegistryDescriptor):
+        raise HTTPException(status_code=503, detail="Registry descriptor unavailable")
+    body = descriptor.to_wire()
+    complete_authenticated_request(
+        authenticated=authenticated,
+        db=db,
+        status=200,
+        body=body,
+    )
+    db.commit()
+    return signed_response(
+        authenticated=authenticated,
+        signer=signer,
+        status=200,
+        body=body,
+    )

--- a/core/registry/src/api/routes.py
+++ b/core/registry/src/api/routes.py
@@ -3,7 +3,7 @@
 from fastapi import APIRouter
 
 from src.api.admin_routes import router as admin_router
-from src.api.api_key_auth import require_read_access
+from src.api.descriptor_routes import router as descriptor_router
 from src.api.filter_spec import router as filter_spec_router
 from src.api.listing_routes import router as listing_router
 from src.api.publisher_routes import router as publisher_router
@@ -19,6 +19,7 @@ router = APIRouter()
 # attached at the admin router (a separate shared secret).
 router.include_router(make_health_router())
 router.include_router(admin_router)
+router.include_router(descriptor_router)
 
 router.include_router(make_system_router())
 router.include_router(filter_spec_router)

--- a/core/registry/src/config.py
+++ b/core/registry/src/config.py
@@ -1,5 +1,3 @@
-import os
-from typing import Literal
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -14,7 +12,7 @@ class Settings(BaseSettings):
         # shared-env/.env) so the registry boots cleanly.
         extra="ignore",
     )
-    
+
     database_url: str = "sqlite:///./indexer.db"
 
     # Server Configuration
@@ -27,16 +25,36 @@ class Settings(BaseSettings):
     root_path: str = ""
 
     registry_authority_id: str | None = Field(
-        default=None, validation_alias="REGISTRY_AUTHORITY_ID",
+        default=None,
+        validation_alias="REGISTRY_AUTHORITY_ID",
     )
     registry_authority_scheme: str | None = Field(
-        default=None, validation_alias="REGISTRY_AUTHORITY_SCHEME",
+        default=None,
+        validation_alias="REGISTRY_AUTHORITY_SCHEME",
     )
     registry_authority_identifier: str | None = Field(
-        default=None, validation_alias="REGISTRY_AUTHORITY_IDENTIFIER",
+        default=None,
+        validation_alias="REGISTRY_AUTHORITY_IDENTIFIER",
     )
     registry_authority_credential_file: str | None = Field(
-        default=None, validation_alias="REGISTRY_AUTHORITY_CREDENTIAL_FILE",
+        default=None,
+        validation_alias="REGISTRY_AUTHORITY_CREDENTIAL_FILE",
+    )
+    registry_descriptor_base_url: str | None = Field(
+        default=None,
+        validation_alias="REGISTRY_DESCRIPTOR_BASE_URL",
+    )
+    registry_descriptor_display_name: str | None = Field(
+        default=None,
+        validation_alias="REGISTRY_DESCRIPTOR_DISPLAY_NAME",
+    )
+    registry_descriptor_operator_identity: str | None = Field(
+        default=None,
+        validation_alias="REGISTRY_DESCRIPTOR_OPERATOR_IDENTITY",
+    )
+    registry_descriptor_access_acquisition_pointer: str | None = Field(
+        default=None,
+        validation_alias="REGISTRY_DESCRIPTOR_ACCESS_ACQUISITION_POINTER",
     )
 
     # Optional ZeroTier configuration (used by deployment/Makefile, not by app logic)
@@ -55,13 +73,16 @@ class Settings(BaseSettings):
     # revoke keys via ``POST /admin/api-keys`` etc., gated by the
     # ``admin_api_key`` env var (separate from the api_keys table).
     require_read_api_key: bool = Field(
-        default=False, validation_alias="REGISTRY_REQUIRE_READ_API_KEY",
+        default=False,
+        validation_alias="REGISTRY_REQUIRE_READ_API_KEY",
     )
     require_write_api_key: bool = Field(
-        default=False, validation_alias="REGISTRY_REQUIRE_WRITE_API_KEY",
+        default=False,
+        validation_alias="REGISTRY_REQUIRE_WRITE_API_KEY",
     )
     admin_api_key: str | None = Field(
-        default=None, validation_alias="REGISTRY_ADMIN_API_KEY",
+        default=None,
+        validation_alias="REGISTRY_ADMIN_API_KEY",
     )
     # Optional bootstrap secret. When set AND the api_keys table is
     # empty at startup, the registry seeds a single row with this raw
@@ -70,7 +91,8 @@ class Settings(BaseSettings):
     # the first run, the env var can stay set or be removed — the
     # row persists across restarts.
     bootstrap_api_key: str | None = Field(
-        default=None, validation_alias="REGISTRY_BOOTSTRAP_API_KEY",
+        default=None,
+        validation_alias="REGISTRY_BOOTSTRAP_API_KEY",
     )
 
     # Logging
@@ -79,11 +101,10 @@ class Settings(BaseSettings):
     @property
     def is_postgres(self) -> bool:
         return self.database_url.startswith("postgresql://")
-    
+
     @property
     def is_sqlite(self) -> bool:
         return self.database_url.startswith("sqlite://")
 
 
 settings = Settings()
-

--- a/core/registry/src/main.py
+++ b/core/registry/src/main.py
@@ -13,11 +13,13 @@ from src.api.publisher_auth import (
 )
 from src.config import settings
 from src.db.database import init_db
+from src.api.filter_spec import get_loaded_spec
+from src.registry_descriptor import build_registry_descriptor
 
 # Configure logging
 logging.basicConfig(
     level=getattr(logging, settings.log_level.upper()),
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
 logger = logging.getLogger(__name__)
 
@@ -39,20 +41,34 @@ async def lifespan(app: FastAPI):
         and settings.registry_authority_identifier
         and settings.registry_authority_credential_file
     ):
-        raise RuntimeError("registry authority principal and credential file are required")
+        raise RuntimeError(
+            "registry authority principal and credential file are required"
+        )
     expected_registry = Identity(
         scheme=settings.registry_authority_scheme,
         identifier=settings.registry_authority_identifier,
     )
-    credential = Path(
-        settings.registry_authority_credential_file
-    ).read_text(encoding="utf-8").strip()
+    credential = (
+        Path(settings.registry_authority_credential_file)
+        .read_text(encoding="utf-8")
+        .strip()
+    )
     registry_signer = create_signer(expected_registry.scheme, credential)
     if registry_signer.identity != expected_registry:
         raise RuntimeError(
             "registry authority credential does not match configured principal"
         )
     app.state.registry_authority_signer = registry_signer
+    app.state.registry_descriptor = build_registry_descriptor(
+        base_url=settings.registry_descriptor_base_url,
+        display_name=settings.registry_descriptor_display_name,
+        operator_identity=settings.registry_descriptor_operator_identity,
+        authority_name=settings.registry_authority_id,
+        authority_principal=registry_signer.identity,
+        filter_spec=get_loaded_spec(),
+        require_read_api_key=settings.require_read_api_key,
+        acquisition_pointer=(settings.registry_descriptor_access_acquisition_pointer),
+    )
     logger.info("Database initialized")
 
     # Bootstrap a single API key from env if configured AND the table
@@ -63,6 +79,7 @@ async def lifespan(app: FastAPI):
         from src.api.api_key_auth import _hash_key
         from src.db.database import SessionLocal
         from src.db.models import ApiKey
+
         with SessionLocal() as session:
             if session.query(ApiKey).count() == 0:
                 # Write scope: the bootstrap key is the operator's own
@@ -74,9 +91,13 @@ async def lifespan(app: FastAPI):
                 )
                 session.add(seed)
                 session.commit()
-                logger.info("[BOOTSTRAP] seeded api_keys with the env-provided write key")
+                logger.info(
+                    "[BOOTSTRAP] seeded api_keys with the env-provided write key"
+                )
             else:
-                logger.info("[BOOTSTRAP] api_keys table not empty; bootstrap key ignored")
+                logger.info(
+                    "[BOOTSTRAP] api_keys table not empty; bootstrap key ignored"
+                )
 
     logger.info(f"Listing registry server ready on {settings.host}:{settings.port}")
 
@@ -121,6 +142,7 @@ async def authenticated_http_error(request: Request, error: HTTPException):
         body={"detail": error.detail},
     )
 
+
 # Add CORS middleware
 app.add_middleware(
     CORSMiddleware,
@@ -138,6 +160,7 @@ def _custom_openapi():
     if app.openapi_schema:
         return app.openapi_schema
     from fastapi.openapi.utils import get_openapi
+
     schema = get_openapi(
         title=app.title,
         version=app.version,
@@ -157,6 +180,7 @@ app.openapi = _custom_openapi
 
 if __name__ == "__main__":
     import uvicorn
+
     uvicorn.run(
         "src.main:app",
         host=settings.host,

--- a/core/registry/src/registry_descriptor.py
+++ b/core/registry/src/registry_descriptor.py
@@ -1,0 +1,71 @@
+"""Construct the registry descriptor from authoritative runtime inputs."""
+
+from __future__ import annotations
+
+from market_core import RegistryDescriptor
+from market_identity import Identity
+
+from src.api.filter_spec import FilterSpec
+
+
+def build_registry_descriptor(
+    *,
+    base_url: str | None,
+    display_name: str | None,
+    operator_identity: str | None,
+    authority_name: str | None,
+    authority_principal: Identity,
+    filter_spec: FilterSpec,
+    require_read_api_key: bool,
+    acquisition_pointer: str | None,
+) -> RegistryDescriptor:
+    """Build one descriptor without duplicating signer, schema, or gate state."""
+
+    required = {
+        "REGISTRY_DESCRIPTOR_BASE_URL": base_url,
+        "REGISTRY_DESCRIPTOR_DISPLAY_NAME": display_name,
+        "REGISTRY_DESCRIPTOR_OPERATOR_IDENTITY": operator_identity,
+        "REGISTRY_AUTHORITY_ID": authority_name,
+    }
+    missing = [name for name, value in required.items() if not value]
+    if missing:
+        raise RuntimeError(
+            "registry descriptor configuration is incomplete: " + ", ".join(missing)
+        )
+    if filter_spec.schema_identity is None:
+        raise RuntimeError("registry descriptor requires a filter-spec schema identity")
+    if require_read_api_key and not acquisition_pointer:
+        raise RuntimeError(
+            "a key-gated registry descriptor requires "
+            "REGISTRY_DESCRIPTOR_ACCESS_ACQUISITION_POINTER"
+        )
+    if not require_read_api_key and acquisition_pointer:
+        raise RuntimeError(
+            "a public registry descriptor must not configure "
+            "REGISTRY_DESCRIPTOR_ACCESS_ACQUISITION_POINTER"
+        )
+
+    access: dict[str, str]
+    if require_read_api_key:
+        access = {
+            "posture": "key-gated",
+            "acquisitionPointer": acquisition_pointer or "",
+        }
+    else:
+        access = {"posture": "public"}
+    return RegistryDescriptor.model_validate(
+        {
+            "access": access,
+            "authority": {
+                "name": authority_name,
+                "principals": [authority_principal.model_dump(mode="json")],
+            },
+            "baseUrl": base_url,
+            "displayName": display_name,
+            "operatorIdentity": operator_identity,
+            "schema": {
+                "id": filter_spec.schema_identity.id,
+                "version": str(filter_spec.schema_identity.version),
+            },
+        }
+    )

--- a/core/registry/tests/integration/conftest.py
+++ b/core/registry/tests/integration/conftest.py
@@ -7,6 +7,7 @@ import uuid
 import httpx
 import pytest
 import pytest_asyncio
+from market_core import RegistryDescriptor
 from market_identity import Ed25519Signer, Eip191Signer, TrustedIdentitySet
 
 from registry_client import RegistryClient
@@ -38,16 +39,32 @@ def taker_signer() -> Eip191Signer:
 def ed25519_signer() -> Ed25519Signer:
     return Ed25519Signer(ED25519_SECRET)
 
+
 @pytest.fixture(autouse=True)
 def registry_authority(monkeypatch):
     signer = Ed25519Signer(bytes(range(1, 33)))
     app.state.registry_authority_signer = signer
+    app.state.registry_descriptor = RegistryDescriptor.model_validate(
+        {
+            "access": {"posture": "public"},
+            "authority": {
+                "name": "test-registry",
+                "principals": [signer.identity.model_dump(mode="json")],
+            },
+            "baseUrl": "http://test",
+            "displayName": "Test Registry",
+            "operatorIdentity": "test-operator",
+            "schema": {"id": "vms.compute", "version": "1"},
+        }
+    )
     monkeypatch.setattr(
         "src.config.settings.registry_authority_id",
         "test-registry",
     )
     yield signer
     del app.state.registry_authority_signer
+    del app.state.registry_descriptor
+
 
 @pytest.fixture(autouse=True)
 def sign_raw_marketplace_requests(monkeypatch, registry_authority, db_session):
@@ -65,6 +82,8 @@ def sign_raw_marketplace_requests(monkeypatch, registry_authority, db_session):
         parts = [part for part in path.split("/") if part]
         if path == "/filter-spec":
             return "filter.get", "filter-spec"
+        if path == "/.well-known/arkhai/registry-descriptor.json":
+            return "registry.descriptor.read", "registry-descriptor"
         if path == "/api/v1/listings/validate-publish":
             return "listing.validate", "listings"
         if path == "/api/v1/system/health":
@@ -152,6 +171,7 @@ def sign_raw_marketplace_requests(monkeypatch, registry_authority, db_session):
         )
         kwargs["headers"] = headers
         return await original(client, method, url, **kwargs)
+
     from src.db.database import get_db
 
     def override_get_db():

--- a/core/registry/tests/integration/test_registry_descriptor.py
+++ b/core/registry/tests/integration/test_registry_descriptor.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import inspect
+import time
+
+import httpx
+import pytest
+from market_core import RegistryDescriptor
+from market_identity import Ed25519Signer
+
+from registry_client import RegistryClient, RegistryClientError, SyncRegistryClient
+from src.db.models import PublisherReplayReservation
+from src.main import app
+
+
+async def test_typed_client_reads_authority_authenticated_descriptor(
+    registry_client,
+    registry_authority,
+) -> None:
+    descriptor = await registry_client.get_registry_descriptor()
+
+    assert isinstance(descriptor, RegistryDescriptor)
+    assert descriptor.base_url == "http://test"
+    assert descriptor.schema_identity.id == "vms.compute"
+    assert descriptor.authority.name == "test-registry"
+    assert descriptor.authority.principals[0].identifier == (
+        registry_authority.identity.identifier
+    )
+
+
+async def test_client_bootstraps_trust_from_descriptor_possession_proof(
+    maker_signer,
+) -> None:
+    descriptor = await RegistryClient.bootstrap_registry_descriptor(
+        "http://test",
+        signer=maker_signer,
+        caller_role="buyer",
+        transport=httpx.ASGITransport(app=app),
+    )
+
+    assert descriptor.authority.name == "test-registry"
+
+
+async def test_bootstrap_rejects_response_signer_outside_descriptor(
+    maker_signer,
+) -> None:
+    advertised = Ed25519Signer(bytes(range(2, 34)))
+    app.state.registry_descriptor = RegistryDescriptor.model_validate(
+        {
+            "access": {"posture": "public"},
+            "authority": {
+                "name": "test-registry",
+                "principals": [advertised.identity.model_dump(mode="json")],
+            },
+            "baseUrl": "http://test",
+            "displayName": "Impersonated Registry",
+            "operatorIdentity": "test-operator",
+            "schema": {"id": "vms.compute", "version": "1"},
+        }
+    )
+
+    with pytest.raises(RegistryClientError, match="wrong_principal"):
+        await RegistryClient.bootstrap_registry_descriptor(
+            "http://test",
+            signer=maker_signer,
+            caller_role="buyer",
+            transport=httpx.ASGITransport(app=app),
+        )
+
+
+def test_registry_clients_keep_descriptor_method_parity() -> None:
+    assert inspect.signature(
+        RegistryClient.get_registry_descriptor
+    ) == inspect.signature(SyncRegistryClient.get_registry_descriptor)
+    async_bootstrap = inspect.signature(
+        RegistryClient.bootstrap_registry_descriptor
+    ).parameters
+    sync_bootstrap = inspect.signature(
+        SyncRegistryClient.bootstrap_registry_descriptor
+    ).parameters
+    assert [
+        (name, parameter.kind, parameter.default)
+        for name, parameter in async_bootstrap.items()
+    ] == [
+        (name, parameter.kind, parameter.default)
+        for name, parameter in sync_bootstrap.items()
+    ]
+
+
+async def test_descriptor_remains_readable_before_key_acquisition(
+    registry_client,
+    registry_authority,
+) -> None:
+    app.state.registry_descriptor = RegistryDescriptor.model_validate(
+        {
+            "access": {
+                "posture": "key-gated",
+                "acquisitionPointer": "https://registry.example/access",
+            },
+            "authority": {
+                "name": "test-registry",
+                "principals": [registry_authority.identity.model_dump(mode="json")],
+            },
+            "baseUrl": "https://registry.example",
+            "displayName": "Private Registry",
+            "operatorIdentity": "test-operator",
+            "schema": {"id": "vms.compute", "version": "1"},
+        }
+    )
+
+    descriptor = await registry_client.get_registry_descriptor()
+
+    assert descriptor.access.posture == "key-gated"
+    assert descriptor.access.acquisition_pointer == ("https://registry.example/access")
+
+
+async def test_exact_descriptor_request_replay_returns_recorded_body(
+    registry_client,
+    db_session,
+) -> None:
+    request_id = "descriptor-replay"
+    timestamp = int(time.time())
+
+    first = await registry_client.get_registry_descriptor(
+        request_id=request_id,
+        timestamp=timestamp,
+    )
+    second = await registry_client.get_registry_descriptor(
+        request_id=request_id,
+        timestamp=timestamp,
+    )
+
+    assert second == first
+    assert db_session.query(PublisherReplayReservation).count() == 1

--- a/core/registry/tests/unit/test_registry_descriptor.py
+++ b/core/registry/tests/unit/test_registry_descriptor.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import pytest
+from market_identity import Ed25519Signer
+
+from src.api.filter_spec import FilterSpec, SchemaIdentity
+from src.registry_descriptor import build_registry_descriptor
+
+
+def _filter_spec() -> FilterSpec:
+    return FilterSpec(
+        version=1,
+        schema=SchemaIdentity(id="api_credits", version=1),
+        listing_shape={},
+        filters=[],
+    )
+
+
+def test_descriptor_derives_authority_schema_and_public_posture() -> None:
+    signer = Ed25519Signer(bytes(range(32)))
+
+    descriptor = build_registry_descriptor(
+        base_url="https://registry.example/credits/",
+        display_name="API Credits Registry",
+        operator_identity="Example Operator",
+        authority_name="credits-registry",
+        authority_principal=signer.identity,
+        filter_spec=_filter_spec(),
+        require_read_api_key=False,
+        acquisition_pointer=None,
+    )
+
+    assert descriptor.to_wire() == {
+        "access": {"posture": "public"},
+        "authority": {
+            "name": "credits-registry",
+            "principals": [signer.identity.model_dump(mode="json")],
+        },
+        "baseUrl": "https://registry.example/credits",
+        "displayName": "API Credits Registry",
+        "operatorIdentity": "Example Operator",
+        "schema": {"id": "api_credits", "version": "1"},
+    }
+
+
+def test_key_gated_descriptor_requires_acquisition_pointer() -> None:
+    signer = Ed25519Signer(bytes(range(32)))
+
+    with pytest.raises(RuntimeError, match="requires.*ACQUISITION_POINTER"):
+        build_registry_descriptor(
+            base_url="https://registry.example",
+            display_name="Private Registry",
+            operator_identity="Example Operator",
+            authority_name="private-registry",
+            authority_principal=signer.identity,
+            filter_spec=_filter_spec(),
+            require_read_api_key=True,
+            acquisition_pointer=None,
+        )
+
+
+def test_public_descriptor_rejects_acquisition_pointer() -> None:
+    signer = Ed25519Signer(bytes(range(32)))
+
+    with pytest.raises(RuntimeError, match="public registry descriptor"):
+        build_registry_descriptor(
+            base_url="https://registry.example",
+            display_name="Public Registry",
+            operator_identity="Example Operator",
+            authority_name="public-registry",
+            authority_principal=signer.identity,
+            filter_spec=_filter_spec(),
+            require_read_api_key=False,
+            acquisition_pointer="https://registry.example/access",
+        )

--- a/core/registry/uv.lock
+++ b/core/registry/uv.lock
@@ -172,6 +172,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "alembic" },
+    { name = "arkhai-core" },
     { name = "arkhai-kit-identity" },
     { name = "fastapi" },
     { name = "jsonpath-ng" },
@@ -199,6 +200,7 @@ dev = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.9.0" },
     { name = "alembic", specifier = ">=1.12.0" },
+    { name = "arkhai-core", specifier = "==0.2.0" },
     { name = "arkhai-kit-identity", specifier = "==0.3.0" },
     { name = "fastapi", specifier = ">=0.104.0" },
     { name = "jsonpath-ng", specifier = ">=1.6" },

--- a/core/src/market_core/__init__.py
+++ b/core/src/market_core/__init__.py
@@ -55,6 +55,15 @@ from .query_dsl import (
     render_field_reference,
     validate_query,
 )
+from .registry_descriptor import (
+    KeyGatedRegistryAccess,
+    PublicRegistryAccess,
+    RegistryAccess,
+    RegistryAuthorityDescriptor,
+    RegistryDescriptor,
+    RegistryPrincipal,
+    RegistrySchemaDescriptor,
+)
 
 __all__ = [
     "MARKET_DOMAIN_CONTRACT_VERSION",
@@ -106,5 +115,11 @@ __all__ = [
     "render_canonical_query",
     "render_field_reference",
     "validate_query",
+    "KeyGatedRegistryAccess",
+    "PublicRegistryAccess",
+    "RegistryAccess",
+    "RegistryAuthorityDescriptor",
+    "RegistryDescriptor",
+    "RegistryPrincipal",
+    "RegistrySchemaDescriptor",
 ]
-

--- a/core/src/market_core/registry_descriptor.py
+++ b/core/src/market_core/registry_descriptor.py
@@ -1,0 +1,113 @@
+"""Portable registry self-description carriers."""
+
+from __future__ import annotations
+
+import re
+from typing import Annotated, Literal
+from urllib.parse import urlsplit
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+_ED25519_IDENTIFIER = re.compile(r"[A-Za-z0-9_-]{42}[AEIMQUYcgkosw048]")
+_EIP191_IDENTIFIER = re.compile(r"0x[0-9a-f]{40}")
+_AUTHORITY_NAME = re.compile(r"[A-Za-z][A-Za-z0-9_.:-]*")
+_SCHEMA_TOKEN = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.+-]*")
+
+
+class _StrictCarrier(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+
+class RegistryPrincipal(_StrictCarrier):
+    """Canonical public principal carried by a registry descriptor."""
+
+    scheme: Literal["ed25519", "eip191"]
+    identifier: str
+
+    @model_validator(mode="after")
+    def validate_identifier(self) -> RegistryPrincipal:
+        pattern = (
+            _ED25519_IDENTIFIER if self.scheme == "ed25519" else _EIP191_IDENTIFIER
+        )
+        if pattern.fullmatch(self.identifier) is None:
+            raise ValueError(f"invalid {self.scheme} registry principal")
+        return self
+
+
+class RegistryAuthorityDescriptor(_StrictCarrier):
+    """Stable authority name and its ordered active trust pins."""
+
+    name: str = Field(min_length=1, max_length=64, pattern=_AUTHORITY_NAME.pattern)
+    principals: tuple[RegistryPrincipal, ...] = Field(min_length=1, max_length=2)
+
+    @model_validator(mode="after")
+    def validate_unique_principals(self) -> RegistryAuthorityDescriptor:
+        identities = {(item.scheme, item.identifier) for item in self.principals}
+        if len(identities) != len(self.principals):
+            raise ValueError("registry authority principals must be unique")
+        return self
+
+
+class PublicRegistryAccess(_StrictCarrier):
+    posture: Literal["public"] = "public"
+
+
+class KeyGatedRegistryAccess(_StrictCarrier):
+    posture: Literal["key-gated"] = "key-gated"
+    acquisition_pointer: str = Field(alias="acquisitionPointer", max_length=2_048)
+
+    @field_validator("acquisition_pointer")
+    @classmethod
+    def validate_acquisition_pointer(cls, value: str) -> str:
+        return _http_url(value, "registry access acquisition pointer")
+
+
+RegistryAccess = Annotated[
+    PublicRegistryAccess | KeyGatedRegistryAccess,
+    Field(discriminator="posture"),
+]
+
+
+class RegistrySchemaDescriptor(_StrictCarrier):
+    id: str = Field(min_length=1, max_length=128, pattern=_SCHEMA_TOKEN.pattern)
+    version: str = Field(min_length=1, max_length=64, pattern=_SCHEMA_TOKEN.pattern)
+
+
+class RegistryDescriptor(_StrictCarrier):
+    """One operator-authored registry description on the public wire."""
+
+    access: RegistryAccess
+    authority: RegistryAuthorityDescriptor
+    base_url: str = Field(alias="baseUrl", max_length=2_048)
+    display_name: str = Field(alias="displayName", min_length=1, max_length=256)
+    operator_identity: str = Field(
+        alias="operatorIdentity",
+        min_length=1,
+        max_length=256,
+    )
+    schema_identity: RegistrySchemaDescriptor = Field(alias="schema")
+
+    @field_validator("base_url")
+    @classmethod
+    def validate_base_url(cls, value: str) -> str:
+        return _http_url(value, "registry base URL").rstrip("/")
+
+    @field_validator("display_name", "operator_identity")
+    @classmethod
+    def normalize_bounded_text(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("registry descriptor text must be nonempty")
+        return normalized
+
+    def to_wire(self) -> dict[str, object]:
+        """Return the exact camel-case JSON object carried over HTTP."""
+
+        return self.model_dump(mode="json", by_alias=True, exclude_none=True)
+
+
+def _http_url(value: str, label: str) -> str:
+    parsed = urlsplit(value)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError(f"{label} must use HTTP or HTTPS")
+    return value

--- a/core/tests/unit/test_registry_descriptor.py
+++ b/core/tests/unit/test_registry_descriptor.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from market_core import RegistryDescriptor
+
+_ED25519 = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+
+
+def _descriptor(**overrides: object) -> dict[str, object]:
+    value: dict[str, object] = {
+        "access": {"posture": "public"},
+        "authority": {
+            "name": "registry-a",
+            "principals": [{"scheme": "ed25519", "identifier": _ED25519}],
+        },
+        "baseUrl": "https://registry.example/",
+        "displayName": " Example Compute Registry ",
+        "operatorIdentity": " Example Operator ",
+        "schema": {"id": "vms.compute", "version": "1"},
+    }
+    value.update(overrides)
+    return value
+
+
+def test_descriptor_emits_exact_portable_wire_shape() -> None:
+    descriptor = RegistryDescriptor.model_validate(_descriptor())
+
+    assert descriptor.to_wire() == {
+        "access": {"posture": "public"},
+        "authority": {
+            "name": "registry-a",
+            "principals": [{"scheme": "ed25519", "identifier": _ED25519}],
+        },
+        "baseUrl": "https://registry.example",
+        "displayName": "Example Compute Registry",
+        "operatorIdentity": "Example Operator",
+        "schema": {"id": "vms.compute", "version": "1"},
+    }
+
+
+def test_key_gated_descriptor_requires_http_acquisition_pointer() -> None:
+    descriptor = RegistryDescriptor.model_validate(
+        _descriptor(
+            access={
+                "posture": "key-gated",
+                "acquisitionPointer": "https://registry.example/access",
+            }
+        )
+    )
+
+    assert descriptor.to_wire()["access"] == {
+        "posture": "key-gated",
+        "acquisitionPointer": "https://registry.example/access",
+    }
+    with pytest.raises(ValidationError, match="HTTP or HTTPS"):
+        RegistryDescriptor.model_validate(
+            _descriptor(
+                access={
+                    "posture": "key-gated",
+                    "acquisitionPointer": "mailto:operator@example.com",
+                }
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    "authority",
+    [
+        {"name": "registry-a", "principals": []},
+        {
+            "name": "registry-a",
+            "principals": [
+                {"scheme": "ed25519", "identifier": _ED25519},
+                {"scheme": "ed25519", "identifier": _ED25519},
+            ],
+        },
+        {
+            "name": "registry-a",
+            "principals": [{"scheme": "eip191", "identifier": "0x" + "AB" * 20}],
+        },
+        {
+            "name": "registry-a",
+            "principals": [{"scheme": "ed25519", "identifier": "A" * 42 + "B"}],
+        },
+    ],
+)
+def test_descriptor_rejects_invalid_authority_pins(authority: object) -> None:
+    with pytest.raises(ValidationError):
+        RegistryDescriptor.model_validate(_descriptor(authority=authority))
+
+
+def test_descriptor_rejects_unknown_fields() -> None:
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        RegistryDescriptor.model_validate(_descriptor(contact="operator@example.com"))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,9 @@ services:
       - REGISTRY_AUTHORITY_SCHEME=ed25519
       - REGISTRY_AUTHORITY_IDENTIFIER=skkdlQKuKGMKK6yy4MdFEP_N0yjDNP8-E5PnWy0x59w
       - REGISTRY_AUTHORITY_CREDENTIAL_FILE=/run/secrets/arkhai/registry-identity/credential
+      - REGISTRY_DESCRIPTOR_BASE_URL=http://localhost:8090
+      - REGISTRY_DESCRIPTOR_DISPLAY_NAME=Local API Credits Registry
+      - REGISTRY_DESCRIPTOR_OPERATOR_IDENTITY=Arkhai local development
     volumes:
       - ${APICREDITS_REGISTRY_IDENTITY_CREDENTIAL_FILE:?set API-credits registry signer credential file}:/run/secrets/arkhai/registry-identity/credential:ro
   credits-storefront:

--- a/docs/development/ARCHITECTURE.md
+++ b/docs/development/ARCHITECTURE.md
@@ -163,6 +163,22 @@ accepted runs recover under immutable ownership.
 
 See the [marketplace identity contract](../../openspec/specs/marketplace-identity/spec.md) and its [architecture](../../openspec/specs/marketplace-identity/architecture.md).
 
+### Registry self-description
+
+Each registry publishes a strict portable descriptor at
+`/.well-known/arkhai/registry-descriptor.json`. The route uses the same
+scheme-neutral version 2 request authentication, durable replay, and signed
+response path as listing discovery. The descriptor's authority principal is
+the live response signer, its schema identity is the active filter
+specification, and its access posture is the live read gate. The registry
+process does not maintain duplicate configuration for those facts.
+
+The public URL, display name, operator identity, and any key-acquisition
+pointer remain operator-owned deployment configuration. A response proof
+establishes possession of the named credential, not third-party endorsement.
+Directory curation and offline operator signatures therefore remain outside
+the registry service boundary.
+
 ### Capacity publication and multi-domain storefront composition
 
 `arkhai-kit-capacity-publication` owns the storefront-side multi-site capacity
@@ -641,5 +657,4 @@ Alkahest remains an independent mechanism lane. API-credit and bare-metal hosted
 Bare metal composes the same provider-neutral hosted mechanism without importing VM packages or the released client directly. The installed buyer plugin uses the core `HostedSettlementTransport`; the seller binds bare-owned callbacks into the shared `HostedSettlementRouteService`. On first start, the seller rebuilds the accepted physical binding only from the durable negotiation thread, trusted listing, exact option, settlement plan, and canonical parties, then persists it under the obligation identity.
 
 Authoritative funding is the gate into the existing selected-site capacity and fulfillment clients. A deterministic fulfillment identity survives retries and restart. Access-ready state produces a credential-free public result and content-addressed lease-ready evidence; the resolver returns the canonical evidence with a marketplace-signer proof. Collection follows evidence. Reclaim is blocked after evidence, committed collection, or unknown physical authority. Financial return/loss recovery and post-collection lease teardown remain separate convergent lifecycles.
-
 

--- a/docs/development/DEPLOYMENT_AND_CONFIG.md
+++ b/docs/development/DEPLOYMENT_AND_CONFIG.md
@@ -110,6 +110,23 @@ separate mechanism resources and never determine profile selection. ConfigMaps,
 arguments, image layers, run logs, evidence, output, and examples contain no
 resolved signing value.
 
+## Registry descriptor configuration
+
+The registry is a Pydantic-settings service rather than a Dynaconf role. Its
+Helm and Compose surfaces set the public descriptor fields through
+`REGISTRY_DESCRIPTOR_BASE_URL`, `REGISTRY_DESCRIPTOR_DISPLAY_NAME`, and
+`REGISTRY_DESCRIPTOR_OPERATOR_IDENTITY`. When
+`REGISTRY_REQUIRE_READ_API_KEY=true`, the deployment must also set
+`REGISTRY_DESCRIPTOR_ACCESS_ACQUISITION_POINTER`; a public registry must omit
+that pointer. Startup rejects missing fields and either posture mismatch.
+
+These values are public operator assertions. The service derives the
+descriptor's authority principal from the credential-backed active signer and
+derives its schema identity from the loaded filter specification. Helm keeps
+the descriptor values in ordinary values while mounting the signer credential
+from a Secret. Compose wrappers likewise carry public descriptor values beside
+public identity pins and keep signer credentials in role-owned file mounts.
+
 ## Per-domain stack composition
 
 Each domain stack owns its public topology while consuming shared core/kit

--- a/docs/development/ROADMAP.md
+++ b/docs/development/ROADMAP.md
@@ -253,6 +253,14 @@ The implemented change mapping is
 Remaining external operational evidence belongs to that change's unchecked
 verification tasks; it does not restore legacy identity precedence.
 
+## Registry discovery status
+
+Registry discovery is schema-driven and authority-authenticated, but a registry
+does not yet publish the complete operator-authored descriptor needed to import
+its public URL, authority trust pins, schema identity, and access posture as one
+unit. That gap is owned by
+[`add-registry-self-description`](../../openspec/changes/add-registry-self-description/).
+
 ---
 
 ## Hosted settlement release status

--- a/docs/development/ROADMAP.md
+++ b/docs/development/ROADMAP.md
@@ -253,16 +253,6 @@ The implemented change mapping is
 Remaining external operational evidence belongs to that change's unchecked
 verification tasks; it does not restore legacy identity precedence.
 
-## Registry discovery status
-
-Registry discovery is schema-driven and authority-authenticated, but a registry
-does not yet publish the complete operator-authored descriptor needed to import
-its public URL, authority trust pins, schema identity, and access posture as one
-unit. That gap is owned by
-[`add-registry-self-description`](../../openspec/changes/add-registry-self-description/).
-
----
-
 ## Hosted settlement release status
 
 The common VM consumer supports exact hosted funding profiles `card.v1`,

--- a/helm/charts/registry/templates/deployment.yaml
+++ b/helm/charts/registry/templates/deployment.yaml
@@ -5,6 +5,12 @@
 {{- if or (ne .Values.identity.principal.scheme $activeIdentity.principal.scheme) (ne .Values.identity.principal.identifier $activeIdentity.principal.identifier) -}}
 {{- fail "registry identity principal must match global.registryIdentity.principal" -}}
 {{- end -}}
+{{- if and .Values.config.requireReadApiKey (not .Values.descriptor.accessAcquisitionPointer) -}}
+{{- fail "key-gated registry descriptor requires an access acquisition pointer" -}}
+{{- end -}}
+{{- if and (not .Values.config.requireReadApiKey) .Values.descriptor.accessAcquisitionPointer -}}
+{{- fail "public registry descriptor must not configure an access acquisition pointer" -}}
+{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -46,6 +52,16 @@ spec:
               value: {{ required "registry identity principal identifier is required" $activeIdentity.principal.identifier | quote }}
             - name: REGISTRY_AUTHORITY_CREDENTIAL_FILE
               value: /var/run/secrets/arkhai/registry-identity/credential
+            - name: REGISTRY_DESCRIPTOR_BASE_URL
+              value: {{ required "registry descriptor base URL is required" .Values.descriptor.baseUrl | quote }}
+            - name: REGISTRY_DESCRIPTOR_DISPLAY_NAME
+              value: {{ required "registry descriptor display name is required" .Values.descriptor.displayName | quote }}
+            - name: REGISTRY_DESCRIPTOR_OPERATOR_IDENTITY
+              value: {{ required "registry descriptor operator identity is required" .Values.descriptor.operatorIdentity | quote }}
+            {{- if .Values.descriptor.accessAcquisitionPointer }}
+            - name: REGISTRY_DESCRIPTOR_ACCESS_ACQUISITION_POINTER
+              value: {{ .Values.descriptor.accessAcquisitionPointer | quote }}
+            {{- end }}
             # --- sourced from subchart values ---
             - name: DATABASE_URL
               value: {{ .Values.config.databaseUrl | quote }}

--- a/helm/charts/registry/values.yaml
+++ b/helm/charts/registry/values.yaml
@@ -28,6 +28,16 @@ identity:
     name: arkhai-registry-identity
     key: credential
 
+# Public, operator-authored registry identity. Authority principals and schema
+# identity are derived inside the service from the active signer and filter
+# specification; they are intentionally not duplicated here.
+descriptor:
+  baseUrl: "http://localhost:8080"
+  displayName: "Local VM Compute Registry"
+  operatorIdentity: "Arkhai local development"
+  # Required only when config.requireReadApiKey is true.
+  accessAcquisitionPointer: ""
+
 service:
   type: ClusterIP
   port: 8080

--- a/helm/scripts/test-render.sh
+++ b/helm/scripts/test-render.sh
@@ -131,6 +131,7 @@ expect_override_failure() {
 
 DEFAULT_CONFIGMAP="$(extract_section "$DEFAULT_RENDERED" 'storefront/templates/configmap\.yaml')"
 DEFAULT_DEPLOYMENT="$(extract_section "$DEFAULT_RENDERED" 'storefront/templates/deployment\.yaml')"
+DEFAULT_REGISTRY="$(extract_section "$DEFAULT_RENDERED" 'registry/templates/deployment\.yaml')"
 FIAT_CONFIGMAP="$(extract_section "$FIAT_RENDERED" 'storefront/templates/configmap\.yaml')"
 FIAT_DEPLOYMENT="$(extract_section "$FIAT_RENDERED" 'storefront/templates/deployment\.yaml')"
 FIAT_REGISTRY="$(extract_section "$FIAT_RENDERED" 'registry/templates/deployment\.yaml')"
@@ -150,6 +151,10 @@ expect_present "$DEFAULT_CONFIGMAP" 'priority = \[\]' "new defaults have empty s
 expect_absent "$DEFAULT_CONFIGMAP" '\[Settlement\.(stripe|alkahest)\]' "new defaults install no mechanism subsection"
 expect_absent "$DEFAULT_RENDERED" 'private_key|privateKey|request_credential' "default manifests contain no signing key fields"
 expect_absent "$DEFAULT_RENDERED" 'admin_api_key|adminApiKey|X-Admin-Key' "default manifests contain no legacy administrator shared secret"
+expect_present "$DEFAULT_REGISTRY" 'name: +REGISTRY_DESCRIPTOR_BASE_URL' "registry renders its public descriptor URL"
+expect_present "$DEFAULT_REGISTRY" 'value: +"?Local VM Compute Registry"?' "registry renders its descriptor display name"
+expect_present "$DEFAULT_REGISTRY" 'value: +"?Arkhai local development"?' "registry renders its operator identity"
+expect_absent "$DEFAULT_REGISTRY" 'REGISTRY_DESCRIPTOR_ACCESS_ACQUISITION_POINTER' "public registry omits an acquisition pointer"
 
 expect_present "$FIAT_CONFIGMAP" 'scheme = \"ed25519\"' "fiat profile renders Ed25519 scheme"
 expect_present "$FIAT_CONFIGMAP" 'identifier = \"0EqyMnQrtKs6E2i9RhXk5tAiSrcaAWuvhSCjMsl3hzc\"' "fiat profile renders the configured public storefront principal"
@@ -253,6 +258,14 @@ expect_override_failure \
     "$CHART_DIR/fixtures/eip191-evm-values.yaml" \
     "Alkahest without wallet Secret fails schema/render" \
     --set-string 'storefront.agents[0].secret.secretName='
+expect_override_failure \
+    "$CHART_DIR/fixtures/fiat-ed25519-values.yaml" \
+    "key-gated registry without an acquisition pointer fails render" \
+    --set 'registry.config.requireReadApiKey=true'
+expect_override_failure \
+    "$CHART_DIR/fixtures/fiat-ed25519-values.yaml" \
+    "public registry with an acquisition pointer fails render" \
+    --set-string 'registry.descriptor.accessAcquisitionPointer=https://registry.example/access'
 
 expect_override_failure \
     "$CHART_DIR/fixtures/fiat-ed25519-values.yaml" \

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -22,10 +22,11 @@
     },
     "registry": {
       "type": "object",
-      "required": ["identity"],
+      "required": ["identity", "descriptor"],
       "properties": {
         "image": {"$ref": "#/definitions/image"},
-        "identity": {"$ref": "#/definitions/identity"}
+        "identity": {"$ref": "#/definitions/identity"},
+        "descriptor": {"$ref": "#/definitions/registryDescriptor"}
       }
     },
     "storefront": {
@@ -175,6 +176,23 @@
       "properties": {
         "authority": {"type": "string", "minLength": 1},
         "principal": {"$ref": "#/definitions/publicIdentity"}
+      }
+    },
+    "registryDescriptor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["baseUrl", "displayName", "operatorIdentity"],
+      "properties": {
+        "baseUrl": {"type": "string", "pattern": "^https?://\\S+$"},
+        "displayName": {"type": "string", "minLength": 1, "maxLength": 256},
+        "operatorIdentity": {"type": "string", "minLength": 1, "maxLength": 256},
+        "accessAcquisitionPointer": {
+          "type": "string",
+          "anyOf": [
+            {"const": ""},
+            {"pattern": "^https?://\\S+$"}
+          ]
+        }
       }
     },
     "registryAuthority": {

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -121,6 +121,12 @@ registry:
       name: arkhai-registry-identity
       key: credential
 
+  descriptor:
+    baseUrl: "http://localhost:8080"
+    displayName: "Local VM Compute Registry"
+    operatorIdentity: "Arkhai local development"
+    accessAcquisitionPointer: ""
+
   service:
     type: NodePort
     port: 8080

--- a/openspec/changes/README.md
+++ b/openspec/changes/README.md
@@ -253,6 +253,7 @@ Changes with no campaign; each stands alone.
 | [`add-development-roadmap`](add-development-roadmap/) | implemented 2026-08-06; pending archive | Establishes `docs/development/ROADMAP.md`, the governance permitting it, and the closeout roadmap-currency step |
 | [`fix-golden-image-config`](fix-golden-image-config/) | active | Align generated and consumed keys and deliver secrets through the provisioning Secret profile |
 | [`deduplicate-dynaconf-bootstrap`](deduplicate-dynaconf-bootstrap/) | active | Parameterized kit/config construction with exact provisioning and e2e parity; storefront loader excluded. Useful precedent for the kit-composition extractions |
+| [`add-registry-self-description`](add-registry-self-description/) | active; no blocking dependency | Publishes one strict operator-authored registry descriptor through the existing signed registry exchange, with schema, access posture, and authority pins derived from their active sources |
 
 ## Archived and superseded
 

--- a/openspec/changes/add-registry-self-description/.openspec.yaml
+++ b/openspec/changes/add-registry-self-description/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-01

--- a/openspec/changes/add-registry-self-description/design.md
+++ b/openspec/changes/add-registry-self-description/design.md
@@ -1,0 +1,79 @@
+## Context
+
+The filter specification identifies the listing vocabulary, while registry authority settings identify the response signer. Neither surface carries the registry's public URL, display name, operator identity, or access posture. Clients therefore need a separate, manually synchronized trust bundle before they can inspect the registry.
+
+The existing version 2 marketplace envelope already authenticates registry responses. The descriptor needs that proof of possession, but it does not need another online signing protocol.
+
+## Goals / Non-Goals
+
+**Goals:** publish one portable descriptor body; bind it to the active authority signer; prevent configuration drift between schema, access gate, and manifest; keep the endpoint available before read-key acquisition.
+
+**Non-Goals:** third-party endorsement, directory curation, authority rotation, read-key issuance, or a new signature implementation.
+
+## Decisions
+
+### Publish a well-known descriptor through the existing signed exchange
+
+The route is `GET /.well-known/arkhai/registry-descriptor.json`. The caller signs the request as `registry.descriptor.read` over resource `registry-descriptor`. The registry signs the response through the same version 2 response contract as authenticated discovery.
+
+The route does not require a read API key. A key-gated registry must disclose its acquisition pointer before a caller possesses that key. Marketplace request authentication and replay classification still apply.
+
+### Keep the descriptor body portable
+
+The JSON body uses stable camel-case field names:
+
+```json
+{
+  "access": {"posture": "public"},
+  "authority": {
+    "name": "registry-a",
+    "principals": [{"scheme": "ed25519", "identifier": "..."}]
+  },
+  "baseUrl": "https://registry.example",
+  "displayName": "Example Compute Registry",
+  "operatorIdentity": "Example Operator",
+  "schema": {"id": "vms.compute", "version": "1"}
+}
+```
+
+The shared core carrier validates this shape without importing identity-kit or role packages. The registry client converts descriptor principals to identity-kit values only at its trust boundary.
+
+### Derive facts that already have an authority
+
+The registry builds the descriptor once at startup:
+
+- `authority.name` comes from the stable registry authority ID.
+- `authority.principals[0]` comes from the loaded signer.
+- `schema` comes from the active filter specification.
+- `access.posture` comes from the read-key gate.
+
+The operator configures `baseUrl`, `displayName`, and `operatorIdentity`. A key-gated registry must also configure `access.acquisitionPointer`; a public registry rejects that pointer. Startup fails if the descriptor cannot be built, so the endpoint cannot advertise stale or contradictory facts.
+
+### Separate possession from endorsement
+
+The signed response proves that the principal named in the body possesses the active registry credential. It does not establish that the operator or URL is trustworthy. A client may use the descriptor for explicit trust-on-first-use, or it may require a separately trusted directory or operator signature before importing the pin.
+
+Offline tooling may sign the descriptor body for curation. That artifact lifecycle is independent from the online request-response signature and is not implemented by the registry process.
+
+## Risks / Trade-offs
+
+- **A proxy URL differs from the service URL.** The public base URL is explicit operator configuration; the service does not infer it from request headers.
+- **Access policy and descriptor drift.** The posture is derived from the live read gate, and startup validates the acquisition-pointer rule.
+- **Schema changes without descriptor changes.** The descriptor reads the same cached filter specification used by listing validation and discovery.
+- **A self-signed descriptor is mistaken for endorsement.** Permanent documentation states that the proof establishes possession only.
+
+## Validation
+
+- Core carrier tests cover exact wire aliases, principal formats, unique pins, URL schemes, and public/key-gated access invariants.
+- Registry integration tests use the typed client to prove the well-known route, signed response verification, replay behavior, and read-key independence.
+- Helm render tests prove public fields reach ordinary configuration and signer material remains Secret-mounted.
+- Strict OpenSpec validation and comment-hygiene checks run before closeout.
+
+## Permanent Documentation Promotion
+
+| Accepted decision | Permanent location |
+|---|---|
+| Registry descriptors use one strict portable body and the existing signed response exchange | `openspec/specs/registry-discovery/{spec,architecture}.md` |
+| Descriptor facts are derived from their existing authorities where possible | `openspec/specs/registry-discovery/spec.md`; `docs/development/ARCHITECTURE.md` |
+| Public descriptor configuration remains separate from signer credentials | `docs/development/DEPLOYMENT_AND_CONFIG.md` |
+| Self-signature proves possession but not third-party endorsement | `openspec/specs/registry-discovery/architecture.md` |

--- a/openspec/changes/add-registry-self-description/design.md
+++ b/openspec/changes/add-registry-self-description/design.md
@@ -36,7 +36,7 @@ The JSON body uses stable camel-case field names:
 }
 ```
 
-The shared core carrier validates this shape without importing identity-kit or role packages. The registry client converts descriptor principals to identity-kit values only at its trust boundary.
+The shared core carrier validates this shape without importing identity-kit or role packages. The registry client's explicit bootstrap method converts descriptor principals to identity-kit values at its trust boundary and verifies the response against those advertised pins before returning the body. Ordinary client instances remain externally pinned and use the same method as other reads.
 
 ### Derive facts that already have an authority
 

--- a/openspec/changes/add-registry-self-description/proposal.md
+++ b/openspec/changes/add-registry-self-description/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+A registry publishes its listing schema but not the operator-authored facts that identify the registry itself. A client must receive the public URL, authority name, authority principal, and schema identity through a separate configuration channel. This prevents a registry from supplying the complete descriptor used for discovery and curation.
+
+## What Changes
+
+- Define one strict registry-descriptor carrier for the public URL, display name, operator identity, authority trust pins, schema identity, and access posture.
+- Serve that descriptor at `/.well-known/arkhai/registry-descriptor.json` through the existing authenticated request and signed registry-response contract.
+- Derive the authority principal from the active signer, derive schema identity from the active filter specification, and derive access posture from the read gate.
+- Require operators to configure only facts that the service cannot derive: the public base URL, display name, operator identity, and an acquisition pointer when reads are key-gated.
+- Add the descriptor method to both registry clients and render the public operator fields through Compose and Helm.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `registry-discovery`: A registry publishes a strict, authority-authenticated self-description that clients and directory operators can import.
+- `deployment-state`: Registry deployments keep operator-authored public descriptor fields separate from signer credentials.
+
+## Non-Goals
+
+- Do not make a self-signed descriptor an endorsement by a third party.
+- Do not add a second runtime signature protocol; directory or release tooling may separately sign the descriptor body.
+- Do not publish read keys, signer credentials, provider data, or private deployment coordinates.
+- Do not implement registry-authority rotation in this change.
+
+## Impact
+
+- Affected code: the core carrier package, registry service, and registry client.
+- Affected configuration: registry Compose and Helm values gain public descriptor fields.
+- Affected documentation: registry discovery, deployment configuration, and the repository architecture.
+
+## Permanent documentation impact
+
+- [ ] `openspec/specs/registry-discovery/{spec,architecture}.md` — descriptor behavior and trust boundary.
+- [ ] `docs/development/ARCHITECTURE.md` — descriptor ownership in the discovery flow.
+- [ ] `docs/development/DEPLOYMENT_AND_CONFIG.md` — public descriptor configuration and secret separation.
+
+## Related issue
+
+- GitHub issue #175.

--- a/openspec/changes/add-registry-self-description/specs/registry-discovery/spec.md
+++ b/openspec/changes/add-registry-self-description/specs/registry-discovery/spec.md
@@ -6,6 +6,8 @@ A registry MUST publish one strict descriptor containing its public base URL, di
 
 The authority principal MUST come from the active registry signer, the schema identity MUST come from the active filter specification, and the access posture MUST come from the active read gate. Operator-authored public fields MUST remain ordinary configuration, and signer credentials or read keys MUST NOT enter the descriptor.
 
+A bootstrap client MUST verify the signed response against the principal set carried in the validated descriptor before returning it.
+
 #### Scenario: Client inspects a public registry
 
 - **WHEN** an authenticated buyer, seller, or service requests the well-known descriptor

--- a/openspec/changes/add-registry-self-description/specs/registry-discovery/spec.md
+++ b/openspec/changes/add-registry-self-description/specs/registry-discovery/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Registry self-description is authority-authenticated
+
+A registry MUST publish one strict descriptor containing its public base URL, display name, operator identity, stable authority name and active principal set, listing schema identity and version, and access posture. The descriptor MUST be returned at `/.well-known/arkhai/registry-descriptor.json` through the shared version 2 authenticated request and signed-response contract.
+
+The authority principal MUST come from the active registry signer, the schema identity MUST come from the active filter specification, and the access posture MUST come from the active read gate. Operator-authored public fields MUST remain ordinary configuration, and signer credentials or read keys MUST NOT enter the descriptor.
+
+#### Scenario: Client inspects a public registry
+
+- **WHEN** an authenticated buyer, seller, or service requests the well-known descriptor
+- **THEN** the registry returns the complete descriptor under a response proof from the principal pinned in that descriptor
+
+#### Scenario: Registry reads require a key
+
+- **WHEN** the registry requires a read key
+- **THEN** the descriptor remains readable without that key and declares `key-gated` posture with an acquisition pointer
+
+#### Scenario: Descriptor configuration contradicts access policy
+
+- **WHEN** a key-gated registry has no acquisition pointer or a public registry configures one
+- **THEN** startup fails before the registry serves a contradictory descriptor
+
+#### Scenario: Descriptor is used as a trust bootstrap
+
+- **WHEN** a client verifies the signed response against the principal carried in the descriptor
+- **THEN** the proof establishes credential possession but does not by itself establish third-party endorsement of the operator or URL

--- a/openspec/changes/add-registry-self-description/tasks.md
+++ b/openspec/changes/add-registry-self-description/tasks.md
@@ -2,43 +2,46 @@
 
 ## 1. Shared descriptor carrier
 
-- [ ] 1.1 Add strict registry descriptor models to `market_core` with exact wire aliases and access/principal invariants.
-- [ ] 1.2 Add focused carrier tests for valid public and key-gated descriptors and malformed trust bundles.
+- [x] 1.1 Add strict registry descriptor models to `market_core` with exact wire aliases and access/principal invariants.
+- [x] 1.2 Add focused carrier tests for valid public and key-gated descriptors and malformed trust bundles.
 
 ## 2. Registry publication
 
-- [ ] 2.1 Add descriptor settings for the operator-authored public fields and build the complete descriptor from the active signer, filter specification, and read gate at startup.
-- [ ] 2.2 Serve the descriptor at the well-known route through authenticated request handling, durable replay, and signed responses without requiring a read key.
-- [ ] 2.3 Add typed async and sync registry-client methods and preserve method parity.
-- [ ] 2.4 Add focused service and client integration evidence for the body, authority pin, replay, and key-gated bootstrap path.
+- [x] 2.1 Add descriptor settings for the operator-authored public fields and build the complete descriptor from the active signer, filter specification, and read gate at startup.
+- [x] 2.2 Serve the descriptor at the well-known route through authenticated request handling, durable replay, and signed responses without requiring a read key.
+- [x] 2.3 Add typed async and sync registry-client methods and preserve method parity.
+- [x] 2.4 Add focused service and client integration evidence for the body, authority pin, replay, and key-gated bootstrap path.
 
 ## 3. Deployment surfaces
 
-- [ ] 3.1 Render descriptor fields in local Compose profiles and the registry Helm chart.
-- [ ] 3.2 Extend Helm validation and render evidence without placing signer credentials in ordinary values.
+- [x] 3.1 Render descriptor fields in local Compose profiles and the registry Helm chart.
+- [x] 3.2 Extend Helm validation and render evidence without placing signer credentials in ordinary values.
 
 ## 4. Permanent documentation
 
-- [ ] 4.1 Promote descriptor behavior and the possession-versus-endorsement boundary to `openspec/specs/registry-discovery/{spec,architecture}.md`.
-- [ ] 4.2 Update `docs/development/ARCHITECTURE.md` and `docs/development/DEPLOYMENT_AND_CONFIG.md` with the current ownership and configuration model.
+- [x] 4.1 Promote descriptor behavior and the possession-versus-endorsement boundary to `openspec/specs/registry-discovery/{spec,architecture}.md`.
+- [x] 4.2 Update `docs/development/ARCHITECTURE.md` and `docs/development/DEPLOYMENT_AND_CONFIG.md` with the current ownership and configuration model.
 - [ ] 4.3 Add the active change to the roadmap and active-change index, then remove those temporary entries at closeout.
 
 ## 5. Validation
 
-- [ ] 5.1 Run focused core, registry-client, registry service, and Helm render tests.
-- [ ] 5.2 Run strict OpenSpec validation and disclose any broader suite not run.
+- [x] 5.1 Run focused core, registry-client, registry service, and Helm render tests.
+- [x] 5.2 Run strict OpenSpec validation and disclose any broader suite not run.
 
 ## 6. Closeout
 
-- [ ] 6.1 **Comment hygiene.** Run `make check-comment-hygiene` and remove change-history commentary from production code.
-- [ ] 6.2 **Import placement.** Confirm the carrier imports only standard-library and Pydantic modules and role packages depend inward on it.
-- [ ] 6.3 **Documentation compliance.** Confirm every material decision is present in permanent current-state documentation.
-- [ ] 6.4 **Narrative compression.** Reduce completed tasks to final behavior, evidence, and promotion destinations.
-- [ ] 6.5 **Roadmap currency.** Remove the implemented gap from the roadmap current-state boundary.
+- [x] 6.1 **Comment hygiene.** Run `make check-comment-hygiene` and remove change-history commentary from production code.
+- [x] 6.2 **Import placement.** Confirm the carrier imports only standard-library and Pydantic modules and role packages depend inward on it.
+- [x] 6.3 **Documentation compliance.** Confirm every material decision is present in permanent current-state documentation.
+- [x] 6.4 **Narrative compression.** Reduce completed tasks to final behavior, evidence, and promotion destinations.
+- [x] 6.5 **Roadmap currency.** Remove the implemented gap from the roadmap current-state boundary.
 - [ ] 6.6 **Promotion.** Complete the design-promotion record and archive the change after review.
 
 ## Design promotion record
 
 | Accepted decision | Permanent location |
 |---|---|
-| Pending implementation | Pending |
+| Portable descriptor and existing signed exchange | `openspec/specs/registry-discovery/{spec,architecture}.md` |
+| Derived authority, schema, and access facts | `openspec/specs/registry-discovery/spec.md`; `docs/development/ARCHITECTURE.md` |
+| Public configuration separated from signer credentials | `docs/development/DEPLOYMENT_AND_CONFIG.md` |
+| Possession is not endorsement | `openspec/specs/registry-discovery/architecture.md` |

--- a/openspec/changes/add-registry-self-description/tasks.md
+++ b/openspec/changes/add-registry-self-description/tasks.md
@@ -1,0 +1,44 @@
+# Implementation Tasks
+
+## 1. Shared descriptor carrier
+
+- [ ] 1.1 Add strict registry descriptor models to `market_core` with exact wire aliases and access/principal invariants.
+- [ ] 1.2 Add focused carrier tests for valid public and key-gated descriptors and malformed trust bundles.
+
+## 2. Registry publication
+
+- [ ] 2.1 Add descriptor settings for the operator-authored public fields and build the complete descriptor from the active signer, filter specification, and read gate at startup.
+- [ ] 2.2 Serve the descriptor at the well-known route through authenticated request handling, durable replay, and signed responses without requiring a read key.
+- [ ] 2.3 Add typed async and sync registry-client methods and preserve method parity.
+- [ ] 2.4 Add focused service and client integration evidence for the body, authority pin, replay, and key-gated bootstrap path.
+
+## 3. Deployment surfaces
+
+- [ ] 3.1 Render descriptor fields in local Compose profiles and the registry Helm chart.
+- [ ] 3.2 Extend Helm validation and render evidence without placing signer credentials in ordinary values.
+
+## 4. Permanent documentation
+
+- [ ] 4.1 Promote descriptor behavior and the possession-versus-endorsement boundary to `openspec/specs/registry-discovery/{spec,architecture}.md`.
+- [ ] 4.2 Update `docs/development/ARCHITECTURE.md` and `docs/development/DEPLOYMENT_AND_CONFIG.md` with the current ownership and configuration model.
+- [ ] 4.3 Add the active change to the roadmap and active-change index, then remove those temporary entries at closeout.
+
+## 5. Validation
+
+- [ ] 5.1 Run focused core, registry-client, registry service, and Helm render tests.
+- [ ] 5.2 Run strict OpenSpec validation and disclose any broader suite not run.
+
+## 6. Closeout
+
+- [ ] 6.1 **Comment hygiene.** Run `make check-comment-hygiene` and remove change-history commentary from production code.
+- [ ] 6.2 **Import placement.** Confirm the carrier imports only standard-library and Pydantic modules and role packages depend inward on it.
+- [ ] 6.3 **Documentation compliance.** Confirm every material decision is present in permanent current-state documentation.
+- [ ] 6.4 **Narrative compression.** Reduce completed tasks to final behavior, evidence, and promotion destinations.
+- [ ] 6.5 **Roadmap currency.** Remove the implemented gap from the roadmap current-state boundary.
+- [ ] 6.6 **Promotion.** Complete the design-promotion record and archive the change after review.
+
+## Design promotion record
+
+| Accepted decision | Permanent location |
+|---|---|
+| Pending implementation | Pending |

--- a/openspec/specs/registry-discovery/architecture.md
+++ b/openspec/specs/registry-discovery/architecture.md
@@ -46,6 +46,23 @@ This pushdown boundary is semantic, not a promise about physical execution. A de
 
 A registry may load another vocabulary on restart, but safe live rotation and coexistence of incompatible client generations are separate rollout concerns. The baseline does not treat a configured registry as a universal domain interpreter.
 
+## Self-description boundary
+
+The well-known registry descriptor assembles facts without creating a second
+authority for them. Its principal comes from the loaded response signer, its
+schema identity comes from the active filter specification, and its access
+posture comes from the read gate. Only the public base URL, display name,
+operator identity, and—when reads are gated—the acquisition pointer are
+operator-authored configuration. Contradictory or incomplete inputs stop
+startup.
+
+The descriptor is returned through the ordinary authenticated registry
+exchange. Its response proof shows that the named principal controls the
+active signing credential. That is proof of possession, not an endorsement of
+the claimed URL or operator. A directory may separately curate and sign the
+portable descriptor body; that offline assertion is a different trust layer
+from the registry's online response proof.
+
 ## Injected signer boundary
 
 The registry client depends on the scheme-neutral signer interface rather than a raw key or an address. The signer exposes only its canonical public principal and signing operation, so Ed25519 and EIP-191 follow the same client and server path and private material does not enter request models, listing payloads, logs, or registry persistence. The registry resolves the exact `{scheme, identifier}` to a stable publisher; it never infers ownership from identifier shape.

--- a/openspec/specs/registry-discovery/spec.md
+++ b/openspec/specs/registry-discovery/spec.md
@@ -132,6 +132,41 @@ Resource-query explanation MUST identify which canonical predicates are evaluate
 - **WHEN** a valid DSL comparison compiles to a declared filter whose `indexed` marker is absent or behaviorally inert
 - **THEN** the registry evaluates it with current filter semantics and explanation makes no indexing claim
 
+### Requirement: Registry self-description is authority-authenticated
+
+A registry MUST publish one strict descriptor containing its public base URL,
+display name, operator identity, stable authority name and active principal set,
+listing schema identity and version, and access posture. It MUST return the
+descriptor at `/.well-known/arkhai/registry-descriptor.json` through the shared
+version 2 authenticated request and signed-response contract.
+
+The authority principal MUST come from the active registry signer, the schema
+identity MUST come from the active filter specification, and the access posture
+MUST come from the active read gate. Operator-authored public fields MUST remain
+ordinary configuration. Signer credentials and read keys MUST NOT enter the
+descriptor. A bootstrap client MUST verify the signed response against the
+principal set carried in the validated descriptor before returning it.
+
+#### Scenario: Client inspects a public registry
+
+- **WHEN** an authenticated buyer, seller, or service requests the well-known descriptor
+- **THEN** the registry returns the complete descriptor under a response proof from the principal named in that descriptor
+
+#### Scenario: Registry reads require a key
+
+- **WHEN** the registry requires a read key
+- **THEN** the descriptor remains readable without that key and declares `key-gated` posture with an acquisition pointer
+
+#### Scenario: Descriptor configuration contradicts access policy
+
+- **WHEN** a key-gated registry has no acquisition pointer or a public registry configures one
+- **THEN** startup fails before the registry serves a contradictory descriptor
+
+#### Scenario: Descriptor is used as a trust bootstrap
+
+- **WHEN** a client verifies the signed response against the principal carried in the descriptor
+- **THEN** the proof establishes credential possession but does not by itself establish third-party endorsement of the operator or URL
+
 ## Evidence
 
 - Schema loading, validation, and ETag behavior: `core/registry/tests/unit/test_filter_spec.py`, `core/registry/tests/integration/test_filter_spec.py`, and `core/registry/tests/integration/test_validate_publish.py`.
@@ -139,3 +174,5 @@ Resource-query explanation MUST identify which canonical predicates are evaluate
 - Injected dual-scheme publisher identity, stable listing ownership, body-bound requests, signed responses, and replay behavior: `core/registry/tests/integration/test_identity_publish.py`, `core/registry/tests/integration/test_listings.py`, `core/registry/tests/unit/test_publisher_auth.py`, and `core/registry-client/tests/test_auth.py`.
 - Publisher rotation and stable-subject ownership: `core/registry/tests/integration/test_publisher_rotation.py`.
 - Atomic canonical-principal migration and rollback: `core/registry/tests/unit/test_principal_migrations.py`.
+- Strict descriptor carriers, startup derivation, access posture, signed reads, and durable replay: `core/tests/unit/test_registry_descriptor.py`, `core/registry/tests/unit/test_registry_descriptor.py`, and `core/registry/tests/integration/test_registry_descriptor.py`.
+- Helm descriptor configuration and Secret separation: `helm/scripts/test-render.sh`.


### PR DESCRIPTION
## Summary

- publish a strict registry descriptor at `/.well-known/arkhai/registry-descriptor.json` through the existing authenticated request, replay, and signed-response contract
- derive authority, schema, and access facts from their live owners while keeping public operator fields in ordinary deployment configuration
- add URL-only client bootstrap that validates the descriptor and verifies the response against its advertised principals before returning it
- wire Compose and Helm surfaces, validation, permanent documentation, and OpenSpec evidence

Closes #175.

## Verification

- core carrier and purity tests: 9 passed
- registry client suite: 21 passed
- focused registry unit/integration suite: 9 passed
- core and registry-client mypy: passed
- new registry modules mypy: passed
- Helm structural render suite: passed
- strict OpenSpec validation: passed
- comment-hygiene check: passed

The registry service's full mypy target still reports its existing SQLAlchemy/config typing baseline; the two new registry modules pass focused mypy.
