### PR TITLE
fix(helm): render required runtime configuration

### DIFF
--- a/domains/vms/storefront/tests/unit/test_config_loader.py
+++ b/domains/vms/storefront/tests/unit/test_config_loader.py
@@ -391,6 +391,24 @@ gemini_api_key = "secret-value"
     assert cfg.integrations.gemini_api_key == "secret-value"
 
 
+def test_secrets_overlay_completes_public_chain_configuration(tmp_path):
+    base = tmp_path / "storefront.toml"
+    base.write_text("""
+[Chains.base_sepolia]
+chain_id = 84532
+""")
+    secret = tmp_path / "storefront.secrets.toml"
+    secret.write_text("""
+[chains.base_sepolia]
+rpc_url = "https://rpc.example.invalid"
+""")
+
+    cfg = _build_isolated(tmp_path, [base, secret])
+
+    assert cfg.chains.base_sepolia.chain_id == 84532
+    assert cfg.chains.base_sepolia.rpc_url == "https://rpc.example.invalid"
+
+
 def test_env_var_wins_over_overlay_files(tmp_path, monkeypatch):
     overlay = tmp_path / "storefront.toml"
     overlay.write_text("port = 8001\n")

--- a/helm/charts/provisioning/templates/configmap.yaml
+++ b/helm/charts/provisioning/templates/configmap.yaml
@@ -11,7 +11,7 @@ metadata:
 data:
   config-production.yml: |
     {{- $config := deepCopy .Values.config -}}
-    {{- $_ := set $config "identity" (dict "principal" .Values.identity.principal) -}}
+    {{- $_ := set $config "identity" .Values.identity.principal -}}
     {{- $_ := set $config "storefront_identity" (dict "principals" .Values.storefrontIdentity.principals) -}}
     {{- $_ := set $config "admin_identity" (dict "principals" .Values.adminIdentity.principals) -}}
     {{- if not $config.storefront_url -}}

--- a/helm/charts/storefront/templates/_helpers.tpl
+++ b/helm/charts/storefront/templates/_helpers.tpl
@@ -200,6 +200,8 @@ principals = [{{ range $i, $principal := $principals }}{{ if $i }}, {{ end }}{ s
 {{- $alkahest := $settlement.alkahest | default dict -}}
 {{- $registryAuthority := $cfg.registryAuthority | default dict -}}
 {{- $domains := required "storefront config.storefrontDomains requires at least one explicit registration" $cfg.storefrontDomains -}}
+{{- $provisioningSiteID := $prov.siteId | default "default" -}}
+{{- $provisioningURL := default (include "provisioning.url" $root) $prov.serviceUrl -}}
 {{- if lt (len $domains) 1 -}}
   {{- fail "storefront config.storefrontDomains requires at least one explicit registration" -}}
 {{- end -}}
@@ -233,7 +235,6 @@ principals = [{{ range $i, $principal := $principals }}{{ if $i }}, {{ end }}{ s
   {{- if not $provisioningAuthorityTrusted -}}
     {{- fail "provisioning authority principals must include the active provisioning principal" -}}
   {{- end -}}
-  {{- $provisioningSiteID := $prov.siteId | default "default" -}}
   {{- $provisioningPeerTrusted := false -}}
   {{- range $peerID, $peer := ($identity.servicePeers | default dict) -}}
     {{- if and (eq ($peer.role | default "") "service") (eq ($peer.siteId | default "") $provisioningSiteID) -}}
@@ -313,7 +314,9 @@ ssh_public_key = {{ $wallet.ssh_public_key | quote }}
 {{- $chain := index $chains $chainName }}
 
 [Chains.{{ $chainName }}]
-rpc_url = {{ default (include "rpc.wsUrl" $root) $chain.rpc_url | quote }}
+{{- if $chain.rpc_url }}
+rpc_url = {{ $chain.rpc_url | quote }}
+{{- end }}
 chain_id = {{ required (printf "chains.%s.chain_id is required" $chainName) $chain.chain_id | int }}
 {{- end }}
 
@@ -333,7 +336,7 @@ root_path = {{ $agent.rootPath | quote }}
 {{- end }}
 
 [provisioning]
-service_url = {{ default (include "provisioning.url" $root) $prov.serviceUrl | quote }}
+service_url = {{ $provisioningURL | quote }}
 {{- if $prov.mode }}
 mode        = {{ $prov.mode | quote }}
 {{- end }}
@@ -343,6 +346,9 @@ poll_interval = {{ $prov.pollInterval | int }}
 
 [provisioning.identity]
 {{ include "storefront.principalsToml" (dict "label" "provisioning identity" "principals" $provIdentity.principals) }}
+
+[capacity.sites]
+{{ $provisioningSiteID | quote }} = {{ $provisioningURL | quote }}
 
 {{- if $pricing }}
 [pricing]

--- a/helm/charts/storefront/templates/deployment.yaml
+++ b/helm/charts/storefront/templates/deployment.yaml
@@ -66,10 +66,10 @@ spec:
         {{- if and ($alkahest.enabled | default false) (gt (len $chains) 0) }}
         {{- $chainName := first (keys $chains | sortAlpha) }}
         {{- $chain := index $chains $chainName }}
+        {{- if $chain.rpc_url }}
         - name: wait-for-rpc
           image: busybox:1.36
-          {{- /* Probe an injected chain only when Alkahest is enabled. */}}
-          {{- $rpcProbeUrl := default (include "rpc.url" $) $chain.rpc_url }}
+          {{- /* Probe only a public RPC URL rendered into the ConfigMap. */}}
           command:
             - sh
             - -c
@@ -77,10 +77,11 @@ spec:
               echo "Waiting for RPC..."
               until wget -qO- --post-data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
                 --header 'Content-Type: application/json' \
-                {{ $rpcProbeUrl | quote }} > /dev/null 2>&1; do
+                {{ $chain.rpc_url | quote }} > /dev/null 2>&1; do
                 echo "RPC not ready, retrying in 5s..."; sleep 5
               done
               echo "RPC ready."
+        {{- end }}
         {{- end }}
         - name: wait-for-registry
           image: busybox:1.36

--- a/helm/charts/storefront/values.schema.json
+++ b/helm/charts/storefront/values.schema.json
@@ -249,7 +249,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "address": {"type": "string", "pattern": "^0x[0-9A-Fa-f]{40}$"},
+        "address": {
+          "anyOf": [
+            {"const": ""},
+            {"type": "string", "pattern": "^0x[0-9A-Fa-f]{40}$"}
+          ]
+        },
         "ssh_public_key": {"type": "string", "minLength": 1}
       }
     },
@@ -279,9 +284,14 @@
       "additionalProperties": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["rpc_url", "chain_id"],
+        "required": ["chain_id"],
         "properties": {
-          "rpc_url": {"type": "string", "minLength": 1},
+          "rpc_url": {
+            "anyOf": [
+              {"const": ""},
+              {"type": "string", "minLength": 1}
+            ]
+          },
           "chain_id": {"type": "integer", "minimum": 1}
         }
       }

--- a/helm/scripts/test-render.sh
+++ b/helm/scripts/test-render.sh
@@ -11,11 +11,12 @@ RELEASE="${RELEASE:-arkhai-test}"
 DEFAULT_RENDERED="$(mktemp)"
 FIAT_RENDERED="$(mktemp)"
 EVM_RENDERED="$(mktemp)"
+SECRET_RPC_RENDERED="$(mktemp)"
 DUAL_RENDERED="$(mktemp)"
 OVERLAP_RENDERED="$(mktemp)"
 TWO_REGISTRIES_RENDERED="$(mktemp)"
 BARE_METAL_RENDERED="$(mktemp)"
-trap 'rm -f "$DEFAULT_RENDERED" "$FIAT_RENDERED" "$EVM_RENDERED" "$DUAL_RENDERED" "$OVERLAP_RENDERED" "$TWO_REGISTRIES_RENDERED" "$BARE_METAL_RENDERED"' EXIT
+trap 'rm -f "$DEFAULT_RENDERED" "$FIAT_RENDERED" "$EVM_RENDERED" "$SECRET_RPC_RENDERED" "$DUAL_RENDERED" "$OVERLAP_RENDERED" "$TWO_REGISTRIES_RENDERED" "$BARE_METAL_RENDERED"' EXIT
 
 helm template "$RELEASE" "$CHART_DIR" \
     --values "$CHART_DIR/values.yaml" >"$DEFAULT_RENDERED" 2>/dev/null
@@ -25,6 +26,11 @@ helm template "$RELEASE-fiat" "$CHART_DIR" \
 helm template "$RELEASE-evm" "$CHART_DIR" \
     --values "$CHART_DIR/values.yaml" \
     --values "$CHART_DIR/fixtures/eip191-evm-values.yaml" >"$EVM_RENDERED" 2>/dev/null
+helm template "$RELEASE-secret-rpc" "$CHART_DIR" \
+    --values "$CHART_DIR/values.yaml" \
+    --values "$CHART_DIR/fixtures/eip191-evm-values.yaml" \
+    --set-string 'storefront.agents[0].config.wallet.address=' \
+    --set-string 'storefront.agents[0].config.chains.anvil.rpc_url=' >"$SECRET_RPC_RENDERED" 2>/dev/null
 helm template "$RELEASE-dual" "$CHART_DIR" \
     --values "$CHART_DIR/values.yaml" \
     --values "$CHART_DIR/fixtures/eip191-evm-values.yaml" \
@@ -147,6 +153,8 @@ FIAT_DEPLOYMENT="$(extract_section "$FIAT_RENDERED" 'storefront/templates/deploy
 FIAT_REGISTRY="$(extract_section "$FIAT_RENDERED" 'registry/templates/deployment\.yaml')"
 EVM_CONFIGMAP="$(extract_section "$EVM_RENDERED" 'storefront/templates/configmap\.yaml')"
 EVM_DEPLOYMENT="$(extract_section "$EVM_RENDERED" 'storefront/templates/deployment\.yaml')"
+SECRET_RPC_CONFIGMAP="$(extract_section "$SECRET_RPC_RENDERED" 'storefront/templates/configmap\.yaml')"
+SECRET_RPC_DEPLOYMENT="$(extract_section "$SECRET_RPC_RENDERED" 'storefront/templates/deployment\.yaml')"
 DUAL_CONFIGMAP="$(extract_section "$DUAL_RENDERED" 'storefront/templates/configmap\.yaml')"
 PROVISIONING_CONFIGMAP="$(extract_section "$FIAT_RENDERED" 'provisioning/templates/configmap\.yaml')"
 PROVISIONING_DEPLOYMENT="$(extract_section "$FIAT_RENDERED" 'provisioning/templates/deployment\.yaml')"
@@ -216,6 +224,7 @@ expect_absent "$FIAT_RENDERED" 'private_key|privateKey|request_credential|STRIPE
 expect_absent "$FIAT_RENDERED" 'checkout\.stripe\.com|client_secret|payer_profile_ref|instrument_ref|payment_method|mandate|bank_instructions' "fiat manifests contain no payer, instrument, action, or bank material"
 expect_present "$PROVISIONING_CONFIGMAP" 'scheme: +ed25519' "fiat provisioning renders Ed25519 public principals"
 expect_present "$PROVISIONING_CONFIGMAP" 'identifier: +xoImN8fTEOxXYnvgC6JZ0lN0n0qvZERwz_vlOjX3MkI' "fiat provisioning renders its public service identity"
+expect_absent "$PROVISIONING_CONFIGMAP" '^[[:space:]]+principal:' "provisioning renders the service identity at the runtime config path"
 expect_absent "$FIAT_RENDERED" 'admin_api_key|adminApiKey|X-Admin-Key' "fiat manifests contain no legacy administrator shared secret"
 expect_present "$PROVISIONING_CONFIGMAP" 'identifier: +0EqyMnQrtKs6E2i9RhXk5tAiSrcaAWuvhSCjMsl3hzc' "fiat provisioning pins the trusted storefront principal"
 expect_present "$PROVISIONING_CONFIGMAP" 'identifier: +5zTqbCtiV95yNV5HKqBaTEh-a0Y8Ap7TBt8vAbVja1g' "fiat provisioning pins a distinct administrator principal"
@@ -223,6 +232,8 @@ expect_present "$PROVISIONING_DEPLOYMENT" 'name: +ARKHAI_IDENTITY_CREDENTIAL' "f
 expect_present "$PROVISIONING_DEPLOYMENT" 'name: +\"?fiat-provisioning-identity\"?' "fiat provisioning signer is Secret-referenced"
 expect_present "$FIAT_CONFIGMAP" '\[Identity\.service_peers\.provisioning_default\]' "fiat storefront renders provisioning service-peer trust"
 expect_present "$FIAT_CONFIGMAP" 'site_id = \"default\"' "fiat storefront binds provisioning callbacks to the default site"
+expect_present "$FIAT_CONFIGMAP" '\[capacity\.sites\]' "fiat storefront renders the capacity site authority table"
+expect_present "$FIAT_CONFIGMAP" '\"default\" = \"http://arkhai-node-operator-provisioning:8081\"' "fiat storefront binds the default site to provisioning"
 expect_present "$FIAT_CONFIGMAP" '\[provisioning\.identity\]' "fiat storefront pins provisioning response authority"
 expect_present "$FIAT_CONFIGMAP" 'identifier = \"xoImN8fTEOxXYnvgC6JZ0lN0n0qvZERwz_vlOjX3MkI\"' "fiat storefront trusts the provisioning principal"
 expect_present "$FIAT_CONFIGMAP" '\[Identity\.administrators\.operator\]' "fiat storefront renders explicit administrator trust"
@@ -247,6 +258,10 @@ expect_present "$OVERLAP_CONFIGMAP" 'principals = \[\{ scheme = \"ed25519\"[^]]+
 expect_present "$OVERLAP_PROVISIONING_CONFIGMAP" 'identifier: +0x9965507d1a55bcc2695c58ba16fb37d819b0a4dc' "overlap profile renders second provisioning administrator principal"
 expect_present "$EVM_CONFIGMAP" 'chain_id = 31337' "EVM profile renders explicit chain ID"
 expect_present "$EVM_DEPLOYMENT" 'wait-for-rpc' "EVM profile retains chain readiness"
+expect_present "$SECRET_RPC_CONFIGMAP" '\[Chains\.anvil\]' "secret-RPC profile keeps public chain metadata"
+expect_present "$SECRET_RPC_CONFIGMAP" 'chain_id = 31337' "secret-RPC profile renders public chain ID"
+expect_absent "$SECRET_RPC_CONFIGMAP" 'rpc_url|address = ' "secret-RPC profile omits credential-backed values from the ConfigMap"
+expect_absent "$SECRET_RPC_DEPLOYMENT" 'wait-for-rpc|RPC_URL|rpc_url' "secret-RPC profile omits the credential from the pod specification"
 expect_present "$EVM_DEPLOYMENT" 'name: +\"?evm-bob-marketplace-identity\"?' "EVM marketplace signer is Secret-referenced"
 expect_present "$EVM_DEPLOYMENT" 'secretName: +\"?evm-bob-runtime\"?' "EVM wallet overlay is Secret-referenced"
 expect_absent "$EVM_RENDERED" 'private_key|privateKey|request_credential|sshPrivateKey|golden_root_ssh_password|frp_dashboard_password' "EVM manifests reference secrets without embedding keys"

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -466,7 +466,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "address": {"type": "string", "pattern": "^0x[0-9A-Fa-f]{40}$"},
+        "address": {
+          "anyOf": [
+            {"const": ""},
+            {"type": "string", "pattern": "^0x[0-9A-Fa-f]{40}$"}
+          ]
+        },
         "ssh_public_key": {"type": "string", "minLength": 1}
       }
     },
@@ -475,9 +480,14 @@
       "additionalProperties": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["rpc_url", "chain_id"],
+        "required": ["chain_id"],
         "properties": {
-          "rpc_url": {"type": "string", "minLength": 1},
+          "rpc_url": {
+            "anyOf": [
+              {"const": ""},
+              {"type": "string", "minLength": 1}
+            ]
+          },
           "chain_id": {"type": "integer", "minimum": 1}
         }
       }


### PR DESCRIPTION
## Summary

- render provisioning identity at the flat runtime path expected by the service
- render the storefront capacity-site authority table required by current startup validation
- keep secret-backed wallet and chain RPC values out of ConfigMaps and pod commands
- prove public chain metadata merges with the runtime Secret overlay

## Verification

- `domains/vms/storefront/.venv/bin/python -m pytest domains/vms/storefront/tests/unit/test_config_loader.py -q`
- `PYTHON=/usr/bin/python3 mise exec helm@3.15.3 -- make -C helm test-render`
- `mise exec helm@3.15.3 -- helm lint helm --values <preprod values>`
- preprod Helm render inspected: immutable images and required identity/capacity/chain metadata present; RPC URL, wallet address, and `wait-for-rpc` absent from storefront runtime manifests
- Ruff check and format check on the changed Python test
- JSON schemas parsed with `jq`
- `git diff --check`