### PR TITLE
fix(build): restore provisioning image publish tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -642,7 +642,7 @@ push-runtime-artifacts: push-images push-charts push-wheels push-cli
 push-images: _require-ar-project
 	$(call push_image,registry,registry)
 	$(call push_image,storefront,storefront)
-	$(call push_image,provisioning,provisioning)
+	$(call push_image,provisioning,compute-provisioning)
 
 push-dev-images: _require-ar-project
 	$(call push_image,dev-env,dev-env)

--- a/provisioning/compute/service/Makefile
+++ b/provisioning/compute/service/Makefile
@@ -59,6 +59,7 @@ clean: ## Remove generated files
 
 IMAGE_NAME ?= arkhai
 IMAGE_TAG ?= compute-provisioning
+GIT_SUFFIX := $(shell git rev-parse --short HEAD)
 APPUSER_UID ?= 1000
 APPUSER_GID ?= 1000
 
@@ -72,6 +73,7 @@ build-image: ## Build the wheel-only destination image
 		--build-arg DIST_FINGERPRINT=$(DIST_FINGERPRINT) \
 		-t $(IMAGE_NAME):$(IMAGE_TAG) \
 		-f Dockerfile ../../..
+	docker tag $(IMAGE_NAME):$(IMAGE_TAG) $(IMAGE_NAME):$(IMAGE_TAG)-$(GIT_SUFFIX)
 
 deploy: ## Run the destination image with mock provisioning
 	docker run -d --rm --name compute-provisioning \

--- a/scripts/tests/test_image_publication_contract.py
+++ b/scripts/tests/test_image_publication_contract.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _make_dry_run(*arguments: str, cwd: Path = REPO_ROOT) -> str:
+    result = subprocess.run(
+        ["make", "--no-print-directory", "--dry-run", *arguments],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def test_provisioning_build_produces_the_tag_consumed_by_push_images() -> None:
+    git_suffix = subprocess.run(
+        ["git", "rev-parse", "--short", "HEAD"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    build = _make_dry_run(
+        "build",
+        cwd=REPO_ROOT / "provisioning" / "compute" / "service",
+    )
+    publish = _make_dry_run("push-images", "AR_PROJECT=test-project")
+
+    local_image = f"arkhai:compute-provisioning-{git_suffix}"
+    remote_image = (
+        "us-central1-docker.pkg.dev/test-project/test-project-docker/"
+        f"arkhai:provisioning-{git_suffix}"
+    )
+    assert f"docker tag arkhai:compute-provisioning {local_image}" in build
+    assert f"docker tag {local_image} {remote_image}" in publish
+    assert f"docker push {remote_image}" in publish


### PR DESCRIPTION
## Summary

- restore the SHA-qualified tag emitted by the provisioning image build
- map the local `compute-provisioning` image name to the remote `provisioning` repository name
- add a dry-run regression test covering the build-to-publish contract

## Verification

- `provisioning/compute/service/.venv/bin/python -m pytest scripts/tests/test_image_publication_contract.py -q`
- `ruff check scripts/tests/test_image_publication_contract.py`
- `ruff format --check scripts/tests/test_image_publication_contract.py`
- `make check-comment-hygiene`
- `make --dry-run -C provisioning/compute/service build`
- `make --dry-run push-images AR_PROJECT=compute-market-1-preprod`