### PR TITLE
Make dedicated bare-metal storefront opt-in

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -23,6 +23,10 @@ dependencies:
     version: "0.1.0"
     repository: "file://charts/storefront"
     condition: storefront.enabled
+  - name: bare-metal-storefront
+    version: "0.1.0"
+    repository: "file://charts/bare-metal-storefront"
+    condition: bare-metal-storefront.enabled
   - name: provisioning
     version: "0.1.0"
     repository: "file://charts/provisioning"

--- a/helm/charts/bare-metal-storefront/values.schema.json
+++ b/helm/charts/bare-metal-storefront/values.schema.json
@@ -18,6 +18,7 @@
     "persistence"
   ],
   "properties": {
+    "enabled": {"type": "boolean"},
     "global": {
       "type": "object",
       "properties": {"imageRepository": {"type": "string"}},

--- a/helm/scripts/test-render.sh
+++ b/helm/scripts/test-render.sh
@@ -14,7 +14,8 @@ EVM_RENDERED="$(mktemp)"
 DUAL_RENDERED="$(mktemp)"
 OVERLAP_RENDERED="$(mktemp)"
 TWO_REGISTRIES_RENDERED="$(mktemp)"
-trap 'rm -f "$DEFAULT_RENDERED" "$FIAT_RENDERED" "$EVM_RENDERED" "$DUAL_RENDERED" "$OVERLAP_RENDERED" "$TWO_REGISTRIES_RENDERED"' EXIT
+BARE_METAL_RENDERED="$(mktemp)"
+trap 'rm -f "$DEFAULT_RENDERED" "$FIAT_RENDERED" "$EVM_RENDERED" "$DUAL_RENDERED" "$OVERLAP_RENDERED" "$TWO_REGISTRIES_RENDERED" "$BARE_METAL_RENDERED"' EXIT
 
 helm template "$RELEASE" "$CHART_DIR" \
     --values "$CHART_DIR/values.yaml" >"$DEFAULT_RENDERED" 2>/dev/null
@@ -61,6 +62,9 @@ helm template "$RELEASE-overlap" "$CHART_DIR" \
 helm template "$RELEASE-registries" "$CHART_DIR" \
     --values "$CHART_DIR/values.yaml" \
     --values "$CHART_DIR/fixtures/two-registries-values.yaml" >"$TWO_REGISTRIES_RENDERED" 2>/dev/null
+helm template "$RELEASE-bare-metal" "$CHART_DIR" \
+    --values "$CHART_DIR/values.yaml" \
+    --set 'bare-metal-storefront.enabled=true' >"$BARE_METAL_RENDERED" 2>/dev/null
 
 errors=0
 fail() {
@@ -157,6 +161,8 @@ expect_present "$DEFAULT_CONFIGMAP" 'priority = \[\]' "new defaults have empty s
 expect_absent "$DEFAULT_CONFIGMAP" '\[Settlement\.(stripe|alkahest)\]' "new defaults install no mechanism subsection"
 expect_absent "$DEFAULT_RENDERED" 'private_key|privateKey|request_credential' "default manifests contain no signing key fields"
 expect_absent "$DEFAULT_RENDERED" 'admin_api_key|adminApiKey|X-Admin-Key' "default manifests contain no legacy administrator shared secret"
+expect_absent "$DEFAULT_RENDERED" 'charts/bare-metal-storefront/' "default render omits the dedicated bare-metal storefront"
+expect_present "$BARE_METAL_RENDERED" 'charts/bare-metal-storefront/templates/deployment\.yaml' "dedicated bare-metal storefront can be enabled explicitly"
 expect_present "$DEFAULT_REGISTRY" 'name: +REGISTRY_DESCRIPTOR_BASE_URL' "registry renders its public descriptor URL"
 expect_present "$DEFAULT_REGISTRY" 'value: +"?Local VM Compute Registry"?' "registry renders its descriptor display name"
 expect_present "$DEFAULT_REGISTRY" 'value: +"?Arkhai local development"?' "registry renders its operator identity"

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -33,6 +33,12 @@
         }
       }
     },
+    "bare-metal-storefront": {
+      "type": "object",
+      "properties": {
+        "enabled": {"type": "boolean"}
+      }
+    },
     "provisioning": {
       "type": "object",
       "required": ["identity", "storefrontIdentity", "adminIdentity"],

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -290,6 +290,10 @@ storefront:
         wallet: {}
         chains: {}
 
+# The dedicated bare-metal storefront is an optional role. The combined
+# compute storefront above already loads the bare-metal domain contribution.
+bare-metal-storefront:
+  enabled: false
 
 # ---------------------------------------------------------------------------
 # provisioning subchart


### PR DESCRIPTION
The umbrella chart currently treats the chart under `helm/charts/bare-metal-storefront` as active even though it is not declared as a dependency. Default renders therefore include the dedicated role, and `helm lint` reports mismatched dependency metadata.

This change declares the role as a conditional dependency, disables it by default, validates its `enabled` flag, and proves both default omission and explicit enablement in the structural render suite.

Verification:
- `helm lint helm`
- `make -C helm test-render`
- `make check-comment-hygiene`
- `git diff --check`
